### PR TITLE
Complete DevTrack: multi-provider LLM, Jira, PR review, bug fixes

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -32,11 +32,26 @@ CLI_DAEMON_NAME=devtrack
 OLLAMA_HOST=http://localhost:11434
 OLLAMA_MODEL=llama3.2
 
+# --- Multi-Provider LLM Support ---
+# Set to "ollama" (default, local/no cost), "openai", or "anthropic"
+LLM_PROVIDER=ollama
+# OpenAI (only needed if LLM_PROVIDER=openai or as cloud fallback)
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
+# Anthropic Claude (only needed if LLM_PROVIDER=anthropic or as cloud fallback)
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-haiku-4-5
+
 # Integration tokens (do not hardcode in code, only here)
 AZURE_DEVOPS_PAT=your_azure_devops_pat_here
 AZURE_API_KEY=your_azure_devops_pat_here
 GITHUB_TOKEN=your_github_token_here
+GITHUB_OWNER=your_github_username_or_org
+GITHUB_REPO=
 JIRA_API_TOKEN=your_jira_api_token_here
+JIRA_URL=https://yourorg.atlassian.net
+JIRA_EMAIL=your_email@example.com
+JIRA_PROJECT_KEY=PROJ
 
 # Azure DevOps (for azure_updator, fetch_stories, azure_work_items)
 ORGANIZATION=your_azure_org

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY devtrack-bin/ ./
 RUN CGO_ENABLED=1 go build -ldflags="-w -s" -o devtrack .
 
 # Stage 2: Base Python environment with cached apt/uv layers
-FROM python:3.11-slim AS python-base
+FROM python:3.12-slim AS python-base
 
 ENV PATH="/root/.local/bin:${PATH}"
 

--- a/backend/ai/create_tasks.py
+++ b/backend/ai/create_tasks.py
@@ -1,4 +1,3 @@
-import ollama
 import json
 import pandas as pd
 from typing import List, Dict, Any, Optional
@@ -17,29 +16,36 @@ def _get_task_defaults():
             azure_default_assignee,
             azure_parent_work_item_id,
             azure_starting_work_item_id,
-            ollama_model,
         )
         return {
             "assignee": azure_default_assignee(),
             "parent_id": azure_parent_work_item_id(),
             "starting_id": azure_starting_work_item_id(),
-            "model": ollama_model(),
         }
     except ImportError:
-        return {"assignee": "", "parent_id": "", "starting_id": 0, "model": "llama3.2"}
+        return {"assignee": "", "parent_id": "", "starting_id": 0}
 
 
 class TaskGenerator:
-    def __init__(self, model_name: Optional[str] = None):
-        """
-        Initialize the TaskGenerator with an Ollama model
+    def __init__(self, provider=None):
+        """Initialize the TaskGenerator.
 
         Args:
-            model_name: The name of the Ollama model (from config if None)
+            provider: Optional LLM provider instance (injected for testing).
+                      Defaults to the global provider chain from get_provider().
         """
-        defaults = _get_task_defaults()
-        self.model_name = model_name or defaults["model"]
-        self.client = ollama.Client()
+        self._provider = provider  # None = lazy init on first use
+
+    def _get_provider(self):
+        if self._provider is None:
+            import sys
+            from pathlib import Path
+            _root = Path(__file__).resolve().parent.parent.parent
+            if str(_root) not in sys.path:
+                sys.path.insert(0, str(_root))
+            from backend.llm import get_provider
+            self._provider = get_provider()
+        return self._provider
 
     def generate_tasks(
         self,
@@ -72,14 +78,20 @@ class TaskGenerator:
         # Prepare the prompt for the LLM
         prompt = self._create_prompt(requirements, constraints, existing_tasks)
 
-        # Generate response using Ollama
-        response = self.client.chat(model=self.model_name, messages=[
-            {'role': 'user', 'content': prompt}
-        ])
+        # Generate response using the configured LLM provider
+        from backend.llm.base import LLMOptions
+        response_text = self._get_provider().generate(
+            prompt=prompt,
+            options=LLMOptions(temperature=0.3, max_tokens=1000),
+            timeout=60,
+        )
+
+        if not response_text:
+            return []
 
         # Parse the response to extract tasks
         tasks = self._parse_response(
-            response['message']['content'],
+            response_text,
             assignee,
             parent_work_item_id,
             starting_work_item_id,

--- a/backend/commit_message_enhancer.py
+++ b/backend/commit_message_enhancer.py
@@ -10,7 +10,6 @@ import os
 import sys
 import subprocess
 import logging
-import requests
 from pathlib import Path
 from typing import Optional
 
@@ -19,16 +18,16 @@ logger = logging.getLogger(__name__)
 
 
 class CommitMessageEnhancer:
-    """Enhances git commit messages using AI analysis of staged changes"""
-    
-    def __init__(self, ollama_host: Optional[str] = None, ollama_model: Optional[str] = None):
-        try:
-            from backend.config import ollama_host as cfg_host, ollama_model as cfg_model
-            self.ollama_host = ollama_host or cfg_host()
-            self.ollama_model = ollama_model or cfg_model()
-        except ImportError:
-            self.ollama_host = ollama_host or os.getenv("OLLAMA_HOST", "http://localhost:11434")
-            self.ollama_model = ollama_model or os.getenv("OLLAMA_MODEL", "llama3.2")
+    """Enhances git commit messages using AI analysis of staged changes."""
+
+    def __init__(self, provider=None):
+        self._provider = provider  # None = lazy init on first use
+
+    def _get_provider(self):
+        if self._provider is None:
+            from backend.llm import get_provider
+            self._provider = get_provider()
+        return self._provider
         
     def get_staged_diff(self, repo_path: str) -> Optional[str]:
         """Get diff of staged changes"""
@@ -297,29 +296,15 @@ class CommitMessageEnhancer:
 
                 Write ONLY the improved commit message. No meta-commentary, nothing else."""
 
-            # Call Ollama
-            response = requests.post(
-                f"{self.ollama_host}/api/generate",
-                json={
-                    "model": self.ollama_model,
-                    "prompt": prompt,
-                    "stream": False,
-                    "options": {
-                        "temperature": 0.2,  # Lower temperature for more focused output
-                        "num_predict": 200   # Allow space for body paragraphs
-                    }
-                },
-                timeout=30
+            from backend.llm.base import LLMOptions
+            enhanced = self._get_provider().generate(
+                prompt=prompt,
+                options=LLMOptions(temperature=0.2, max_tokens=200),
+                timeout=30,
             )
-            
-            if response.status_code != 200:
-                logger.error(f"Ollama API error: {response.status_code}")
+
+            if not enhanced:
                 return original_message
-            
-            result = response.json()
-            enhanced = result.get("response", "").strip()
-            
-            # Clean up response - remove markdown, meta-commentary, and formatting
             enhanced = enhanced.replace("```", "").strip()
             
             # Remove common meta-commentary patterns
@@ -342,9 +327,6 @@ class CommitMessageEnhancer:
             
             return enhanced
             
-        except requests.exceptions.Timeout:
-            logger.warning("Ollama timeout, using original message")
-            return original_message
         except Exception as e:
             logger.error(f"Error enhancing message: {e}")
             return original_message

--- a/backend/config.py
+++ b/backend/config.py
@@ -252,3 +252,61 @@ def azure_excel_file() -> Path:
 def azure_excel_sheet() -> str:
     """Sheet name in Excel file."""
     return get("AZURE_EXCEL_SHEET", "my_tasks")
+
+
+# --- Multi-Provider LLM ---
+def llm_provider() -> str:
+    """Primary LLM provider: 'ollama' | 'openai' | 'anthropic'. Default: ollama."""
+    return get("LLM_PROVIDER", "ollama").lower().strip()
+
+
+def openai_api_key() -> str:
+    """OpenAI API key. Optional - only needed if LLM_PROVIDER=openai or as fallback."""
+    return get("OPENAI_API_KEY", "")
+
+
+def openai_model() -> str:
+    """OpenAI model name."""
+    return get("OPENAI_MODEL", "gpt-4o-mini")
+
+
+def anthropic_api_key() -> str:
+    """Anthropic API key. Optional - only needed if LLM_PROVIDER=anthropic or as fallback."""
+    return get("ANTHROPIC_API_KEY", "")
+
+
+def anthropic_model() -> str:
+    """Anthropic model name."""
+    return get("ANTHROPIC_MODEL", "claude-haiku-4-5")
+
+
+# --- Jira ---
+def jira_url() -> str:
+    """Jira base URL, e.g. https://yourorg.atlassian.net"""
+    return get("JIRA_URL", "")
+
+
+def jira_email() -> str:
+    """Jira account email (used with API token for Basic auth)."""
+    return get("JIRA_EMAIL", "")
+
+
+def jira_api_token() -> str:
+    """Jira API token."""
+    return get("JIRA_API_TOKEN", "")
+
+
+def jira_project_key() -> str:
+    """Default Jira project key (e.g. PROJ)."""
+    return get("JIRA_PROJECT_KEY", "")
+
+
+# --- GitHub PR Analysis ---
+def github_owner() -> str:
+    """GitHub org/user name (for PR queries)."""
+    return get("GITHUB_OWNER", "")
+
+
+def github_repo() -> str:
+    """Default GitHub repo name (for PR queries). Leave empty to query all repos."""
+    return get("GITHUB_REPO", "")

--- a/backend/daily_report_generator.py
+++ b/backend/daily_report_generator.py
@@ -75,25 +75,21 @@ class DailyReportGenerator:
     def __init__(
         self,
         db_path: Optional[str] = None,
+        provider=None,
+        # Legacy params kept for backwards compatibility but ignored:
         ollama_url: Optional[str] = None,
-        model: Optional[str] = None
+        model: Optional[str] = None,
     ):
-        """
-        Initialize the daily report generator.
-        
+        """Initialize the daily report generator.
+
         Args:
             db_path: Path to SQLite database (auto-detected if None)
-            ollama_url: URL for Ollama API (from config if None)
-            model: Ollama model to use for AI insights (from config if None)
+            provider: Optional LLM provider instance (injected for testing).
         """
         try:
-            from backend.config import ollama_host, ollama_model, database_path
-            self.ollama_url = ollama_url or ollama_host()
-            self.model = model or ollama_model()
+            from backend.config import database_path
             self.db_path = str(db_path) if db_path else str(database_path())
         except ImportError:
-            self.ollama_url = ollama_url or os.getenv("OLLAMA_HOST", "http://localhost:11434")
-            self.model = model or os.getenv("OLLAMA_MODEL", "llama3.2")
             if db_path:
                 self.db_path = str(db_path)
             else:
@@ -104,8 +100,8 @@ class DailyReportGenerator:
                     from pathlib import Path
                     cur = Path(__file__).resolve().parent.parent
                     self.db_path = str(cur / "Data" / "db" / "devtrack.db")
+        self._provider = provider  # None = lazy init on first use
         self.email_reporter = EmailReporter(self.db_path)
-        self._ollama_available: Optional[bool] = None
     
     def is_end_of_day(
         self,
@@ -134,20 +130,19 @@ class DailyReportGenerator:
         
         return window_start <= now <= window_end
     
+    def _get_provider(self):
+        if self._provider is None:
+            from backend.llm import get_provider
+            self._provider = get_provider()
+        return self._provider
+
     def check_ollama_available(self) -> bool:
-        """Check if Ollama is available and responsive."""
-        if self._ollama_available is not None:
-            return bool(self._ollama_available)
-        
+        """Check if the LLM provider is available and responsive."""
         try:
-            import urllib.request
-            req = urllib.request.Request(f"{self.ollama_url}/api/tags")
-            with urllib.request.urlopen(req, timeout=2) as response:
-                self._ollama_available = response.status == 200
+            return self._get_provider().primary.is_available()
         except Exception:
-            self._ollama_available = False
-        
-        return bool(self._ollama_available)
+            return False
+
     
     def generate_ai_insights(self, report: DailyReport) -> Optional[AIInsights]:
         """
@@ -202,32 +197,15 @@ Provide a JSON response with these exact fields:
 Keep it professional and constructive. Respond ONLY with valid JSON."""
 
         try:
-            import urllib.request
-            import json
-            
-            data = json.dumps({
-                "model": self.model,
-                "prompt": prompt,
-                "stream": False,
-                "options": {
-                    "temperature": 0.3,
-                    "top_p": 0.9
-                }
-            }).encode()
-            
-            req = urllib.request.Request(
-                f"{self.ollama_url}/api/generate",
-                data=data,
-                headers={"Content-Type": "application/json"}
+            from backend.llm.base import LLMOptions
+            response_text = self._get_provider().generate(
+                prompt=prompt,
+                options=LLMOptions(temperature=0.3, max_tokens=500),
+                timeout=30,
             )
-            
-            with urllib.request.urlopen(req, timeout=30) as response:
-                result = json.loads(response.read().decode())
-                response_text = result.get("response", "")
-                
-                # Parse JSON from response
+
+            if response_text:
                 insights_data = self._parse_ai_response(response_text)
-                
                 if insights_data:
                     return AIInsights(
                         executive_summary=insights_data.get("executive_summary", ""),
@@ -238,10 +216,10 @@ Keep it professional and constructive. Respond ONLY with valid JSON."""
                         productivity_score=int(insights_data.get("productivity_score", 5)),
                         focus_areas=insights_data.get("focus_areas", [])
                     )
-        
+
         except Exception as e:
             print(f"AI insights generation failed: {e}")
-        
+
         return None
     
     def _format_activities_for_ai(self, report: DailyReport) -> str:
@@ -1093,25 +1071,13 @@ Provide a JSON response with these exact fields:
 Be constructive and highlight patterns. Respond ONLY with valid JSON."""
 
         try:
-            import urllib.request
-            import json
-            
-            data = json.dumps({
-                "model": self.model,
-                "prompt": prompt,
-                "stream": False,
-                "options": {"temperature": 0.3}
-            }).encode()
-            
-            req = urllib.request.Request(
-                f"{self.ollama_url}/api/generate",
-                data=data,
-                headers={"Content-Type": "application/json"}
+            from backend.llm.base import LLMOptions
+            response_text = self._get_provider().generate(
+                prompt=prompt,
+                options=LLMOptions(temperature=0.3, max_tokens=600),
+                timeout=45,
             )
-            
-            with urllib.request.urlopen(req, timeout=45) as response:
-                result = json.loads(response.read().decode())
-                response_text = result.get("response", "")
+            if response_text:
                 insights_data = self._parse_ai_response(response_text)
                 
                 if insights_data:

--- a/backend/description_enhancer.py
+++ b/backend/description_enhancer.py
@@ -5,9 +5,7 @@ This module takes raw user input describing their work and enhances it
 to be more professional, clear, and suitable for task tracking systems.
 """
 
-import os
 import logging
-import requests
 from typing import Dict, Optional, List
 from dataclasses import dataclass
 
@@ -36,8 +34,8 @@ class EnhancedDescription:
 
 
 class DescriptionEnhancer:
-    """Enhances task descriptions using Ollama LLM"""
-    
+    """Enhances task descriptions using the configured LLM provider."""
+
     CATEGORIES = [
         "feature",      # New functionality
         "bugfix",       # Bug fixes
@@ -53,63 +51,50 @@ class DescriptionEnhancer:
         "other"         # General work
     ]
     
-    def __init__(self, ollama_host: Optional[str] = None, model: Optional[str] = None):
-        """
-        Initialize the description enhancer
-        
+    def __init__(self, provider=None):
+        """Initialize the description enhancer.
+
         Args:
-            ollama_host: Ollama API endpoint
-            model: Model to use for enhancement
+            provider: Optional LLM provider instance (injected for testing).
+                      Defaults to the global provider chain from get_provider().
         """
-        try:
-            from backend.config import ollama_host as cfg_host, ollama_model as cfg_model
-            self.ollama_host = ollama_host or cfg_host()
-            self.model = model or cfg_model()
-        except ImportError:
-            self.ollama_host = ollama_host or os.getenv("OLLAMA_HOST", "http://localhost:11434")
-            self.model = model or os.getenv("OLLAMA_MODEL", "llama3.2")
-        self._available = None  # Cache availability check
-        
+        self._provider = provider  # None = lazy init on first use
+
+    def _get_provider(self):
+        if self._provider is None:
+            from backend.llm import get_provider
+            self._provider = get_provider()
+        return self._provider
+
     def is_available(self) -> bool:
-        """Check if Ollama is available"""
-        if self._available is not None:
-            return self._available
-            
-        try:
-            response = requests.get(f"{self.ollama_host}/api/tags", timeout=2)
-            self._available = response.status_code == 200
-        except Exception:
-            self._available = False
-            
-        return self._available
+        """Check if the LLM provider is available."""
+        return self._get_provider().primary.is_available()
     
     def enhance(self, raw_input: str, context: Optional[Dict] = None) -> EnhancedDescription:
-        """
-        Enhance a raw user description
-        
+        """Enhance a raw user description.
+
         Args:
             raw_input: The raw user input describing their work
             context: Optional context (project name, recent tickets, etc.)
-            
+
         Returns:
             EnhancedDescription object with enhanced text
         """
         if not raw_input or not raw_input.strip():
             return self._create_empty_result(raw_input)
-            
-        # Try Ollama enhancement
-        if self.is_available():
-            try:
-                return self._enhance_with_ollama(raw_input, context)
-            except Exception as e:
-                logger.warning(f"Ollama enhancement failed: {e}")
-                
+
+        # Try LLM enhancement
+        try:
+            return self._enhance_with_llm(raw_input, context)
+        except Exception as e:
+            logger.warning(f"LLM enhancement failed: {e}")
+
         # Fallback to basic enhancement
         return self._basic_enhance(raw_input, context)
     
-    def _enhance_with_ollama(self, raw_input: str, context: Optional[Dict] = None) -> EnhancedDescription:
-        """Use Ollama to enhance the description"""
-        
+    def _enhance_with_llm(self, raw_input: str, context: Optional[Dict] = None) -> EnhancedDescription:
+        """Use the configured LLM provider to enhance the description."""
+
         # Build context string
         context_str = ""
         if context:
@@ -119,7 +104,7 @@ class DescriptionEnhancer:
                 context_str += f"Ticket: {context['ticket_id']}\n"
             if context.get("recent_work"):
                 context_str += f"Recent work: {context['recent_work']}\n"
-        
+
         prompt = f"""You are a technical writer helping a developer describe their work for task tracking.
 
 Take this raw description of work done and enhance it to be:
@@ -152,37 +137,17 @@ KEYWORDS: API, REST, endpoints, user-management
 
 Now enhance this input:"""
 
-        try:
-            response = requests.post(
-                f"{self.ollama_host}/api/generate",
-                json={
-                    "model": self.model,
-                    "prompt": prompt,
-                    "stream": False,
-                    "options": {
-                        "temperature": 0.3,
-                        "num_predict": 300
-                    }
-                },
-                timeout=30
-            )
-            
-            if response.status_code != 200:
-                logger.warning(f"Ollama returned status {response.status_code}")
-                return self._basic_enhance(raw_input, context)
-            
-            result = response.json()
-            response_text = result.get("response", "")
-            
-            # Parse the response
-            return self._parse_ollama_response(raw_input, response_text)
-            
-        except requests.exceptions.Timeout:
-            logger.warning("Ollama timeout")
+        from backend.llm.base import LLMOptions
+        response_text = self._get_provider().generate(
+            prompt=prompt,
+            options=LLMOptions(temperature=0.3, max_tokens=300),
+            timeout=30,
+        )
+
+        if not response_text:
             return self._basic_enhance(raw_input, context)
-        except Exception as e:
-            logger.error(f"Ollama error: {e}")
-            return self._basic_enhance(raw_input, context)
+
+        return self._parse_ollama_response(raw_input, response_text)
     
     def _parse_ollama_response(self, raw_input: str, response_text: str) -> EnhancedDescription:
         """Parse the structured response from Ollama"""
@@ -363,7 +328,7 @@ if __name__ == "__main__":
     
     print("Description Enhancer Examples")
     print("=" * 60)
-    print(f"Ollama available: {enhancer.is_available()}")
+    print(f"LLM available: {enhancer.is_available()}")
     print()
     
     for text in examples:

--- a/backend/git_diff_analyzer.py
+++ b/backend/git_diff_analyzer.py
@@ -8,30 +8,28 @@ It uses Ollama to generate intelligent commit message summaries based on code ch
 import os
 import subprocess
 import logging
-import requests
 from typing import Dict, Optional, List
 
 logger = logging.getLogger(__name__)
 
 
 class GitDiffAnalyzer:
-    """Analyzes git diffs and generates intelligent summaries using Ollama"""
-    
-    def __init__(self, ollama_host: Optional[str] = None, model: Optional[str] = None):
-        """
-        Initialize the Git Diff Analyzer
-        
+    """Analyzes git diffs and generates intelligent summaries using the configured LLM provider."""
+
+    def __init__(self, provider=None):
+        """Initialize the Git Diff Analyzer.
+
         Args:
-            ollama_host: Ollama API endpoint (defaults to config)
-            model: Ollama model (defaults to config)
+            provider: Optional LLM provider instance (injected for testing).
+                      Defaults to the global provider chain from get_provider().
         """
-        try:
-            from backend.config import ollama_host as cfg_host, ollama_model as cfg_model
-            self.ollama_host = ollama_host or cfg_host()
-            self.model = model or cfg_model()
-        except ImportError:
-            self.ollama_host = ollama_host or os.getenv("OLLAMA_HOST", "http://localhost:11434")
-            self.model = model or os.getenv("OLLAMA_MODEL", "llama3.2")
+        self._provider = provider  # None = lazy init on first use
+
+    def _get_provider(self):
+        if self._provider is None:
+            from backend.llm import get_provider
+            self._provider = get_provider()
+        return self._provider
         
     def is_project_management_connected(self) -> bool:
         """
@@ -154,42 +152,27 @@ class GitDiffAnalyzer:
                     IMPACT: <impact>
                 """
 
-            # Call Ollama API
-            response = requests.post(
-                f"{self.ollama_host}/api/generate",
-                json={
-                    "model": self.model,
-                    "prompt": prompt,
-                    "stream": False,
-                    "options": {
-                        "temperature": 0.3,  # Lower temperature for more factual responses
-                        "num_predict": 200   # Limit response length
-                    }
-                },
-                timeout=30
+            from backend.llm.base import LLMOptions
+            analysis_text = self._get_provider().generate(
+                prompt=prompt,
+                options=LLMOptions(temperature=0.3, max_tokens=200),
+                timeout=30,
             )
-            
-            if response.status_code != 200:
-                logger.error(f"Ollama API error: {response.status_code}")
+
+            if not analysis_text:
                 return self._fallback_analysis(commit_message, files_changed)
-            
-            result = response.json()
-            analysis_text = result.get("response", "")
-            
+
             # Parse the response
             analysis = self._parse_ollama_response(analysis_text)
-            
+
             # Add original commit message for reference
             analysis["original_message"] = commit_message
             analysis["files_count"] = len(files_changed)
-            
+
             return analysis
-            
-        except requests.exceptions.Timeout:
-            logger.warning("Ollama request timed out, using fallback")
-            return self._fallback_analysis(commit_message, files_changed)
+
         except Exception as e:
-            logger.error(f"Error analyzing diff with Ollama: {e}")
+            logger.error(f"Error analyzing diff with LLM: {e}")
             return self._fallback_analysis(commit_message, files_changed)
     
     def _parse_ollama_response(self, response_text: str) -> Dict[str, str]:

--- a/backend/github/pr_analyzer.py
+++ b/backend/github/pr_analyzer.py
@@ -1,0 +1,264 @@
+"""
+GitHub Pull Request Analyzer
+
+Lists PRs by author and generates LLM-powered summaries suitable for standups.
+
+Configuration (via .env):
+    GITHUB_TOKEN    = ghp_... (required)
+    GITHUB_OWNER    = your_org_or_username (optional default owner)
+    GITHUB_REPO     = repo_name (optional default repo)
+"""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PRSummary:
+    """Represents a GitHub Pull Request with an optional AI summary."""
+
+    number: int
+    title: str
+    state: str                    # 'open', 'closed', 'merged'
+    author: str
+    created_at: datetime
+    updated_at: datetime
+    url: str
+    repo: str
+    base_branch: str
+    head_branch: str
+    additions: int = 0
+    deletions: int = 0
+    changed_files: int = 0
+    labels: List[str] = field(default_factory=list)
+    ai_summary: str = ""
+
+
+class PRAnalyzer:
+    """Fetch and summarize GitHub PRs using the GitHub API + LLM."""
+
+    def __init__(self, token: Optional[str] = None, provider=None):
+        """
+        Args:
+            token:    GitHub PAT. Reads GITHUB_TOKEN from config if None.
+            provider: Optional LLM provider (lazy-initialised if None).
+        """
+        _token = token
+        if _token is None:
+            try:
+                from backend.config import github_token
+                _token = github_token()
+            except Exception:
+                import os
+                _token = os.getenv("GITHUB_TOKEN", "")
+
+        self._token = _token or ""
+        self._provider = provider  # None = lazy init on first use
+
+    def _get_provider(self):
+        if self._provider is None:
+            try:
+                from backend.llm import get_provider
+                self._provider = get_provider()
+            except Exception as e:
+                logger.warning(f"LLM provider unavailable: {e}")
+        return self._provider
+
+    def _get_github(self):
+        """Return an authenticated Github client, or raise if no token."""
+        from github import Auth, Github
+        if not self._token:
+            raise ValueError("GITHUB_TOKEN is required for PR analysis")
+        return Github(auth=Auth.Token(self._token))
+
+    def _default_owner_repo(self) -> tuple:
+        """Read GITHUB_OWNER and GITHUB_REPO from config."""
+        try:
+            from backend.config import github_owner, github_repo
+            return github_owner(), github_repo()
+        except Exception:
+            import os
+            return os.getenv("GITHUB_OWNER", ""), os.getenv("GITHUB_REPO", "")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def list_prs_by_author(
+        self,
+        author: str,
+        owner: Optional[str] = None,
+        repo_name: Optional[str] = None,
+        state: str = "open",
+        max_results: int = 20,
+    ) -> List[PRSummary]:
+        """Return PRs authored by *author* in the given repo (or across the org).
+
+        Args:
+            author:     GitHub username whose PRs to fetch.
+            owner:      GitHub owner / org. Falls back to GITHUB_OWNER from config.
+            repo_name:  Repository name. Falls back to GITHUB_REPO from config.
+            state:      'open', 'closed', or 'all'.
+            max_results: Maximum number of PRs to return.
+        """
+        try:
+            g = self._get_github()
+        except Exception as e:
+            logger.warning(f"GitHub authentication failed: {e}")
+            return []
+
+        default_owner, default_repo = self._default_owner_repo()
+        effective_owner = owner or default_owner
+        effective_repo = repo_name or default_repo
+
+        try:
+            if effective_owner and effective_repo:
+                return self._list_repo_prs(g, effective_owner, effective_repo, author, state, max_results)
+            elif effective_owner:
+                return self._search_org_prs(g, effective_owner, author, state, max_results)
+            else:
+                logger.warning("No GITHUB_OWNER or repo configured for PR listing")
+                return []
+        except Exception as e:
+            logger.warning(f"Failed to list PRs for {author}: {e}")
+            return []
+
+    def summarize_pr(self, pr: PRSummary) -> str:
+        """Generate a one-sentence standup summary for *pr* using the LLM.
+
+        Falls back to the PR title if the LLM is unavailable.
+        """
+        provider = self._get_provider()
+        if not provider:
+            return pr.title
+
+        prompt = (
+            f"Summarize this GitHub PR in one sentence suitable for a standup update.\n"
+            f"PR #{pr.number}: {pr.title}\n"
+            f"Branch: {pr.head_branch} → {pr.base_branch}\n"
+            f"Changed files: {pr.changed_files} (+{pr.additions} -{pr.deletions})\n"
+            f"State: {pr.state}\n"
+            f"Keep it under 20 words. Focus on the purpose of the change."
+        )
+
+        try:
+            from backend.llm.base import LLMOptions
+            result = provider.generate(
+                prompt=prompt,
+                options=LLMOptions(temperature=0.3, max_tokens=60),
+                timeout=15,
+            )
+            return result.strip() if result else pr.title
+        except Exception as e:
+            logger.warning(f"LLM summarization failed: {e}")
+            return pr.title
+
+    def summarize_author_prs(
+        self,
+        author: str,
+        prs: Optional[List[PRSummary]] = None,
+        **list_kwargs,
+    ) -> Dict:
+        """Fetch (or accept) PRs and return a structured summary dict.
+
+        Returns:
+            {
+                "author": str,
+                "total": int,
+                "open": int,
+                "merged": int,
+                "closed": int,
+                "prs": List[PRSummary],    # with ai_summary populated
+            }
+        """
+        if prs is None:
+            prs = self.list_prs_by_author(author, **list_kwargs)
+
+        open_count = sum(1 for p in prs if p.state == "open")
+        merged_count = sum(1 for p in prs if p.state == "merged")
+        closed_count = sum(1 for p in prs if p.state == "closed")
+
+        enriched = []
+        for pr in prs:
+            if not pr.ai_summary:
+                pr.ai_summary = self.summarize_pr(pr)
+            enriched.append(pr)
+
+        return {
+            "author": author,
+            "total": len(prs),
+            "open": open_count,
+            "merged": merged_count,
+            "closed": closed_count,
+            "prs": enriched,
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _list_repo_prs(
+        self, g, owner: str, repo_name: str, author: str, state: str, max_results: int
+    ) -> List[PRSummary]:
+        """List PRs from a specific repo, filtered by author."""
+        repo = g.get_repo(f"{owner}/{repo_name}")
+        pulls = repo.get_pulls(state=state if state != "merged" else "closed")
+        results = []
+        for pr in pulls:
+            if pr.user.login.lower() != author.lower():
+                continue
+            if state == "merged" and not pr.merged:
+                continue
+            results.append(self._build_summary(pr, repo_name))
+            if len(results) >= max_results:
+                break
+        return results
+
+    def _search_org_prs(
+        self, g, owner: str, author: str, state: str, max_results: int
+    ) -> List[PRSummary]:
+        """Search for PRs by author within an org (no specific repo)."""
+        state_q = state if state in ("open", "closed") else "open"
+        query = f"is:pr author:{author} is:{state_q} org:{owner}"
+        issues = g.search_issues(query)
+        results = []
+        for item in issues:
+            try:
+                pr = item.as_pull_request()
+                repo_name = item.repository.name if item.repository else ""
+                results.append(self._build_summary(pr, repo_name))
+            except Exception:
+                continue
+            if len(results) >= max_results:
+                break
+        return results
+
+    @staticmethod
+    def _build_summary(pr, repo_name: str) -> PRSummary:
+        """Convert a PyGitHub PullRequest object to a PRSummary."""
+        state = pr.state
+        if pr.merged:
+            state = "merged"
+
+        labels = [lbl.name for lbl in (pr.labels or [])]
+
+        return PRSummary(
+            number=pr.number,
+            title=pr.title or "",
+            state=state,
+            author=pr.user.login if pr.user else "",
+            created_at=pr.created_at or datetime.utcnow(),
+            updated_at=pr.updated_at or datetime.utcnow(),
+            url=pr.html_url or "",
+            repo=repo_name,
+            base_branch=pr.base.ref if pr.base else "",
+            head_branch=pr.head.ref if pr.head else "",
+            additions=pr.additions or 0,
+            deletions=pr.deletions or 0,
+            changed_files=pr.changed_files or 0,
+            labels=labels,
+        )

--- a/backend/jira/__init__.py
+++ b/backend/jira/__init__.py
@@ -1,0 +1,13 @@
+"""
+Jira integration for DevTrack.
+
+Usage:
+    from backend.jira import JiraClient, JiraIssue
+    client = JiraClient()
+    if client.is_configured():
+        issues = client.get_my_issues()
+"""
+
+from backend.jira.client import JiraClient, JiraIssue
+
+__all__ = ["JiraClient", "JiraIssue"]

--- a/backend/jira/client.py
+++ b/backend/jira/client.py
@@ -1,0 +1,167 @@
+"""
+Jira Cloud REST API v3 client.
+
+Uses Basic auth with email + API token (no third-party jira library needed).
+The 'requests' package is already a project dependency.
+
+Configuration (via .env):
+    JIRA_URL        = https://yourorg.atlassian.net
+    JIRA_EMAIL      = your_email@example.com
+    JIRA_API_TOKEN  = your_jira_api_token
+    JIRA_PROJECT_KEY = PROJ  (optional default project)
+"""
+
+import logging
+from base64 import b64encode
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class JiraIssue:
+    """Represents a Jira issue/ticket."""
+    id: str
+    key: str                  # e.g. PROJ-123
+    summary: str
+    description: str
+    status: str
+    assignee: Optional[str]
+    issue_type: str
+    priority: str
+    labels: List[str] = field(default_factory=list)
+    url: str = ""
+
+
+class JiraClient:
+    """Jira Cloud REST API v3 client using Basic auth (email + API token)."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        email: Optional[str] = None,
+        api_token: Optional[str] = None,
+        project_key: Optional[str] = None,
+    ):
+        _url = base_url
+        _email = email
+        _token = api_token
+        _project = project_key
+        if any(v is None for v in [_url, _email, _token, _project]):
+            try:
+                from backend.config import jira_url, jira_email, jira_api_token, jira_project_key
+                _url = _url if _url is not None else jira_url()
+                _email = _email if _email is not None else jira_email()
+                _token = _token if _token is not None else jira_api_token()
+                _project = _project if _project is not None else jira_project_key()
+            except Exception:
+                pass
+
+        self.base_url = (_url or "").rstrip("/")
+        self._email = _email or ""
+        self._token = _token or ""
+        self.project_key = _project or ""
+
+        credentials = b64encode(f"{self._email}:{self._token}".encode()).decode()
+        self._headers = {
+            "Authorization": f"Basic {credentials}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def is_configured(self) -> bool:
+        """Return True if all required credentials are present."""
+        return bool(self.base_url and self._email and self._token)
+
+    def _get(self, path: str, params: Optional[Dict] = None, timeout: int = 15) -> Optional[Dict]:
+        """Make a GET request to the Jira API."""
+        if not self.is_configured():
+            return None
+        try:
+            import requests
+            url = f"{self.base_url}/rest/api/3{path}"
+            resp = requests.get(url, headers=self._headers, params=params, timeout=timeout)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as e:
+            logger.warning(f"Jira GET {path} failed: {e}")
+            return None
+
+    def get_my_issues(
+        self,
+        assignee_email: Optional[str] = None,
+        status_filter: Optional[List[str]] = None,
+        max_results: int = 50,
+    ) -> List[JiraIssue]:
+        """Fetch issues assigned to the given user (defaults to configured email).
+
+        Args:
+            assignee_email: Filter by this assignee. Uses JIRA_EMAIL from config if None.
+            status_filter: Optional list of status names to filter on (e.g. ['In Progress']).
+            max_results: Maximum number of issues to return.
+        """
+        assignee = assignee_email or self._email
+        if not assignee:
+            logger.warning("No assignee email configured for Jira query")
+            return []
+
+        status_clause = ""
+        if status_filter:
+            statuses = ", ".join(f'"{s}"' for s in status_filter)
+            status_clause = f" AND status in ({statuses})"
+
+        jql = f'assignee = "{assignee}"{status_clause} ORDER BY updated DESC'
+        params = {
+            "jql": jql,
+            "maxResults": max_results,
+            "fields": "summary,description,status,assignee,issuetype,priority,labels",
+        }
+        data = self._get("/search", params=params)
+        if not data:
+            return []
+        return [self._parse_issue(issue) for issue in data.get("issues", [])]
+
+    def get_issue(self, issue_key: str) -> Optional[JiraIssue]:
+        """Fetch a single issue by key (e.g. PROJ-123)."""
+        data = self._get(f"/issue/{issue_key}")
+        if not data:
+            return None
+        return self._parse_issue(data)
+
+    def _parse_issue(self, raw: Dict) -> JiraIssue:
+        """Parse a raw Jira issue JSON response into a JiraIssue."""
+        fields = raw.get("fields", {})
+        assignee_field = fields.get("assignee") or {}
+        return JiraIssue(
+            id=raw.get("id", ""),
+            key=raw.get("key", ""),
+            summary=fields.get("summary", ""),
+            description=self._extract_description(fields.get("description")),
+            status=(fields.get("status") or {}).get("name", "Unknown"),
+            assignee=(
+                assignee_field.get("displayName")
+                or assignee_field.get("emailAddress", "")
+            ),
+            issue_type=(fields.get("issuetype") or {}).get("name", ""),
+            priority=(fields.get("priority") or {}).get("name", ""),
+            labels=fields.get("labels", []),
+            url=f"{self.base_url}/browse/{raw.get('key', '')}",
+        )
+
+    def _extract_description(self, desc: Any) -> str:
+        """Convert a Jira description field (ADF or plain text) to a string."""
+        if desc is None:
+            return ""
+        if isinstance(desc, str):
+            return desc
+        if isinstance(desc, dict):
+            return self._adf_to_text(desc)
+        return ""
+
+    def _adf_to_text(self, node: Dict) -> str:
+        """Recursively extract plain text from an Atlassian Document Format (ADF) node."""
+        if node.get("type") == "text":
+            return node.get("text", "")
+        parts = [self._adf_to_text(child) for child in node.get("content", [])]
+        return " ".join(p for p in parts if p)

--- a/backend/learning_integration.py
+++ b/backend/learning_integration.py
@@ -188,7 +188,11 @@ class LearningIntegration:
                 print(f"📧 Using email: {self.user_email}")
             except Exception as e:
                 print(f"⚠️  Could not get user email: {e}")
-                self.user_email = "user@example.com"
+                try:
+                    from backend.config import get
+                    self.user_email = get("EMAIL", "") or get("USER_EMAIL", "")
+                except ImportError:
+                    self.user_email = ""
         
         # Initialize PersonalizedAI
         self.ai = PersonalizedAI(self.user_email)

--- a/backend/llm/__init__.py
+++ b/backend/llm/__init__.py
@@ -1,0 +1,24 @@
+"""
+Multi-provider LLM abstraction for DevTrack.
+
+Quick start:
+    from backend.llm import get_provider
+    result = get_provider().generate("summarize this commit")
+
+Provider selection is driven by LLM_PROVIDER in .env (default: 'ollama').
+Supported: 'ollama', 'openai', 'anthropic'.
+
+The project can run entirely on Ollama with no cloud dependencies.
+Cloud providers are optional — add keys to .env to enable them as fallbacks.
+"""
+
+from backend.llm.base import LLMOptions, LLMProvider
+from backend.llm.provider_factory import ProviderChain, get_provider, reset_provider_cache
+
+__all__ = [
+    "LLMProvider",
+    "LLMOptions",
+    "ProviderChain",
+    "get_provider",
+    "reset_provider_cache",
+]

--- a/backend/llm/anthropic_provider.py
+++ b/backend/llm/anthropic_provider.py
@@ -1,0 +1,72 @@
+"""
+Anthropic Claude LLM provider.
+
+Requires the 'anthropic' package (optional dependency).
+Install: pip install anthropic  OR  uv add anthropic
+If the package is absent, is_available() returns False and generate() returns None.
+"""
+
+import logging
+from typing import Optional
+
+from backend.llm.base import LLMOptions, LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class AnthropicProvider(LLMProvider):
+    """LLM provider that dispatches to the Anthropic Claude API."""
+
+    def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None):
+        _key = api_key
+        _model = model
+        if _key is None or _model is None:
+            try:
+                from backend.config import anthropic_api_key, anthropic_model
+                _key = _key if _key is not None else anthropic_api_key()
+                _model = _model or anthropic_model()
+            except Exception:
+                _key = _key or ""
+                _model = _model or "claude-haiku-4-5"
+        self._api_key = _key
+        self._model = _model
+
+    @property
+    def provider_name(self) -> str:
+        return "anthropic"
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    def is_available(self) -> bool:
+        """Available if we have an API key. No network check — key presence is sufficient."""
+        return bool(self._api_key)
+
+    def generate(
+        self,
+        prompt: str,
+        options: Optional[LLMOptions] = None,
+        timeout: int = 30,
+    ) -> Optional[str]:
+        if not self._api_key:
+            return None
+        try:
+            import anthropic
+        except ImportError:
+            logger.debug("anthropic package not installed; AnthropicProvider unavailable")
+            return None
+        try:
+            opts = options or LLMOptions()
+            client = anthropic.Anthropic(api_key=self._api_key, timeout=timeout)
+            msg = client.messages.create(
+                model=self._model,
+                max_tokens=opts.max_tokens,
+                temperature=opts.temperature,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = msg.content[0].text if msg.content else None
+            return text.strip() if text else None
+        except Exception as e:
+            logger.warning(f"AnthropicProvider.generate failed: {e}")
+            return None

--- a/backend/llm/base.py
+++ b/backend/llm/base.py
@@ -1,0 +1,61 @@
+"""
+Abstract base class and data types for LLM provider abstraction.
+
+All LLM providers (Ollama, OpenAI, Anthropic) implement LLMProvider.
+Consumer modules call get_provider().generate(prompt, options) instead of
+calling Ollama or cloud APIs directly.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class LLMOptions:
+    """Options to pass to the LLM for a generation request."""
+    temperature: float = 0.3
+    max_tokens: int = 300
+    # Provider-specific extras (e.g. Ollama's num_ctx, Anthropic's top_k)
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+class LLMProvider(ABC):
+    """Abstract LLM provider interface.
+
+    Implementations must:
+    - Never raise exceptions from generate() — return None on failure
+    - Return False from is_available() on any error (fast, < 2s)
+    - Be safe to call from multiple threads (no shared mutable state)
+    """
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Check if this provider can currently accept requests.
+
+        Must be fast (< 2s). Used for health checks before dispatch.
+        Must NOT raise — return False on any error.
+        """
+
+    @abstractmethod
+    def generate(
+        self,
+        prompt: str,
+        options: Optional[LLMOptions] = None,
+        timeout: int = 30,
+    ) -> Optional[str]:
+        """Generate a text completion.
+
+        Returns the response text stripped of whitespace, or None on failure.
+        Must NOT raise — catch all exceptions internally and return None.
+        """
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """Short string identifier: 'ollama', 'openai', 'anthropic'."""
+
+    @property
+    @abstractmethod
+    def model_name(self) -> str:
+        """The specific model being used, e.g. 'llama3.2', 'gpt-4o-mini'."""

--- a/backend/llm/ollama_provider.py
+++ b/backend/llm/ollama_provider.py
@@ -1,0 +1,67 @@
+"""
+Ollama LLM provider.
+
+Thin wrapper over the existing backend/ai/ollama_client.py so that
+module is preserved untouched (other code may import it directly).
+"""
+
+import logging
+from typing import Optional
+
+from backend.llm.base import LLMOptions, LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaProvider(LLMProvider):
+    """LLM provider that dispatches to a local Ollama instance."""
+
+    def __init__(self, host: Optional[str] = None, model: Optional[str] = None):
+        # Lazy config load — same pattern used by ollama_client.py
+        _host = host
+        _model = model
+        if _host is None or _model is None:
+            try:
+                from backend.config import ollama_host, ollama_model
+                _host = _host or ollama_host()
+                _model = _model or ollama_model()
+            except Exception:
+                _host = _host or "http://localhost:11434"
+                _model = _model or "llama3.2"
+        self._host = _host
+        self._model = _model
+
+    @property
+    def provider_name(self) -> str:
+        return "ollama"
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    def is_available(self) -> bool:
+        try:
+            from backend.ai.ollama_client import is_available
+            return is_available(self._host)
+        except Exception:
+            return False
+
+    def generate(
+        self,
+        prompt: str,
+        options: Optional[LLMOptions] = None,
+        timeout: int = 30,
+    ) -> Optional[str]:
+        try:
+            from backend.ai.ollama_client import generate
+            opts = options or LLMOptions()
+            return generate(
+                prompt=prompt,
+                model=self._model,
+                host=self._host,
+                options={"temperature": opts.temperature, "num_predict": opts.max_tokens, **opts.extra},
+                timeout=timeout,
+            )
+        except Exception as e:
+            logger.warning(f"OllamaProvider.generate failed: {e}")
+            return None

--- a/backend/llm/openai_provider.py
+++ b/backend/llm/openai_provider.py
@@ -1,0 +1,72 @@
+"""
+OpenAI LLM provider.
+
+Requires the 'openai' package (optional dependency).
+Install: pip install openai  OR  uv add openai
+If the package is absent, is_available() returns False and generate() returns None.
+"""
+
+import logging
+from typing import Optional
+
+from backend.llm.base import LLMOptions, LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIProvider(LLMProvider):
+    """LLM provider that dispatches to the OpenAI API."""
+
+    def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None):
+        _key = api_key
+        _model = model
+        if _key is None or _model is None:
+            try:
+                from backend.config import openai_api_key, openai_model
+                _key = _key if _key is not None else openai_api_key()
+                _model = _model or openai_model()
+            except Exception:
+                _key = _key or ""
+                _model = _model or "gpt-4o-mini"
+        self._api_key = _key
+        self._model = _model
+
+    @property
+    def provider_name(self) -> str:
+        return "openai"
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    def is_available(self) -> bool:
+        """Available if we have an API key. No network check — key presence is sufficient."""
+        return bool(self._api_key)
+
+    def generate(
+        self,
+        prompt: str,
+        options: Optional[LLMOptions] = None,
+        timeout: int = 30,
+    ) -> Optional[str]:
+        if not self._api_key:
+            return None
+        try:
+            import openai
+        except ImportError:
+            logger.debug("openai package not installed; OpenAIProvider unavailable")
+            return None
+        try:
+            opts = options or LLMOptions()
+            client = openai.OpenAI(api_key=self._api_key, timeout=timeout)
+            resp = client.chat.completions.create(
+                model=self._model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=opts.temperature,
+                max_tokens=opts.max_tokens,
+            )
+            text = resp.choices[0].message.content
+            return text.strip() if text else None
+        except Exception as e:
+            logger.warning(f"OpenAIProvider.generate failed: {e}")
+            return None

--- a/backend/llm/provider_factory.py
+++ b/backend/llm/provider_factory.py
@@ -1,0 +1,123 @@
+"""
+LLM provider factory with fallback chain.
+
+Usage:
+    from backend.llm import get_provider
+    result = get_provider().generate("your prompt")
+
+The factory reads LLM_PROVIDER from config (default: 'ollama') and builds an
+ordered provider chain. On each generate() call, providers are tried in order;
+the first non-None response wins. Ollama is always the final fallback since it
+requires no API key.
+
+The chain is cached as a module-level singleton (built once per process).
+Call reset_provider_cache() in tests that need to change the provider mid-test.
+"""
+
+import logging
+from typing import List, Optional
+
+from backend.llm.base import LLMOptions, LLMProvider
+
+logger = logging.getLogger(__name__)
+
+_provider_cache: Optional["ProviderChain"] = None
+
+
+class ProviderChain:
+    """Ordered list of providers with automatic fallback on failure or unavailability."""
+
+    def __init__(self, providers: List[LLMProvider]):
+        if not providers:
+            raise ValueError("ProviderChain requires at least one provider")
+        self._providers = providers
+
+    @property
+    def primary(self) -> LLMProvider:
+        return self._providers[0]
+
+    @property
+    def providers(self) -> List[LLMProvider]:
+        return list(self._providers)
+
+    def generate(
+        self,
+        prompt: str,
+        options: Optional[LLMOptions] = None,
+        timeout: int = 30,
+    ) -> Optional[str]:
+        """Try each provider in order. Return the first non-None result."""
+        for provider in self._providers:
+            if not provider.is_available():
+                logger.debug(f"LLM provider '{provider.provider_name}' unavailable, skipping")
+                continue
+            result = provider.generate(prompt, options, timeout)
+            if result is not None:
+                if provider is not self._providers[0]:
+                    logger.info(
+                        f"Used fallback LLM provider: '{provider.provider_name}' "
+                        f"(primary '{self._providers[0].provider_name}' failed)"
+                    )
+                return result
+        logger.warning("All LLM providers failed or unavailable — returning None")
+        return None
+
+
+def _build_chain() -> ProviderChain:
+    """Build provider chain from configuration."""
+    from backend.llm.ollama_provider import OllamaProvider
+    from backend.llm.openai_provider import OpenAIProvider
+    from backend.llm.anthropic_provider import AnthropicProvider
+
+    try:
+        from backend.config import llm_provider, openai_api_key, anthropic_api_key
+        primary_name = llm_provider()
+        has_openai = bool(openai_api_key())
+        has_anthropic = bool(anthropic_api_key())
+    except Exception:
+        primary_name = "ollama"
+        has_openai = False
+        has_anthropic = False
+
+    provider_map = {
+        "ollama": OllamaProvider,
+        "openai": OpenAIProvider,
+        "anthropic": AnthropicProvider,
+    }
+
+    ordered: List[LLMProvider] = []
+
+    # Primary provider first
+    primary_cls = provider_map.get(primary_name, OllamaProvider)
+    ordered.append(primary_cls())
+
+    # Add other providers that have credentials as fallbacks
+    if primary_name != "openai" and has_openai:
+        ordered.append(OpenAIProvider())
+    if primary_name != "anthropic" and has_anthropic:
+        ordered.append(AnthropicProvider())
+    # Ollama is always the final free fallback (no API key required)
+    if primary_name != "ollama":
+        ordered.append(OllamaProvider())
+
+    names = [p.provider_name for p in ordered]
+    logger.debug(f"LLM provider chain built: {names}")
+    return ProviderChain(ordered)
+
+
+def get_provider() -> ProviderChain:
+    """Get (or lazily create) the global provider chain.
+
+    Thread-safe at the module-import level; the singleton is set once.
+    For test isolation use reset_provider_cache() before and after each test.
+    """
+    global _provider_cache
+    if _provider_cache is None:
+        _provider_cache = _build_chain()
+    return _provider_cache
+
+
+def reset_provider_cache() -> None:
+    """Force rebuild on next get_provider() call. Use in tests only."""
+    global _provider_cache
+    _provider_cache = None

--- a/backend/msgraph_python/sentiment_analysis.py
+++ b/backend/msgraph_python/sentiment_analysis.py
@@ -7,7 +7,6 @@ Teams Chat Analysis using OLLAMA
 
 import duckdb
 import json
-import requests
 import os
 import sys
 import re
@@ -19,57 +18,35 @@ import glob
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 
-def _get_ollama_config():
-    """Get Ollama config from .env"""
-    try:
-        from backend.config import ollama_host, ollama_model
-        return ollama_host(), ollama_model()
-    except ImportError:
-        return os.getenv("OLLAMA_HOST", "http://localhost:11434"), os.getenv("OLLAMA_MODEL", "llama3.2")
-
-
 class ChatResponsivenessAnalyzer:
     def __init__(
         self,
         db_path: str,
+        provider=None,
+        # Legacy params kept for backwards compatibility but ignored:
         ollama_url: Optional[str] = None,
-        model: Optional[str] = None
+        model: Optional[str] = None,
     ):
-        """Initialize the responsiveness analyzer"""
+        """Initialize the responsiveness analyzer."""
         if not os.path.exists(db_path):
             raise FileNotFoundError(f"Database file not found: {db_path}")
 
-        cfg_host, cfg_model = _get_ollama_config()
         self.db_path = db_path
-        self.ollama_url = ollama_url or cfg_host
-        self.model = model or cfg_model
+        self._provider = provider  # None = lazy init on first use
         self.conn = duckdb.connect(db_path, read_only=True)
-
-        # Test OLLAMA connection
-        self._test_ollama_connection()
 
         # Load metadata
         self._load_metadata()
-    
-    def _test_ollama_connection(self):
-        """Test if OLLAMA is running and accessible"""
-        try:
-            response = requests.get(f"{self.ollama_url}/api/tags", timeout=5)
-            if response.status_code == 200:
-                models = response.json().get('models', [])
-                available_models = [model['name'] for model in models]
-                print(f"✅ OLLAMA connection successful. Available models: {available_models}")
-                
-                if not any(self.model in model for model in available_models):
-                    print(f"⚠️  Model '{self.model}' not found. Available: {available_models}")
-                    print(f"💡 Run: ollama pull {self.model}")
-                    sys.exit(1)
-            else:
-                raise Exception(f"HTTP {response.status_code}")
-        except Exception as e:
-            print(f"❌ OLLAMA connection failed: {e}")
-            print("💡 Make sure OLLAMA is running: ollama serve")
-            sys.exit(1)
+
+    def _get_provider(self):
+        if self._provider is None:
+            try:
+                from backend.llm import get_provider
+                self._provider = get_provider()
+            except Exception as e:
+                import logging
+                logging.getLogger(__name__).warning(f"LLM provider unavailable: {e}")
+        return self._provider
     
     def _load_metadata(self):
         """Load chat metadata"""
@@ -104,35 +81,20 @@ class ChatResponsivenessAnalyzer:
             return ' '.join(text.split())
 
     def _call_ollama(self, prompt: str) -> str:
-        """Call OLLAMA API with a prompt"""
+        """Call the configured LLM provider with a prompt."""
         try:
-            payload = {
-                "model": self.model,
-                "prompt": prompt,
-                "stream": False,
-                "options": {
-                    "temperature": 0.2,
-                    "num_predict": 300
-                }
-            }
-            
-            response = requests.post(
-                f"{self.ollama_url}/api/generate",
-                json=payload,
-                timeout=60
+            from backend.llm.base import LLMOptions
+            provider = self._get_provider()
+            if provider is None:
+                return "Error: LLM provider unavailable"
+            result = provider.generate(
+                prompt=prompt,
+                options=LLMOptions(temperature=0.2, max_tokens=300),
+                timeout=60,
             )
-            
-            if response.status_code == 200:
-                return response.json()['response'].strip()
-            else:
-                print(f"OLLAMA API error: {response.status_code}")
-                return "Error: API call failed"
-                
-        except requests.exceptions.Timeout:
-            print("OLLAMA request timed out - continuing without this analysis")
-            return "Error: Request timed out"
+            return result if result else "Error: No response"
         except Exception as e:
-            print(f"Error calling OLLAMA: {e}")
+            print(f"Error calling LLM: {e}")
             return "Error: Connection failed"
     
     def _analyze_message_sentiment(self, content: str) -> str:
@@ -644,10 +606,16 @@ def main():
             print("❌ Invalid input.")
             return
     
-    # Get target sender
-    target_sender = input("\n🎯 Enter target sender name (default: Shashank Raj): ").strip()
+    # Get target sender (from config or user input)
+    try:
+        from backend.config import sentiment_target_sender
+        default_sender = sentiment_target_sender()
+    except ImportError:
+        default_sender = ""
+    prompt_default = f" (default: {default_sender})" if default_sender else ""
+    target_sender = input(f"\n🎯 Enter target sender name{prompt_default}: ").strip()
     if not target_sender:
-        target_sender = "Shashank Raj"
+        target_sender = default_sender
     
     # Get OLLAMA model
     model = input("🤖 Enter OLLAMA model (default: llama3:latest): ").strip()

--- a/backend/personalized_ai.py
+++ b/backend/personalized_ai.py
@@ -26,13 +26,6 @@ from dataclasses import dataclass, asdict
 from collections import defaultdict
 import re
 
-# Ollama for local AI (as per requirement)
-try:
-    import ollama
-    ollama_available = True
-except ImportError:
-    ollama_available = False
-    logging.warning("Ollama not available. Install: pip install ollama")
 
 logger = logging.getLogger(__name__)
 
@@ -640,19 +633,13 @@ Use their common phrases and vocabulary where appropriate.
 Response:"""
         
         try:
-            model_name = "llama3.2"
-            try:
-                from backend.config import ollama_model
-                model_name = ollama_model()
-            except ImportError:
-                model_name = os.getenv("OLLAMA_MODEL", "llama3.2")
-            response = ollama.generate(
-                model=model_name,
+            from backend.llm import get_provider
+            from backend.llm.base import LLMOptions
+            result = get_provider().generate(
                 prompt=prompt,
-                options={'temperature': 0.7}
+                options=LLMOptions(temperature=0.7, max_tokens=300),
             )
-            
-            return response['response']
+            return result if result else "Error: LLM unavailable"
         except Exception as e:
             logger.error(f"Error generating response: {e}")
             return f"Error generating response: {e}"

--- a/backend/task_matcher.py
+++ b/backend/task_matcher.py
@@ -411,10 +411,28 @@ class TaskRepository:
         return []
     
     def _get_jira_tasks(self) -> List[Task]:
-        """Fetch tasks from Jira"""
-        # Placeholder - would use actual Jira API
+        """Fetch tasks from Jira using the configured JiraClient."""
+        if not self.jira_client:
+            return []
         logger.info("Fetching tasks from Jira...")
-        return []
+        try:
+            issues = self.jira_client.get_my_issues()
+            return [
+                Task(
+                    id=issue.key,
+                    title=issue.summary,
+                    description=issue.description,
+                    status=issue.status,
+                    project=issue.key.split("-")[0] if "-" in issue.key else issue.key,
+                    assignee=issue.assignee or "",
+                    tags=issue.labels,
+                    source="jira",
+                )
+                for issue in issues
+            ]
+        except Exception as e:
+            logger.warning(f"Failed to fetch Jira tasks: {e}")
+            return []
 
 
 # CLI interface

--- a/backend/tests/test_jira_client.py
+++ b/backend/tests/test_jira_client.py
@@ -1,0 +1,335 @@
+"""
+Tests for the Jira integration module.
+
+No network calls are made — all external calls are mocked.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+def _make_raw_issue(
+    id="10001",
+    key="PROJ-1",
+    summary="Fix the login bug",
+    description=None,
+    status_name="In Progress",
+    assignee_display="Alice Smith",
+    assignee_email="alice@example.com",
+    issue_type="Bug",
+    priority="High",
+    labels=None,
+):
+    """Return a raw Jira API issue dict."""
+    return {
+        "id": id,
+        "key": key,
+        "fields": {
+            "summary": summary,
+            "description": description,
+            "status": {"name": status_name},
+            "assignee": {
+                "displayName": assignee_display,
+                "emailAddress": assignee_email,
+            },
+            "issuetype": {"name": issue_type},
+            "priority": {"name": priority},
+            "labels": labels or [],
+        },
+    }
+
+
+def _make_adf_description(text_parts):
+    """Build a minimal ADF document with paragraph nodes."""
+    return {
+        "type": "doc",
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": t} for t in text_parts],
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# JiraClient.is_configured()
+# ---------------------------------------------------------------------------
+
+class TestIsConfigured:
+    def test_returns_false_when_no_credentials(self):
+        from backend.jira.client import JiraClient
+        client = JiraClient(base_url="", email="", api_token="", project_key="")
+        assert client.is_configured() is False
+
+    def test_returns_false_when_missing_url(self):
+        from backend.jira.client import JiraClient
+        client = JiraClient(base_url="", email="me@example.com", api_token="token123", project_key="PROJ")
+        assert client.is_configured() is False
+
+    def test_returns_false_when_missing_email(self):
+        from backend.jira.client import JiraClient
+        client = JiraClient(base_url="https://org.atlassian.net", email="", api_token="token123", project_key="PROJ")
+        assert client.is_configured() is False
+
+    def test_returns_false_when_missing_token(self):
+        from backend.jira.client import JiraClient
+        client = JiraClient(base_url="https://org.atlassian.net", email="me@example.com", api_token="", project_key="PROJ")
+        assert client.is_configured() is False
+
+    def test_returns_true_when_all_credentials_present(self):
+        from backend.jira.client import JiraClient
+        client = JiraClient(
+            base_url="https://org.atlassian.net",
+            email="me@example.com",
+            api_token="token123",
+            project_key="PROJ",
+        )
+        assert client.is_configured() is True
+
+
+# ---------------------------------------------------------------------------
+# JiraClient.get_my_issues() — no network
+# ---------------------------------------------------------------------------
+
+class TestGetMyIssues:
+    def _unconfigured_client(self):
+        from backend.jira.client import JiraClient
+        return JiraClient(base_url="", email="", api_token="", project_key="")
+
+    def _configured_client(self):
+        from backend.jira.client import JiraClient
+        return JiraClient(
+            base_url="https://org.atlassian.net",
+            email="me@example.com",
+            api_token="token123",
+            project_key="PROJ",
+        )
+
+    def test_returns_empty_list_when_not_configured(self):
+        client = self._unconfigured_client()
+        assert client.get_my_issues() == []
+
+    def test_returns_empty_list_when_no_email(self):
+        from backend.jira.client import JiraClient
+        # configured URL + token but no email
+        client = JiraClient(base_url="https://org.atlassian.net", email="", api_token="token123", project_key="PROJ")
+        result = client.get_my_issues()
+        assert result == []
+
+    def test_returns_issues_on_success(self):
+        client = self._configured_client()
+        raw = _make_raw_issue()
+        mock_response = {"issues": [raw]}
+
+        with patch("requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = mock_response
+            mock_resp.raise_for_status.return_value = None
+            mock_get.return_value = mock_resp
+
+            issues = client.get_my_issues()
+
+        assert len(issues) == 1
+        assert issues[0].key == "PROJ-1"
+        assert issues[0].summary == "Fix the login bug"
+
+    def test_returns_empty_on_api_failure(self):
+        client = self._configured_client()
+
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = Exception("Connection refused")
+            issues = client.get_my_issues()
+
+        assert issues == []
+
+    def test_status_filter_passed_in_jql(self):
+        client = self._configured_client()
+        mock_response = {"issues": []}
+
+        with patch("requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = mock_response
+            mock_resp.raise_for_status.return_value = None
+            mock_get.return_value = mock_resp
+
+            client.get_my_issues(status_filter=["In Progress", "To Do"])
+
+        call_kwargs = mock_get.call_args
+        jql = call_kwargs.kwargs.get("params", {}).get("jql", "")
+        assert "In Progress" in jql
+        assert "To Do" in jql
+
+
+# ---------------------------------------------------------------------------
+# JiraClient.get_issue()
+# ---------------------------------------------------------------------------
+
+class TestGetIssue:
+    def _configured_client(self):
+        from backend.jira.client import JiraClient
+        return JiraClient(
+            base_url="https://org.atlassian.net",
+            email="me@example.com",
+            api_token="token123",
+            project_key="PROJ",
+        )
+
+    def test_returns_none_when_not_configured(self):
+        from backend.jira.client import JiraClient
+        client = JiraClient(base_url="", email="", api_token="", project_key="")
+        assert client.get_issue("PROJ-1") is None
+
+    def test_returns_issue_on_success(self):
+        client = self._configured_client()
+        raw = _make_raw_issue(key="PROJ-42", summary="Add OAuth support")
+
+        with patch("requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = raw
+            mock_resp.raise_for_status.return_value = None
+            mock_get.return_value = mock_resp
+
+            issue = client.get_issue("PROJ-42")
+
+        assert issue is not None
+        assert issue.key == "PROJ-42"
+        assert issue.summary == "Add OAuth support"
+
+    def test_returns_none_on_api_error(self):
+        client = self._configured_client()
+
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = Exception("404 Not Found")
+            result = client.get_issue("PROJ-999")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# JiraClient._parse_issue() — field mapping
+# ---------------------------------------------------------------------------
+
+class TestParseIssue:
+    def _client(self):
+        from backend.jira.client import JiraClient
+        return JiraClient(
+            base_url="https://org.atlassian.net",
+            email="me@example.com",
+            api_token="token123",
+            project_key="PROJ",
+        )
+
+    def test_maps_all_basic_fields(self):
+        client = self._client()
+        raw = _make_raw_issue(
+            id="10002",
+            key="PROJ-2",
+            summary="Update API docs",
+            status_name="To Do",
+            assignee_display="Bob Jones",
+            issue_type="Task",
+            priority="Medium",
+            labels=["docs", "api"],
+        )
+
+        issue = client._parse_issue(raw)
+
+        assert issue.id == "10002"
+        assert issue.key == "PROJ-2"
+        assert issue.summary == "Update API docs"
+        assert issue.status == "To Do"
+        assert issue.assignee == "Bob Jones"
+        assert issue.issue_type == "Task"
+        assert issue.priority == "Medium"
+        assert issue.labels == ["docs", "api"]
+
+    def test_url_constructed_correctly(self):
+        client = self._client()
+        raw = _make_raw_issue(key="PROJ-5")
+        issue = client._parse_issue(raw)
+        assert issue.url == "https://org.atlassian.net/browse/PROJ-5"
+
+    def test_handles_missing_assignee(self):
+        client = self._client()
+        raw = _make_raw_issue()
+        raw["fields"]["assignee"] = None
+        issue = client._parse_issue(raw)
+        assert issue.assignee == ""
+
+    def test_handles_missing_status(self):
+        client = self._client()
+        raw = _make_raw_issue()
+        raw["fields"]["status"] = None
+        issue = client._parse_issue(raw)
+        assert issue.status == "Unknown"
+
+    def test_handles_empty_labels(self):
+        client = self._client()
+        raw = _make_raw_issue(labels=[])
+        issue = client._parse_issue(raw)
+        assert issue.labels == []
+
+
+# ---------------------------------------------------------------------------
+# JiraClient._extract_description() and _adf_to_text()
+# ---------------------------------------------------------------------------
+
+class TestDescriptionExtraction:
+    def _client(self):
+        from backend.jira.client import JiraClient
+        return JiraClient(
+            base_url="https://org.atlassian.net",
+            email="me@example.com",
+            api_token="token123",
+            project_key="PROJ",
+        )
+
+    def test_none_returns_empty_string(self):
+        client = self._client()
+        assert client._extract_description(None) == ""
+
+    def test_plain_string_returned_as_is(self):
+        client = self._client()
+        assert client._extract_description("Simple description") == "Simple description"
+
+    def test_adf_single_text_node(self):
+        client = self._client()
+        adf = {"type": "text", "text": "Hello world"}
+        assert client._adf_to_text(adf) == "Hello world"
+
+    def test_adf_paragraph_with_multiple_text_nodes(self):
+        client = self._client()
+        adf = _make_adf_description(["Fix the bug", "in login flow"])
+        result = client._extract_description(adf)
+        assert "Fix the bug" in result
+        assert "login flow" in result
+
+    def test_adf_empty_document_returns_empty(self):
+        client = self._client()
+        adf = {"type": "doc", "content": []}
+        result = client._extract_description(adf)
+        assert result == ""
+
+    def test_nested_adf_extracts_all_text(self):
+        client = self._client()
+        adf = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "First paragraph"}],
+                },
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "Second paragraph"}],
+                },
+            ],
+        }
+        result = client._extract_description(adf)
+        assert "First paragraph" in result
+        assert "Second paragraph" in result

--- a/backend/tests/test_llm_providers.py
+++ b/backend/tests/test_llm_providers.py
@@ -1,0 +1,340 @@
+"""
+Tests for the LLM provider abstraction layer.
+
+No network calls are made — all external calls are mocked.
+"""
+
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+class _AlwaysAvailableProvider:
+    """Test double: always available, returns a fixed response."""
+    def __init__(self, response="mock response"):
+        self._response = response
+
+    @property
+    def provider_name(self): return "mock"
+
+    @property
+    def model_name(self): return "mock-model"
+
+    def is_available(self): return True
+
+    def generate(self, prompt, options=None, timeout=30):
+        return self._response
+
+
+class _NeverAvailableProvider:
+    """Test double: never available."""
+    @property
+    def provider_name(self): return "unavail"
+
+    @property
+    def model_name(self): return "unavail"
+
+    def is_available(self): return False
+
+    def generate(self, prompt, options=None, timeout=30):
+        pytest.fail("generate() called on unavailable provider")
+
+
+class _FailingProvider:
+    """Test double: available but always returns None (simulate LLM failure)."""
+    @property
+    def provider_name(self): return "failing"
+
+    @property
+    def model_name(self): return "failing"
+
+    def is_available(self): return True
+
+    def generate(self, prompt, options=None, timeout=30):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# ProviderChain tests
+# ---------------------------------------------------------------------------
+
+class TestProviderChain:
+    def _make_chain(self, *providers):
+        from backend.llm.provider_factory import ProviderChain
+        return ProviderChain(list(providers))
+
+    def test_returns_first_successful_response(self):
+        chain = self._make_chain(_AlwaysAvailableProvider("first"))
+        assert chain.generate("hi") == "first"
+
+    def test_skips_unavailable_provider_tries_next(self):
+        chain = self._make_chain(_NeverAvailableProvider(), _AlwaysAvailableProvider("second"))
+        assert chain.generate("hi") == "second"
+
+    def test_skips_failing_provider_tries_next(self):
+        chain = self._make_chain(_FailingProvider(), _AlwaysAvailableProvider("fallback"))
+        assert chain.generate("hi") == "fallback"
+
+    def test_returns_none_when_all_fail(self):
+        chain = self._make_chain(_FailingProvider(), _FailingProvider())
+        assert chain.generate("hi") is None
+
+    def test_returns_none_when_all_unavailable(self):
+        chain = self._make_chain(_NeverAvailableProvider(), _NeverAvailableProvider())
+        assert chain.generate("hi") is None
+
+    def test_primary_property(self):
+        p1 = _AlwaysAvailableProvider("first")
+        p2 = _AlwaysAvailableProvider("second")
+        chain = self._make_chain(p1, p2)
+        assert chain.primary is p1
+
+    def test_raises_on_empty_providers(self):
+        from backend.llm.provider_factory import ProviderChain
+        with pytest.raises(ValueError):
+            ProviderChain([])
+
+
+# ---------------------------------------------------------------------------
+# OllamaProvider tests
+# ---------------------------------------------------------------------------
+
+class TestOllamaProvider:
+    def test_delegates_generate_to_ollama_client(self):
+        from backend.llm.ollama_provider import OllamaProvider
+        provider = OllamaProvider(host="http://localhost:11434", model="llama3.2")
+        with patch("backend.ai.ollama_client.generate", return_value="ollama response") as mock_gen:
+            result = provider.generate("test prompt")
+            assert result == "ollama response"
+            mock_gen.assert_called_once()
+            call_kwargs = mock_gen.call_args
+            assert call_kwargs.kwargs.get("model") == "llama3.2" or call_kwargs.args[1] == "llama3.2"
+
+    def test_is_available_delegates_to_ollama_client(self):
+        from backend.llm.ollama_provider import OllamaProvider
+        provider = OllamaProvider(host="http://localhost:11434", model="llama3.2")
+        with patch("backend.ai.ollama_client.is_available", return_value=True):
+            assert provider.is_available() is True
+        with patch("backend.ai.ollama_client.is_available", return_value=False):
+            assert provider.is_available() is False
+
+    def test_is_available_returns_false_on_exception(self):
+        from backend.llm.ollama_provider import OllamaProvider
+        provider = OllamaProvider(host="http://localhost:11434", model="llama3.2")
+        with patch("backend.ai.ollama_client.is_available", side_effect=Exception("network error")):
+            assert provider.is_available() is False
+
+    def test_generate_returns_none_on_exception(self):
+        from backend.llm.ollama_provider import OllamaProvider
+        provider = OllamaProvider(host="http://localhost:11434", model="llama3.2")
+        with patch("backend.ai.ollama_client.generate", side_effect=Exception("timeout")):
+            assert provider.generate("test") is None
+
+    def test_provider_name(self):
+        from backend.llm.ollama_provider import OllamaProvider
+        assert OllamaProvider(host="h", model="m").provider_name == "ollama"
+
+    def test_model_name(self):
+        from backend.llm.ollama_provider import OllamaProvider
+        assert OllamaProvider(host="h", model="llama3.2").model_name == "llama3.2"
+
+
+# ---------------------------------------------------------------------------
+# OpenAIProvider tests
+# ---------------------------------------------------------------------------
+
+class TestOpenAIProvider:
+    def test_not_available_without_key(self):
+        from backend.llm.openai_provider import OpenAIProvider
+        provider = OpenAIProvider(api_key="", model="gpt-4o-mini")
+        assert provider.is_available() is False
+
+    def test_available_with_key(self):
+        from backend.llm.openai_provider import OpenAIProvider
+        provider = OpenAIProvider(api_key="sk-test", model="gpt-4o-mini")
+        assert provider.is_available() is True
+
+    def test_generate_returns_none_without_key(self):
+        from backend.llm.openai_provider import OpenAIProvider
+        provider = OpenAIProvider(api_key="", model="gpt-4o-mini")
+        assert provider.generate("test") is None
+
+    def test_generate_returns_none_when_import_fails(self):
+        from backend.llm.openai_provider import OpenAIProvider
+        provider = OpenAIProvider(api_key="sk-test", model="gpt-4o-mini")
+        with patch.dict("sys.modules", {"openai": None}):
+            # ImportError path
+            result = provider.generate("test")
+            assert result is None
+
+    def test_generate_delegates_to_openai_when_available(self):
+        from backend.llm.openai_provider import OpenAIProvider
+        from backend.llm.base import LLMOptions
+
+        provider = OpenAIProvider(api_key="sk-test", model="gpt-4o-mini")
+
+        mock_openai = MagicMock()
+        mock_client_instance = MagicMock()
+        mock_openai.OpenAI.return_value = mock_client_instance
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = "openai response"
+        mock_client_instance.chat.completions.create.return_value = mock_response
+
+        with patch.dict("sys.modules", {"openai": mock_openai}):
+            result = provider.generate("test prompt", LLMOptions(temperature=0.5, max_tokens=100))
+
+        assert result == "openai response"
+        mock_client_instance.chat.completions.create.assert_called_once()
+
+    def test_generate_returns_none_on_api_exception(self):
+        from backend.llm.openai_provider import OpenAIProvider
+        provider = OpenAIProvider(api_key="sk-test", model="gpt-4o-mini")
+
+        mock_openai = MagicMock()
+        mock_client_instance = MagicMock()
+        mock_openai.OpenAI.return_value = mock_client_instance
+        mock_client_instance.chat.completions.create.side_effect = Exception("rate limit")
+
+        with patch.dict("sys.modules", {"openai": mock_openai}):
+            result = provider.generate("test")
+        assert result is None
+
+    def test_provider_name(self):
+        from backend.llm.openai_provider import OpenAIProvider
+        assert OpenAIProvider(api_key="", model="m").provider_name == "openai"
+
+
+# ---------------------------------------------------------------------------
+# AnthropicProvider tests
+# ---------------------------------------------------------------------------
+
+class TestAnthropicProvider:
+    def test_not_available_without_key(self):
+        from backend.llm.anthropic_provider import AnthropicProvider
+        provider = AnthropicProvider(api_key="", model="claude-haiku-4-5")
+        assert provider.is_available() is False
+
+    def test_available_with_key(self):
+        from backend.llm.anthropic_provider import AnthropicProvider
+        provider = AnthropicProvider(api_key="sk-ant-test", model="claude-haiku-4-5")
+        assert provider.is_available() is True
+
+    def test_generate_returns_none_without_key(self):
+        from backend.llm.anthropic_provider import AnthropicProvider
+        provider = AnthropicProvider(api_key="", model="claude-haiku-4-5")
+        assert provider.generate("test") is None
+
+    def test_generate_returns_none_on_api_exception(self):
+        from backend.llm.anthropic_provider import AnthropicProvider
+        provider = AnthropicProvider(api_key="sk-ant-test", model="claude-haiku-4-5")
+
+        mock_anthropic = MagicMock()
+        mock_client = MagicMock()
+        mock_anthropic.Anthropic.return_value = mock_client
+        mock_client.messages.create.side_effect = Exception("overloaded")
+
+        with patch.dict("sys.modules", {"anthropic": mock_anthropic}):
+            result = provider.generate("test")
+        assert result is None
+
+    def test_provider_name(self):
+        from backend.llm.anthropic_provider import AnthropicProvider
+        assert AnthropicProvider(api_key="", model="m").provider_name == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# Provider factory tests
+# ---------------------------------------------------------------------------
+
+class TestProviderFactory:
+    def setup_method(self):
+        from backend.llm.provider_factory import reset_provider_cache
+        reset_provider_cache()
+
+    def teardown_method(self):
+        from backend.llm.provider_factory import reset_provider_cache
+        reset_provider_cache()
+
+    def test_defaults_to_ollama_when_env_not_set(self):
+        from backend.llm.provider_factory import _build_chain
+        env = {"LLM_PROVIDER": "ollama", "OPENAI_API_KEY": "", "ANTHROPIC_API_KEY": ""}
+        with patch.dict(os.environ, env, clear=False):
+            chain = _build_chain()
+        assert chain.primary.provider_name == "ollama"
+
+    def test_primary_is_openai_when_configured(self):
+        from backend.llm.provider_factory import _build_chain
+        env = {"LLM_PROVIDER": "openai", "OPENAI_API_KEY": "sk-test", "ANTHROPIC_API_KEY": ""}
+        with patch.dict(os.environ, env, clear=False):
+            chain = _build_chain()
+        assert chain.primary.provider_name == "openai"
+
+    def test_primary_is_anthropic_when_configured(self):
+        from backend.llm.provider_factory import _build_chain
+        env = {"LLM_PROVIDER": "anthropic", "OPENAI_API_KEY": "", "ANTHROPIC_API_KEY": "sk-ant"}
+        with patch.dict(os.environ, env, clear=False):
+            chain = _build_chain()
+        assert chain.primary.provider_name == "anthropic"
+
+    def test_ollama_included_as_fallback_when_primary_is_openai(self):
+        from backend.llm.provider_factory import _build_chain
+        env = {"LLM_PROVIDER": "openai", "OPENAI_API_KEY": "sk-test", "ANTHROPIC_API_KEY": ""}
+        with patch.dict(os.environ, env, clear=False):
+            chain = _build_chain()
+        names = [p.provider_name for p in chain.providers]
+        assert "ollama" in names
+        assert names[0] == "openai"
+
+    def test_get_provider_returns_cached_instance(self):
+        from backend.llm.provider_factory import get_provider
+        with patch.dict(os.environ, {"LLM_PROVIDER": "ollama"}, clear=False):
+            p1 = get_provider()
+            p2 = get_provider()
+        assert p1 is p2
+
+    def test_reset_cache_rebuilds_chain(self):
+        from backend.llm.provider_factory import get_provider, reset_provider_cache
+        with patch.dict(os.environ, {"LLM_PROVIDER": "ollama"}, clear=False):
+            p1 = get_provider()
+        reset_provider_cache()
+        with patch.dict(os.environ, {"LLM_PROVIDER": "ollama"}, clear=False):
+            p2 = get_provider()
+        assert p1 is not p2
+
+
+# ---------------------------------------------------------------------------
+# Config integration tests
+# ---------------------------------------------------------------------------
+
+class TestConfigIntegration:
+    def test_llm_provider_defaults_to_ollama(self):
+        from backend.config import llm_provider
+        saved = os.environ.pop("LLM_PROVIDER", None)
+        try:
+            result = llm_provider()
+            assert result == "ollama"
+        finally:
+            if saved is not None:
+                os.environ["LLM_PROVIDER"] = saved
+
+    def test_openai_api_key_returns_empty_when_not_set(self):
+        from backend.config import openai_api_key
+        saved = os.environ.pop("OPENAI_API_KEY", None)
+        try:
+            assert openai_api_key() == ""
+        finally:
+            if saved is not None:
+                os.environ["OPENAI_API_KEY"] = saved
+
+    def test_anthropic_api_key_returns_empty_when_not_set(self):
+        from backend.config import anthropic_api_key
+        saved = os.environ.pop("ANTHROPIC_API_KEY", None)
+        try:
+            assert anthropic_api_key() == ""
+        finally:
+            if saved is not None:
+                os.environ["ANTHROPIC_API_KEY"] = saved

--- a/backend/tests/test_pr_analyzer.py
+++ b/backend/tests/test_pr_analyzer.py
@@ -1,0 +1,291 @@
+"""
+Tests for the GitHub PR Analyzer.
+
+No real network calls are made — all GitHub API and LLM calls are mocked.
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_pr(
+    number=1,
+    title="Add feature X",
+    state="open",
+    merged=False,
+    login="alice",
+    base_ref="main",
+    head_ref="feature/x",
+    additions=50,
+    deletions=10,
+    changed_files=3,
+    labels=None,
+    html_url="https://github.com/org/repo/pull/1",
+):
+    """Return a mock PyGitHub PullRequest-like object."""
+    pr = MagicMock()
+    pr.number = number
+    pr.title = title
+    pr.state = state
+    pr.merged = merged
+    pr.user.login = login
+    pr.base.ref = base_ref
+    pr.head.ref = head_ref
+    pr.additions = additions
+    pr.deletions = deletions
+    pr.changed_files = changed_files
+    pr.labels = [MagicMock(name=lbl) for lbl in (labels or [])]
+    pr.html_url = html_url
+    pr.created_at = datetime(2026, 3, 1, 10, 0)
+    pr.updated_at = datetime(2026, 3, 2, 10, 0)
+    return pr
+
+
+class _MockProvider:
+    """Test double: always returns a fixed summary."""
+
+    def __init__(self, response="Fixed auth bug in login flow."):
+        self._response = response
+
+    def generate(self, prompt, options=None, timeout=30):
+        return self._response
+
+
+class _FailingProvider:
+    """Test double: always returns None."""
+
+    def generate(self, prompt, options=None, timeout=30):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# PRSummary dataclass
+# ---------------------------------------------------------------------------
+
+class TestPRSummary:
+    def test_defaults(self):
+        from backend.github.pr_analyzer import PRSummary
+        pr = PRSummary(
+            number=1,
+            title="Test PR",
+            state="open",
+            author="alice",
+            created_at=datetime(2026, 3, 1),
+            updated_at=datetime(2026, 3, 2),
+            url="https://github.com/org/repo/pull/1",
+            repo="repo",
+            base_branch="main",
+            head_branch="feature/x",
+        )
+        assert pr.additions == 0
+        assert pr.deletions == 0
+        assert pr.changed_files == 0
+        assert pr.labels == []
+        assert pr.ai_summary == ""
+
+
+# ---------------------------------------------------------------------------
+# PRAnalyzer.summarize_pr()
+# ---------------------------------------------------------------------------
+
+class TestSummarizePR:
+    def _make_pr_summary(self, **kwargs):
+        from backend.github.pr_analyzer import PRSummary
+        defaults = dict(
+            number=1, title="Add feature X", state="open", author="alice",
+            created_at=datetime(2026, 3, 1), updated_at=datetime(2026, 3, 2),
+            url="https://github.com/org/repo/pull/1", repo="repo",
+            base_branch="main", head_branch="feature/x",
+            additions=50, deletions=10, changed_files=3,
+        )
+        defaults.update(kwargs)
+        return PRSummary(**defaults)
+
+    def test_returns_ai_summary_when_provider_available(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=_MockProvider("Adds feature X to the API."))
+        pr = self._make_pr_summary()
+        result = analyzer.summarize_pr(pr)
+        assert result == "Adds feature X to the API."
+
+    def test_falls_back_to_title_when_provider_unavailable(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=None)
+        analyzer._provider = None  # ensure no lazy init
+        # Patch get_provider to raise so no provider can be obtained
+        with patch("backend.llm.get_provider", side_effect=Exception("no provider")):
+            pr = self._make_pr_summary(title="My PR title")
+            result = analyzer.summarize_pr(pr)
+        assert result == "My PR title"
+
+    def test_falls_back_to_title_when_llm_returns_none(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=_FailingProvider())
+        pr = self._make_pr_summary(title="My fallback title")
+        result = analyzer.summarize_pr(pr)
+        assert result == "My fallback title"
+
+    def test_strips_whitespace_from_ai_response(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=_MockProvider("  Refactored auth module.  "))
+        pr = self._make_pr_summary()
+        result = analyzer.summarize_pr(pr)
+        assert result == "Refactored auth module."
+
+
+# ---------------------------------------------------------------------------
+# PRAnalyzer.list_prs_by_author()
+# ---------------------------------------------------------------------------
+
+class TestListPRsByAuthor:
+    def test_returns_empty_when_no_token(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="", provider=_MockProvider())
+        with patch.dict("os.environ", {"GITHUB_TOKEN": ""}, clear=False):
+            result = analyzer.list_prs_by_author("alice", owner="org", repo_name="repo")
+        assert result == []
+
+    def test_returns_empty_when_github_auth_fails(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_bad", provider=_MockProvider())
+        with patch("github.Github", side_effect=Exception("Bad credentials")):
+            result = analyzer.list_prs_by_author("alice", owner="org", repo_name="repo")
+        assert result == []
+
+    def test_returns_empty_on_repo_api_error(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=_MockProvider())
+
+        mock_g = MagicMock()
+        mock_g.get_repo.side_effect = Exception("Not Found")
+
+        with patch("github.Github") as mock_gh_cls, patch("github.Auth.Token"):
+            mock_gh_cls.return_value = mock_g
+            result = analyzer.list_prs_by_author("alice", owner="org", repo_name="repo")
+
+        assert result == []
+
+    def test_filters_by_author(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=_MockProvider())
+
+        pr_alice = _make_mock_pr(number=1, login="alice")
+        pr_bob = _make_mock_pr(number=2, login="bob")
+
+        mock_repo = MagicMock()
+        mock_repo.get_pulls.return_value = [pr_alice, pr_bob]
+
+        mock_g = MagicMock()
+        mock_g.get_repo.return_value = mock_repo
+
+        with patch("github.Github") as mock_gh_cls, patch("github.Auth.Token"):
+            mock_gh_cls.return_value = mock_g
+            results = analyzer.list_prs_by_author("alice", owner="org", repo_name="repo")
+
+        assert all(r.author == "alice" for r in results)
+        assert len(results) == 1
+
+    def test_merged_pr_gets_merged_state(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=_MockProvider())
+
+        pr_mock = _make_mock_pr(number=3, login="alice", state="closed", merged=True)
+
+        mock_repo = MagicMock()
+        mock_repo.get_pulls.return_value = [pr_mock]
+
+        mock_g = MagicMock()
+        mock_g.get_repo.return_value = mock_repo
+
+        with patch("github.Github") as mock_gh_cls, patch("github.Auth.Token"):
+            mock_gh_cls.return_value = mock_g
+            results = analyzer.list_prs_by_author("alice", owner="org", repo_name="repo", state="merged")
+
+        assert len(results) == 1
+        assert results[0].state == "merged"
+
+    def test_respects_max_results(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=_MockProvider())
+
+        prs = [_make_mock_pr(number=i, login="alice") for i in range(10)]
+
+        mock_repo = MagicMock()
+        mock_repo.get_pulls.return_value = prs
+
+        mock_g = MagicMock()
+        mock_g.get_repo.return_value = mock_repo
+
+        with patch("github.Github") as mock_gh_cls, patch("github.Auth.Token"):
+            mock_gh_cls.return_value = mock_g
+            results = analyzer.list_prs_by_author("alice", owner="org", repo_name="repo", max_results=3)
+
+        assert len(results) == 3
+
+    def test_returns_empty_when_no_owner_configured(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=_MockProvider())
+
+        with patch("github.Github"), patch("github.Auth.Token"):
+            with patch.object(analyzer, "_default_owner_repo", return_value=("", "")):
+                result = analyzer.list_prs_by_author("alice")
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# PRAnalyzer.summarize_author_prs()
+# ---------------------------------------------------------------------------
+
+class TestSummarizeAuthorPRs:
+    def _make_pr_summary(self, number=1, state="open"):
+        from backend.github.pr_analyzer import PRSummary
+        return PRSummary(
+            number=number, title=f"PR #{number}", state=state, author="alice",
+            created_at=datetime(2026, 3, 1), updated_at=datetime(2026, 3, 2),
+            url=f"https://github.com/org/repo/pull/{number}", repo="repo",
+            base_branch="main", head_branch=f"feature/{number}",
+        )
+
+    def test_returns_correct_structure(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=_MockProvider())
+        prs = [self._make_pr_summary(1, "open"), self._make_pr_summary(2, "merged")]
+        result = analyzer.summarize_author_prs("alice", prs=prs)
+
+        assert result["author"] == "alice"
+        assert result["total"] == 2
+        assert result["open"] == 1
+        assert result["merged"] == 1
+        assert result["closed"] == 0
+        assert len(result["prs"]) == 2
+
+    def test_ai_summary_populated_on_each_pr(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=_MockProvider("AI summary."))
+        prs = [self._make_pr_summary(1)]
+        result = analyzer.summarize_author_prs("alice", prs=prs)
+        assert result["prs"][0].ai_summary == "AI summary."
+
+    def test_skips_summarization_if_already_present(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=_MockProvider("New summary."))
+        pr = self._make_pr_summary(1)
+        pr.ai_summary = "Existing summary."
+        result = analyzer.summarize_author_prs("alice", prs=[pr])
+        # ai_summary already set — should not be overwritten
+        assert result["prs"][0].ai_summary == "Existing summary."
+
+    def test_fetches_prs_when_not_provided(self):
+        from backend.github.pr_analyzer import PRAnalyzer
+        analyzer = PRAnalyzer(token="ghp_test", provider=_MockProvider())
+        mock_prs = [self._make_pr_summary(1)]
+        with patch.object(analyzer, "list_prs_by_author", return_value=mock_prs) as mock_list:
+            result = analyzer.summarize_author_prs("alice", owner="org", repo_name="repo")
+        mock_list.assert_called_once()
+        assert result["total"] == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,8 @@ dependencies = [
     "pytest-asyncio>=0.21.0",
     "pandas-stubs==2.3.2.250926",
 ]
+
+[project.optional-dependencies]
+openai = ["openai>=1.0.0"]
+anthropic = ["anthropic>=0.25.0"]
+cloud = ["openai>=1.0.0", "anthropic>=0.25.0"]

--- a/python_bridge.py
+++ b/python_bridge.py
@@ -99,6 +99,16 @@ except ImportError as e:
     OutputFormat = None
     WeeklyReport = None
 
+# Import Task Repository and Jira client (Phase 4)
+try:
+    from backend.task_matcher import TaskRepository
+    from backend.config import jira_url, jira_api_token
+    task_repo_available = True
+except ImportError as e:
+    logger.warning(f"Task repository not available: {e}")
+    task_repo_available = False
+    TaskRepository = None
+
 
 class DevTrackBridge:
     """Main bridge between Go daemon and Python AI layer"""
@@ -158,6 +168,20 @@ class DevTrackBridge:
                     logger.info("✓ Daily report generator initialized (basic mode)")
             except Exception as e:
                 logger.warning(f"Could not initialize daily report generator: {e}")
+
+        # Initialize Task Repository with Jira (Phase 4)
+        self.task_repo = None
+        if task_repo_available:
+            try:
+                self.task_repo = TaskRepository()
+                if jira_url() and jira_api_token():
+                    from backend.jira import JiraClient
+                    self.task_repo.initialize_jira(JiraClient())
+                    logger.info("✓ Jira integration initialized")
+                else:
+                    logger.info("✓ Task repository initialized (Jira not configured)")
+            except Exception as e:
+                logger.warning(f"Could not initialize task repository: {e}")
     
     def handle_commit_trigger(self, msg: IPCMessage):
         """Handle commit trigger from Go daemon"""

--- a/uv.lock
+++ b/uv.lock
@@ -29,9 +29,23 @@ dependencies = [
     { name = "spacy" },
 ]
 
+[package.optional-dependencies]
+anthropic = [
+    { name = "anthropic" },
+]
+cloud = [
+    { name = "anthropic" },
+    { name = "openai" },
+]
+openai = [
+    { name = "openai" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.13" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.25.0" },
+    { name = "anthropic", marker = "extra == 'cloud'", specifier = ">=0.25.0" },
     { name = "azure-identity", specifier = ">=1.23.0" },
     { name = "dateparser", specifier = ">=1.2.0" },
     { name = "duckdb", specifier = ">=1.3.1" },
@@ -40,6 +54,8 @@ requires-dist = [
     { name = "fuzzywuzzy", specifier = ">=0.18.0" },
     { name = "msgraph-sdk", specifier = ">=1.35.0" },
     { name = "ollama", specifier = ">=0.1.0" },
+    { name = "openai", marker = "extra == 'cloud'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=2.3.0" },
     { name = "pandas-stubs", specifier = "==2.3.2.250926" },
@@ -52,6 +68,7 @@ requires-dist = [
     { name = "sentence-transformers", specifier = ">=2.2.0" },
     { name = "spacy", specifier = ">=3.7.0" },
 ]
+provides-extras = ["openai", "anthropic", "cloud"]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -142,6 +159,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.84.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/ea/0869d6df9ef83dcf393aeefc12dd81677d091c6ffc86f783e51cf44062f2/anthropic-0.84.0.tar.gz", hash = "sha256:72f5f90e5aebe62dca316cb013629cfa24996b0f5a4593b8c3d712bc03c43c37", size = 539457, upload-time = "2026-02-25T05:22:38.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ca/218fa25002a332c0aa149ba18ffc0543175998b1f65de63f6d106689a345/anthropic-0.84.0-py3-none-any.whl", hash = "sha256:861c4c50f91ca45f942e091d83b60530ad6d4f98733bfe648065364da05d29e7", size = 455156, upload-time = "2026-02-25T05:22:40.468Z" },
 ]
 
 [[package]]
@@ -447,12 +483,30 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
 ]
 
 [[package]]
@@ -828,6 +882,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
+    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
+    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
+    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
+    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
+    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
 ]
 
 [[package]]
@@ -1395,6 +1492,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9d/5a/652dac4b7affc2b37b95386f8ae78f22808af09d720689e3d7a86b6ed98e/ollama-0.6.1.tar.gz", hash = "sha256:478c67546836430034b415ed64fa890fd3d1ff91781a9d548b3325274e69d7c6", size = 51620, upload-time = "2025-11-13T23:02:17.416Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/4f/4a617ee93d8208d2bcf26b2d8b9402ceaed03e3853c754940e2290fed063/ollama-0.6.1-py3-none-any.whl", hash = "sha256:fc4c984b345735c5486faeee67d8a265214a31cbb828167782dc642ce0a2bf8c", size = 14354, upload-time = "2025-11-13T23:02:16.292Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Multi-provider LLM abstraction** (`backend/llm/`): new `LLMProvider` ABC with `OllamaProvider`, `OpenAIProvider`, and `AnthropicProvider`; `ProviderChain` singleton with ordered fallback so DevTrack runs entirely on local Ollama or swaps to cloud models via `.env`. All 7 consumer modules migrated from direct Ollama HTTP calls.
- **Jira integration** (`backend/jira/`): full Jira Cloud REST API v3 client using Basic auth (no third-party lib). `TaskRepository._get_jira_tasks()` now returns real issues; `python_bridge.py` conditionally initialises `JiraClient` when `JIRA_URL` + `JIRA_API_TOKEN` are set.
- **GitHub PR review** (`backend/github/pr_analyzer.py`): `PRAnalyzer` lists PRs by author and generates LLM-powered standup summaries via `summarize_author_prs()`.
- **Bug fixes**: Dockerfile Python 3.11 → 3.12; `sys.exit(1)` removed from `sentiment_analysis.py`; hardcoded `"Shashank Raj"` sender and `"user@example.com"` placeholder replaced with config; `openai`/`anthropic`/`cloud` optional dep groups added to `pyproject.toml`; 11 new config accessors in `backend/config.py`.

## Test plan

- [x] `pytest backend/tests/ -v` — 99 tests, 0 failures, no network required
- [ ] Smoke-test with Ollama: `python -c "from backend.llm import get_provider; p = get_provider(); print(p.primary.provider_name)"`
- [ ] Test Jira (requires `JIRA_URL` + `JIRA_API_TOKEN` in `.env`): `python -c "from backend.jira import JiraClient; c = JiraClient(); print(c.is_configured(), c.get_my_issues()[:2])"`
- [ ] Test PR analyzer (requires `GITHUB_TOKEN`): `python -c "from backend.github.pr_analyzer import PRAnalyzer; a = PRAnalyzer(); print(a.list_prs_by_author('your-username'))"`
- [ ] End-to-end daemon: `devtrack start && devtrack force-trigger`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
