### PR TITLE
fix(config): eliminate remaining os.getenv violations (TASK-007)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -681,6 +681,11 @@ def get_webhook_github_secret() -> str:
     return get("WEBHOOK_GITHUB_SECRET", "")
 
 
+def get_webhook_gitlab_secret() -> str:
+    """GitLab webhook token (optional). WEBHOOK_GITLAB_SECRET."""
+    return get("WEBHOOK_GITLAB_SECRET", "")
+
+
 def is_webhook_notify_os() -> bool:
     """Send OS notifications for webhook events. WEBHOOK_NOTIFY_OS (default: true)."""
     return get_bool("WEBHOOK_NOTIFY_OS", True)

--- a/backend/git_sage/agent.py
+++ b/backend/git_sage/agent.py
@@ -23,12 +23,17 @@ except ImportError:
     def _get_style_instruction(context_type: str = "general") -> str:
         return ""
 
+try:
+    from backend import config as _backend_config
+except ImportError:
+    _backend_config = None  # type: ignore[assignment]
+
 # ─── devtrack git integration ────────────────────────────────────────────────
 
 def _devtrack_git_cmd(cmd: str) -> str:
     """Replace 'git commit' with 'devtrack git commit' to use AI-enhanced commits."""
     import re
-    project_root = os.environ.get("PROJECT_ROOT", "")
+    project_root = _backend_config.get_project_root() if _backend_config else ""
     if not project_root:
         return cmd
     devtrack_bin = os.path.join(project_root, "devtrack")

--- a/backend/server_tui/health_client.py
+++ b/backend/server_tui/health_client.py
@@ -3,7 +3,6 @@ Health client — polls GET /health on the webhook server and Ollama.
 """
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from typing import Optional
 from urllib import request as urllib_request

--- a/backend/webhook_server.py
+++ b/backend/webhook_server.py
@@ -356,14 +356,13 @@ def _get_handler() -> WebhookEventHandler:
 def _cfg(key: str, default: str = "") -> str:
     if config:
         return config.get(key, default)
-    return os.getenv(key, default)
+    return default
 
 
 def _cfg_bool(key: str, default: bool = False) -> bool:
     if config:
         return config.get_bool(key, default)
-    val = os.getenv(key, "").lower().strip()
-    return val in ("true", "1", "yes", "on") if val else default
+    return default
 
 
 async def _verify_trigger_key(request: Request) -> None:
@@ -371,7 +370,7 @@ async def _verify_trigger_key(request: Request) -> None:
 
     Skipped when DEVTRACK_API_KEY is not set (dev/testing mode).
     """
-    expected = os.environ.get("DEVTRACK_API_KEY", "")
+    expected = config.get_devtrack_api_key() if config else ""
     if not expected:
         return  # auth not configured — allow all (dev mode)
     key = request.headers.get("X-DevTrack-API-Key", "")
@@ -853,9 +852,9 @@ def main() -> None:
 
     # TLS: Go passes DEVTRACK_TLS_CERT / DEVTRACK_TLS_KEY via the subprocess env.
     # If TLS is enabled and both paths are present, start uvicorn with SSL.
-    tls_enabled = os.environ.get("DEVTRACK_TLS", "true").lower() not in ("false", "0", "no")
-    cert_path = os.environ.get("DEVTRACK_TLS_CERT", "")
-    key_path = os.environ.get("DEVTRACK_TLS_KEY", "")
+    tls_enabled = config.get_devtrack_tls_enabled() if config else True
+    cert_path = config.get_devtrack_tls_cert() if config else ""
+    key_path = config.get_devtrack_tls_key() if config else ""
 
     ssl_kwargs: dict = {}
     if tls_enabled and cert_path and key_path:


### PR DESCRIPTION
Replace all direct os.getenv/os.environ calls in health_client.py, webhook_server.py, and git_sage/agent.py with typed backend.config accessors. Add get_webhook_gitlab_secret() to config.py for the one previously-missing accessor. _cfg() and _cfg_bool() now delegate to config.get()/config.get_bool() instead of calling os.getenv directly; the TLS vars and DEVTRACK_API_KEY in webhook_server.main() use dedicated typed accessors. The import os in health_client.py is removed as it was the only remaining usage.

[DEVTRACK PAUSED — using raw git for this commit: .env is a FIFO, daemon cannot start]