### PR TITLE
feat(admin): trigger stats panel on admin dashboard (TASK-014)

### DIFF
--- a/backend/admin/routes.py
+++ b/backend/admin/routes.py
@@ -118,6 +118,19 @@ async def logout(current_user: str = Depends(require_auth)):
 # Dashboard
 # ---------------------------------------------------------------------------
 
+def _trigger_stats_ctx():
+    """Return TriggerStats; degrades to zero-valued instance on any error."""
+    try:
+        from backend.server_tui.stats_client import get_trigger_stats, TriggerStats
+        return get_trigger_stats()
+    except Exception:
+        try:
+            from backend.server_tui.stats_client import TriggerStats
+            return TriggerStats()
+        except Exception:
+            return None
+
+
 @router.get("/", response_class=HTMLResponse)
 async def dashboard(request: Request, current_user: str = Depends(require_auth)):
     snapshot = _snapshot_ctx()
@@ -129,6 +142,7 @@ async def dashboard(request: Request, current_user: str = Depends(require_auth))
     except Exception:
         tier = "personal"
         tier_label = "Personal (Free)"
+    stats = _trigger_stats_ctx()
     return templates.TemplateResponse(
         "dashboard.html",
         _ctx(
@@ -137,6 +151,7 @@ async def dashboard(request: Request, current_user: str = Depends(require_auth))
             user_count=user_count,
             tier=tier,
             tier_label=tier_label,
+            stats=stats,
         ),
     )
 
@@ -144,6 +159,15 @@ async def dashboard(request: Request, current_user: str = Depends(require_auth))
 # ---------------------------------------------------------------------------
 # HTMX partials
 # ---------------------------------------------------------------------------
+
+@router.get("/_partials/stats", response_class=HTMLResponse)
+async def partial_stats(request: Request, current_user: str = Depends(require_auth)):
+    stats = _trigger_stats_ctx()
+    return templates.TemplateResponse(
+        "_stats_panel.html",
+        {"request": request, "stats": stats},
+    )
+
 
 @router.get("/_partials/processes", response_class=HTMLResponse)
 async def partial_processes(request: Request, current_user: str = Depends(require_auth)):

--- a/backend/admin/routes.py
+++ b/backend/admin/routes.py
@@ -122,9 +122,22 @@ async def logout(current_user: str = Depends(require_auth)):
 async def dashboard(request: Request, current_user: str = Depends(require_auth)):
     snapshot = _snapshot_ctx()
     user_count = len(list_users())
+    try:
+        from backend.license_manager import detect_tier, get_tier_label
+        tier = detect_tier(user_count)
+        tier_label = get_tier_label(tier)
+    except Exception:
+        tier = "personal"
+        tier_label = "Personal (Free)"
     return templates.TemplateResponse(
         "dashboard.html",
-        _ctx(request, current_user, "dashboard", snapshot=snapshot, user_count=user_count),
+        _ctx(
+            request, current_user, "dashboard",
+            snapshot=snapshot,
+            user_count=user_count,
+            tier=tier,
+            tier_label=tier_label,
+        ),
     )
 
 
@@ -331,6 +344,45 @@ async def api_key_revoke(
     # Redirect back to the referring user's key page (best-effort)
     referer = request.headers.get("referer", "/admin/users")
     return RedirectResponse(referer, status_code=303)
+
+
+# ---------------------------------------------------------------------------
+# License page
+# ---------------------------------------------------------------------------
+
+@router.get("/license", response_class=HTMLResponse)
+async def license_page(request: Request, current_user: str = Depends(require_auth)):
+    from backend.license_manager import (
+        detect_tier,
+        get_acceptance_record,
+        get_tier_label,
+        check_seat_limit,
+        is_accepted,
+        LICENSE_TIERS,
+        FREE_TEAM_SEAT_LIMIT,
+    )
+    users = list_users()
+    user_count = len(users)
+    tier = detect_tier(user_count)
+    tier_label = get_tier_label(tier)
+    seat_ok, seat_msg = check_seat_limit(user_count)
+    acceptance = get_acceptance_record()
+    accepted = is_accepted()
+    return templates.TemplateResponse(
+        "license.html",
+        _ctx(
+            request, current_user, "license",
+            acceptance=acceptance,
+            accepted=accepted,
+            user_count=user_count,
+            tier=tier,
+            tier_label=tier_label,
+            seat_ok=seat_ok,
+            seat_msg=seat_msg,
+            license_tiers=LICENSE_TIERS,
+            free_team_seat_limit=FREE_TEAM_SEAT_LIMIT,
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/admin/routes.py
+++ b/backend/admin/routes.py
@@ -26,6 +26,8 @@ from backend.admin.user_manager import (
     create_api_key,
     create_user,
     delete_user,
+    disable_user,
+    enable_user,
     ensure_default_admin,
     get_audit_log,
     get_user,
@@ -35,6 +37,7 @@ from backend.admin.user_manager import (
     log_action,
     revoke_api_key,
     touch_last_login,
+    update_role,
 )
 
 router = APIRouter()
@@ -239,6 +242,49 @@ async def users_delete(
     log_action(current_user, "delete_user", f"username={username}",
                ip=request.client.host if request.client else "")
     return RedirectResponse(f"/admin/users?flash=User+'{username}'+deleted", status_code=303)
+
+
+@router.post("/users/{username}/role")
+async def users_update_role(
+    username: str,
+    request: Request,
+    current_user: str = Depends(require_auth),
+    role: str = Form(...),
+):
+    if role not in ("viewer", "admin"):
+        return RedirectResponse(
+            f"/admin/users?flash=Invalid+role+'{role}'&flash_type=error", status_code=303
+        )
+    update_role(username, role)
+    log_action(current_user, "update_role", f"username={username} role={role}",
+               ip=request.client.host if request.client else "")
+    return RedirectResponse(
+        f"/admin/users?flash=Role+updated+for+'{username}'", status_code=303
+    )
+
+
+@router.post("/users/{username}/disable")
+async def users_disable(
+    username: str, request: Request, current_user: str = Depends(require_auth)
+):
+    if username == current_user:
+        return RedirectResponse(
+            "/admin/users?flash=Cannot+disable+yourself&flash_type=error", status_code=303
+        )
+    disable_user(username)
+    log_action(current_user, "disable_user", f"username={username}",
+               ip=request.client.host if request.client else "")
+    return RedirectResponse(f"/admin/users?flash=User+'{username}'+disabled", status_code=303)
+
+
+@router.post("/users/{username}/enable")
+async def users_enable(
+    username: str, request: Request, current_user: str = Depends(require_auth)
+):
+    enable_user(username)
+    log_action(current_user, "enable_user", f"username={username}",
+               ip=request.client.host if request.client else "")
+    return RedirectResponse(f"/admin/users?flash=User+'{username}'+enabled", status_code=303)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/admin/templates/_stats_panel.html
+++ b/backend/admin/templates/_stats_panel.html
@@ -1,0 +1,26 @@
+{% if stats %}
+<div class="grid-4">
+  <div class="stat-card">
+    <div class="stat-label">Triggers Today</div>
+    <div class="stat-value">{{ stats.triggers_today }}</div>
+    <div class="stat-sub">all types</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Commits Today</div>
+    <div class="stat-value">{{ stats.commits_today }}</div>
+    <div class="stat-sub">commit triggers</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Last Trigger</div>
+    <div class="stat-value" style="font-size:20px">{{ stats.last_trigger }}</div>
+    <div class="stat-sub">most recent</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Errors (24h)</div>
+    <div class="stat-value {{ 'text-red' if stats.errors_24h > 0 else '' }}">{{ stats.errors_24h }}</div>
+    <div class="stat-sub">unprocessed &gt;5 min</div>
+  </div>
+</div>
+{% else %}
+<div class="text-muted" style="padding:12px 0;font-size:13px">Trigger stats unavailable — database not accessible.</div>
+{% endif %}

--- a/backend/admin/templates/base.html
+++ b/backend/admin/templates/base.html
@@ -28,6 +28,9 @@
       <a href="/admin/audit" class="{{ 'active' if active == 'audit' }}">
         <span class="nav-icon">📋</span> Audit Log
       </a>
+      <a href="/admin/license" class="{{ 'active' if active == 'license' }}">
+        <span class="nav-icon">⚖</span> License
+      </a>
     </nav>
     <div class="sidebar-footer">
       Signed in as <strong>{{ current_user }}</strong><br>

--- a/backend/admin/templates/dashboard.html
+++ b/backend/admin/templates/dashboard.html
@@ -21,9 +21,9 @@
     <div class="stat-sub">trigger API</div>
   </div>
   <div class="stat-card">
-    <div class="stat-label">Admin Users</div>
-    <div class="stat-value">{{ user_count }}</div>
-    <div class="stat-sub"><a href="/admin/users">manage →</a></div>
+    <div class="stat-label">License Tier</div>
+    <div class="stat-value" style="font-size:16px">{{ tier_label }}</div>
+    <div class="stat-sub">{{ user_count }} user{{ 's' if user_count != 1 }} · <a href="/admin/license">details →</a></div>
   </div>
 </div>
 

--- a/backend/admin/templates/dashboard.html
+++ b/backend/admin/templates/dashboard.html
@@ -66,6 +66,20 @@
   </div>
 </div>
 
+<!-- Trigger activity stats -->
+<div class="card">
+  <div class="section-header">
+    <div class="card-title" style="margin-bottom:0">Trigger Activity</div>
+    <span class="text-muted" style="font-size:12px">auto-refreshes every 30s</span>
+  </div>
+  <div id="stats-panel"
+       hx-get="/admin/_partials/stats"
+       hx-trigger="every 30s"
+       hx-swap="innerHTML">
+    {% include "_stats_panel.html" %}
+  </div>
+</div>
+
 <!-- Auto-refresh every 15s -->
 <div hx-get="/admin/_partials/processes" hx-trigger="every 15s" hx-target="#proc-table-body" hx-swap="innerHTML" style="display:none"></div>
 {% endblock %}

--- a/backend/admin/templates/license.html
+++ b/backend/admin/templates/license.html
@@ -1,0 +1,97 @@
+{% extends "base.html" %}
+{% block title %}License — DevTrack Admin{% endblock %}
+{% block page_title %}License{% endblock %}
+
+{% block content %}
+<!-- Acceptance status -->
+<div class="grid-2" style="margin-bottom:20px">
+  <div class="card">
+    <div class="card-title">Terms Acceptance</div>
+    {% if accepted %}
+    <div style="display:flex;align-items:center;gap:10px;margin-bottom:16px">
+      <span class="badge badge-green"><span class="dot"></span>Accepted</span>
+      <span class="text-muted" style="font-size:13px">Terms v{{ acceptance.terms_version }}</span>
+    </div>
+    <table>
+      <tbody>
+        <tr>
+          <td class="mono" style="color:var(--muted);width:40%">Accepted at</td>
+          <td>{{ acceptance.accepted_at[:19] if acceptance else '—' }}</td>
+        </tr>
+        <tr>
+          <td class="mono" style="color:var(--muted)">User</td>
+          <td>{{ acceptance.user_identifier if acceptance else '—' }}</td>
+        </tr>
+        <tr>
+          <td class="mono" style="color:var(--muted)">Mode</td>
+          <td>{{ acceptance.mode if acceptance else '—' }}</td>
+        </tr>
+      </tbody>
+    </table>
+    {% else %}
+    <div class="error-msg" style="margin-bottom:12px">
+      Terms of Service have not been accepted. DevTrack may refuse to start.
+    </div>
+    <p class="text-muted" style="font-size:13px">
+      Run the following command to accept the terms:
+    </p>
+    <code style="display:block;background:var(--bg);padding:10px 14px;border-radius:6px;font-size:13px;margin-top:8px">devtrack terms --accept</code>
+    {% endif %}
+  </div>
+
+  <!-- Tier / seat status -->
+  <div class="card">
+    <div class="card-title">Current Tier</div>
+    <div style="font-size:28px;font-weight:700;margin-bottom:4px">{{ tier_label }}</div>
+    <div class="text-muted" style="margin-bottom:16px;font-size:13px">{{ user_count }} admin user{{ 's' if user_count != 1 }}</div>
+
+    {% if seat_ok %}
+    <span class="badge badge-green"><span class="dot"></span>{{ seat_msg }}</span>
+    {% else %}
+    <div class="error-msg">{{ seat_msg }}</div>
+    {% endif %}
+  </div>
+</div>
+
+<!-- Tier comparison table -->
+<div class="card">
+  <div class="card-title">Tier Overview</div>
+  <table>
+    <thead>
+      <tr>
+        <th>Tier</th>
+        <th>Users</th>
+        <th>Deployment</th>
+        <th>Cost</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr {% if tier == 'personal' %}style="background:rgba(99,102,241,.06)"{% endif %}>
+        <td><strong>Personal</strong></td>
+        <td>1</td>
+        <td>Local / self-hosted</td>
+        <td>Free</td>
+        <td>{% if tier == 'personal' %}<span class="badge badge-green">current</span>{% endif %}</td>
+      </tr>
+      <tr {% if tier == 'team' %}style="background:rgba(99,102,241,.06)"{% endif %}>
+        <td><strong>Team</strong></td>
+        <td>2–{{ free_team_seat_limit }}</td>
+        <td>Self-hosted</td>
+        <td>Free</td>
+        <td>{% if tier == 'team' %}<span class="badge badge-green">current</span>{% endif %}</td>
+      </tr>
+      <tr {% if tier == 'enterprise' %}style="background:rgba(239,68,68,.06)"{% endif %}>
+        <td><strong>Enterprise</strong></td>
+        <td>{{ free_team_seat_limit + 1 }}+</td>
+        <td>Self-hosted or SaaS</td>
+        <td>Commercial licence required</td>
+        <td>{% if tier == 'enterprise' %}<span class="badge badge-red">current</span>{% endif %}</td>
+      </tr>
+    </tbody>
+  </table>
+  <p class="text-muted" style="font-size:12px;margin-top:12px">
+    Enterprise licences: <a href="mailto:license@devtrack.dev">license@devtrack.dev</a>
+  </p>
+</div>
+{% endblock %}

--- a/backend/admin/templates/users.html
+++ b/backend/admin/templates/users.html
@@ -51,24 +51,50 @@
 
   <table>
     <thead>
-      <tr><th>Username</th><th>Role</th><th>Created</th><th>Last Login</th><th>API Keys</th><th></th></tr>
+      <tr><th>Username</th><th>Role</th><th>Status</th><th>Created</th><th>Last Login</th><th>API Keys</th><th></th></tr>
     </thead>
     <tbody>
       {% for user in users %}
-      <tr>
+      <tr {% if user.disabled %}style="opacity:0.55"{% endif %}>
         <td><strong>{{ user.username }}</strong></td>
         <td>
-          <span class="badge {{ 'badge-purple' if user.role == 'admin' else 'badge-blue' }}">
-            {{ user.role }}
-          </span>
+          <!-- Inline role-change form -->
+          {% if user.username != current_user %}
+          <form method="post" action="/admin/users/{{ user.username }}/role" style="display:inline-flex;gap:4px;align-items:center">
+            <select name="role" style="padding:2px 6px;font-size:12px;border-radius:4px;border:1px solid var(--border);background:var(--surface);color:var(--text)">
+              <option value="viewer" {{ 'selected' if user.role == 'viewer' }}>viewer</option>
+              <option value="admin" {{ 'selected' if user.role == 'admin' }}>admin</option>
+            </select>
+            <button type="submit" class="btn btn-ghost btn-sm" style="font-size:11px;padding:2px 6px">set</button>
+          </form>
+          {% else %}
+          <span class="badge {{ 'badge-purple' if user.role == 'admin' else 'badge-blue' }}">{{ user.role }}</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if user.disabled %}
+          <span class="badge badge-red"><span class="dot"></span>disabled</span>
+          {% else %}
+          <span class="badge badge-green"><span class="dot"></span>active</span>
+          {% endif %}
         </td>
         <td class="mono">{{ user.created_at[:10] }}</td>
         <td class="mono">{{ user.last_login[:10] if user.last_login else '—' }}</td>
         <td>
           <a href="/admin/users/{{ user.username }}/keys" class="btn btn-ghost btn-sm">Keys</a>
         </td>
-        <td style="text-align:right">
+        <td style="text-align:right;white-space:nowrap">
           {% if user.username != current_user %}
+          {% if user.disabled %}
+          <form method="post" action="/admin/users/{{ user.username }}/enable" style="display:inline">
+            <button type="submit" class="btn btn-ghost btn-sm">Enable</button>
+          </form>
+          {% else %}
+          <form method="post" action="/admin/users/{{ user.username }}/disable" style="display:inline"
+                onsubmit="return confirm('Disable user {{ user.username }}?')">
+            <button type="submit" class="btn btn-ghost btn-sm">Disable</button>
+          </form>
+          {% endif %}
           <form method="post" action="/admin/users/{{ user.username }}/delete" style="display:inline"
                 onsubmit="return confirm('Delete user {{ user.username }}?')">
             <button type="submit" class="btn btn-danger btn-sm">Delete</button>
@@ -79,7 +105,7 @@
         </td>
       </tr>
       {% else %}
-      <tr><td colspan="6" class="text-muted" style="text-align:center;padding:24px">No users yet.</td></tr>
+      <tr><td colspan="7" class="text-muted" style="text-align:center;padding:24px">No users yet.</td></tr>
       {% endfor %}
     </tbody>
   </table>

--- a/backend/admin/user_manager.py
+++ b/backend/admin/user_manager.py
@@ -72,6 +72,13 @@ def init_db() -> None:
                 ts       TEXT NOT NULL DEFAULT (datetime('now'))
             );
         """)
+        # Idempotent migration: add `disabled` column if it doesn't exist yet.
+        try:
+            con.execute(
+                "ALTER TABLE admin_users ADD COLUMN disabled INTEGER NOT NULL DEFAULT 0"
+            )
+        except Exception:
+            pass  # column already exists — safe to ignore
 
 
 # ---------------------------------------------------------------------------
@@ -85,6 +92,7 @@ class AdminUser:
     role: str
     created_at: str
     last_login: Optional[str]
+    disabled: bool = False
 
 
 @dataclass
@@ -104,18 +112,20 @@ class ApiKey:
 def list_users() -> list[AdminUser]:
     with _conn() as con:
         rows = con.execute(
-            "SELECT id, username, role, created_at, last_login FROM admin_users ORDER BY id"
+            "SELECT id, username, role, created_at, last_login, disabled "
+            "FROM admin_users ORDER BY id"
         ).fetchall()
-    return [AdminUser(**dict(r)) for r in rows]
+    return [AdminUser(**{**dict(r), "disabled": bool(r["disabled"])}) for r in rows]
 
 
 def get_user(username: str) -> Optional[AdminUser]:
     with _conn() as con:
         row = con.execute(
-            "SELECT id, username, role, created_at, last_login FROM admin_users WHERE username=?",
+            "SELECT id, username, role, created_at, last_login, disabled "
+            "FROM admin_users WHERE username=?",
             (username,),
         ).fetchone()
-    return AdminUser(**dict(row)) if row else None
+    return AdminUser(**{**dict(row), "disabled": bool(row["disabled"])}) if row else None
 
 
 def create_user(username: str, password: str, role: str = "viewer") -> AdminUser:
@@ -150,6 +160,24 @@ def update_role(username: str, role: str) -> bool:
 def delete_user(username: str) -> bool:
     with _conn() as con:
         cur = con.execute("DELETE FROM admin_users WHERE username=?", (username,))
+    return cur.rowcount > 0
+
+
+def disable_user(username: str) -> bool:
+    """Set disabled=1 for the given user. Returns True if a row was updated."""
+    with _conn() as con:
+        cur = con.execute(
+            "UPDATE admin_users SET disabled=1 WHERE username=?", (username,)
+        )
+    return cur.rowcount > 0
+
+
+def enable_user(username: str) -> bool:
+    """Set disabled=0 for the given user. Returns True if a row was updated."""
+    with _conn() as con:
+        cur = con.execute(
+            "UPDATE admin_users SET disabled=0 WHERE username=?", (username,)
+        )
     return cur.rowcount > 0
 
 

--- a/backend/tests/test_admin_routes.py
+++ b/backend/tests/test_admin_routes.py
@@ -274,6 +274,36 @@ class TestApiKeys:
 
 
 # ---------------------------------------------------------------------------
+# TestTriggerStats — HTMX partial GET /admin/_partials/stats (CS-3 TASK-014)
+# ---------------------------------------------------------------------------
+
+class TestTriggerStats:
+    def test_stats_partial_returns_200(self, client, auth_cookies):
+        r = client.get("/admin/_partials/stats", cookies=auth_cookies)
+        assert r.status_code == 200
+
+    def test_stats_partial_unauthenticated_redirects(self, client):
+        r = client.get("/admin/_partials/stats", follow_redirects=False)
+        assert r.status_code == 303
+        assert "/admin/login" in r.headers["location"]
+
+    def test_stats_partial_returns_html_with_stats_or_unavailable(self, client, auth_cookies):
+        r = client.get("/admin/_partials/stats", cookies=auth_cookies)
+        assert r.status_code == 200
+        # Either the 4-stat grid or the graceful-degrade message must appear
+        assert (
+            b"Triggers Today" in r.content
+            or b"Trigger stats unavailable" in r.content
+        )
+
+    def test_dashboard_includes_stats_panel(self, client, auth_cookies):
+        with patch("backend.admin.routes.get_snapshot", return_value=_make_snapshot()):
+            r = client.get("/admin/", cookies=auth_cookies)
+        assert r.status_code == 200
+        assert b"Trigger Activity" in r.content
+
+
+# ---------------------------------------------------------------------------
 # TestLicensePage — GET /admin/license (CS-3 TASK-013)
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_admin_routes.py
+++ b/backend/tests/test_admin_routes.py
@@ -1,0 +1,338 @@
+"""
+Tests for backend/admin/routes.py  (HTTP-level coverage via starlette TestClient)
+
+All tests use a fresh in-memory SQLite database isolated to tmp_path via the
+DATABASE_DIR env override — no writes to the real Data/ directory.
+
+The ServerSnapshot returned by get_snapshot() is mocked for every test so that
+no live processes, psutil calls, or health HTTP checks are required.
+
+Naming convention: TestXxx classes group routes by feature area.
+"""
+from __future__ import annotations
+
+import importlib
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers / stubs
+# ---------------------------------------------------------------------------
+
+def _make_snapshot():
+    """Return a minimal ServerSnapshot with no processes and no services."""
+    from backend.admin.server_status import ServerSnapshot
+    return ServerSnapshot(
+        processes=[],
+        services=[],
+        llm_provider="ollama",
+        llm_model="llama3",
+        webhook_port=8089,
+        admin_port=8090,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def db_dir(tmp_path, monkeypatch) -> Generator:
+    """Isolate DATABASE_DIR and DATA_DIR to tmp_path for every test.
+
+    Also sets ADMIN_USERNAME / ADMIN_PASSWORD so check_credentials() (which reads
+    from env vars, not the DB) can authenticate in login route tests.
+    """
+    monkeypatch.setenv("DATABASE_DIR", str(tmp_path))
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("ADMIN_USERNAME", "admin")
+    monkeypatch.setenv("ADMIN_PASSWORD", "adminpass")
+
+    # Reload user_manager so _admin_db_path() picks up the new DATABASE_DIR.
+    import backend.admin.user_manager as um
+    importlib.reload(um)
+    um.init_db()
+    um.ensure_default_admin("admin", "adminpass")
+    yield um
+
+
+@pytest.fixture()
+def client(db_dir) -> TestClient:
+    """Return a TestClient wired to the admin FastAPI app.
+
+    get_snapshot is patched so no live process checks run.
+    ADMIN_USERNAME / ADMIN_PASSWORD env vars are already set by db_dir fixture.
+    """
+    with patch("backend.admin.routes.get_snapshot", return_value=_make_snapshot()):
+        from backend.admin.app import app
+        yield TestClient(app, raise_server_exceptions=True)
+
+
+@pytest.fixture()
+def auth_cookies() -> dict:
+    """Return a cookie dict with a valid session for user 'admin'."""
+    from backend.admin.auth import COOKIE_NAME, create_token
+    return {COOKIE_NAME: create_token("admin")}
+
+
+# ---------------------------------------------------------------------------
+# TestLogin — GET /admin/login, POST /admin/login
+# ---------------------------------------------------------------------------
+
+class TestLogin:
+    def test_login_page_returns_200(self, client):
+        r = client.get("/admin/login")
+        assert r.status_code == 200
+        assert b"<form" in r.content
+
+    def test_login_page_contains_username_field(self, client):
+        r = client.get("/admin/login")
+        assert b"username" in r.content
+
+    def test_post_valid_credentials_sets_cookie_and_redirects(self, client):
+        r = client.post(
+            "/admin/login",
+            data={"username": "admin", "password": "adminpass"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert r.headers["location"] == "/admin/"
+        from backend.admin.auth import COOKIE_NAME
+        assert COOKIE_NAME in r.cookies
+
+    def test_post_wrong_password_returns_401(self, client):
+        r = client.post(
+            "/admin/login",
+            data={"username": "admin", "password": "wrongpass"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 401
+        assert b"Invalid" in r.content
+
+    def test_post_unknown_user_returns_401(self, client):
+        r = client.post(
+            "/admin/login",
+            data={"username": "nobody", "password": "anything"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 401
+
+    def test_post_empty_password_returns_401(self, client):
+        r = client.post(
+            "/admin/login",
+            data={"username": "admin", "password": ""},
+            follow_redirects=False,
+        )
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# TestLogout — GET /admin/logout
+# ---------------------------------------------------------------------------
+
+class TestLogout:
+    def test_logout_clears_cookie_and_redirects(self, client, auth_cookies):
+        r = client.get("/admin/logout", cookies=auth_cookies, follow_redirects=False)
+        assert r.status_code == 303
+        assert "/admin/login" in r.headers["location"]
+
+    def test_logout_without_session_redirects_to_login(self, client):
+        r = client.get("/admin/logout", follow_redirects=False)
+        # require_auth raises 303 redirect when no cookie present
+        assert r.status_code == 303
+        assert "/admin/login" in r.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# TestDashboard — GET /admin/
+# ---------------------------------------------------------------------------
+
+class TestDashboard:
+    def test_dashboard_authenticated_returns_200(self, client, auth_cookies):
+        with patch("backend.admin.routes.get_snapshot", return_value=_make_snapshot()):
+            r = client.get("/admin/", cookies=auth_cookies)
+        assert r.status_code == 200
+
+    def test_dashboard_unauthenticated_redirects_to_login(self, client):
+        r = client.get("/admin/", follow_redirects=False)
+        assert r.status_code == 303
+        assert "/admin/login" in r.headers["location"]
+
+    def test_dashboard_shows_admin_section(self, client, auth_cookies):
+        with patch("backend.admin.routes.get_snapshot", return_value=_make_snapshot()):
+            r = client.get("/admin/", cookies=auth_cookies)
+        assert r.status_code == 200
+        # The page should contain navigation markers
+        assert b"Dashboard" in r.content or b"dashboard" in r.content
+
+
+# ---------------------------------------------------------------------------
+# TestUsers — GET/POST /admin/users
+# ---------------------------------------------------------------------------
+
+class TestUsers:
+    def test_users_page_returns_200(self, client, auth_cookies):
+        r = client.get("/admin/users", cookies=auth_cookies)
+        assert r.status_code == 200
+
+    def test_users_page_unauthenticated_redirects(self, client):
+        r = client.get("/admin/users", follow_redirects=False)
+        assert r.status_code == 303
+
+    def test_users_page_shows_admin_user(self, client, auth_cookies):
+        r = client.get("/admin/users", cookies=auth_cookies)
+        assert r.status_code == 200
+        assert b"admin" in r.content
+
+    def test_create_user_redirects_and_user_exists(self, client, auth_cookies, db_dir):
+        r = client.post(
+            "/admin/users/create",
+            data={"username": "newuser", "password": "pass1234", "role": "viewer"},
+            cookies=auth_cookies,
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert "/admin/users" in r.headers["location"]
+        # Verify user was actually created in the DB
+        user = db_dir.get_user("newuser")
+        assert user is not None
+        assert user.role == "viewer"
+
+    def test_create_duplicate_user_redirects_with_error(self, client, auth_cookies):
+        # "admin" user already exists from fixture
+        r = client.post(
+            "/admin/users/create",
+            data={"username": "admin", "password": "pass1234", "role": "viewer"},
+            cookies=auth_cookies,
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert "error" in r.headers["location"].lower() or "already" in r.headers["location"]
+
+    def test_delete_other_user(self, client, auth_cookies, db_dir):
+        db_dir.create_user("todelete", "pass", "viewer")
+        r = client.post(
+            "/admin/users/todelete/delete",
+            cookies=auth_cookies,
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert db_dir.get_user("todelete") is None
+
+    def test_cannot_delete_self(self, client, auth_cookies, db_dir):
+        r = client.post(
+            "/admin/users/admin/delete",
+            cookies=auth_cookies,
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        # User must still exist
+        assert db_dir.get_user("admin") is not None
+        # Flash message should contain an error indicator
+        assert "error" in r.headers["location"].lower() or "cannot" in r.headers["location"].lower()
+
+
+# ---------------------------------------------------------------------------
+# TestApiKeys — GET/POST /admin/users/{username}/keys
+# ---------------------------------------------------------------------------
+
+class TestApiKeys:
+    def test_api_keys_page_returns_200(self, client, auth_cookies):
+        r = client.get("/admin/users/admin/keys", cookies=auth_cookies)
+        assert r.status_code == 200
+
+    def test_api_keys_page_unauthenticated_redirects(self, client):
+        r = client.get("/admin/users/admin/keys", follow_redirects=False)
+        assert r.status_code == 303
+
+    def test_create_api_key_redirects_with_new_key_param(self, client, auth_cookies):
+        r = client.post(
+            "/admin/users/admin/keys/create",
+            data={"label": "ci-token"},
+            cookies=auth_cookies,
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        location = r.headers["location"]
+        assert "new_key=" in location
+
+    def test_revoke_api_key(self, client, auth_cookies, db_dir):
+        raw, key = db_dir.create_api_key("admin", "test-label")
+        r = client.post(
+            f"/admin/keys/{key.id}/revoke",
+            cookies=auth_cookies,
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        # Key should be gone
+        remaining = db_dir.list_api_keys("admin")
+        assert all(k.id != key.id for k in remaining)
+
+
+# ---------------------------------------------------------------------------
+# TestServerPage — GET /admin/server
+# ---------------------------------------------------------------------------
+
+class TestServerPage:
+    def test_server_page_returns_200(self, client, auth_cookies):
+        with patch("backend.admin.routes.get_snapshot", return_value=_make_snapshot()):
+            r = client.get("/admin/server", cookies=auth_cookies)
+        assert r.status_code == 200
+
+    def test_server_page_unauthenticated_redirects(self, client):
+        r = client.get("/admin/server", follow_redirects=False)
+        assert r.status_code == 303
+
+    def test_server_page_shows_llm_section(self, client, auth_cookies):
+        with patch("backend.admin.routes.get_snapshot", return_value=_make_snapshot()):
+            r = client.get("/admin/server", cookies=auth_cookies)
+        assert r.status_code == 200
+        # Server page renders LLM_PROVIDER in the config table
+        assert b"LLM" in r.content or b"llm" in r.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestAuditPage — GET /admin/audit
+# ---------------------------------------------------------------------------
+
+class TestAuditPage:
+    def test_audit_page_returns_200(self, client, auth_cookies):
+        r = client.get("/admin/audit", cookies=auth_cookies)
+        assert r.status_code == 200
+
+    def test_audit_page_unauthenticated_redirects(self, client):
+        r = client.get("/admin/audit", follow_redirects=False)
+        assert r.status_code == 303
+
+    def test_audit_page_shows_login_event(self, client, auth_cookies, db_dir):
+        # Write an audit entry directly so we don't depend on DB path resolution
+        # across module reloads.
+        db_dir.log_action("admin", "login", detail="test entry", ip="127.0.0.1")
+        r = client.get("/admin/audit", cookies=auth_cookies)
+        assert r.status_code == 200
+        assert b"login" in r.content
+
+
+# ---------------------------------------------------------------------------
+# TestPartials — HTMX partial routes
+# ---------------------------------------------------------------------------
+
+class TestPartials:
+    def test_partial_processes_returns_200(self, client, auth_cookies):
+        with patch("backend.admin.routes.get_snapshot", return_value=_make_snapshot()):
+            r = client.get("/admin/_partials/processes", cookies=auth_cookies)
+        assert r.status_code == 200
+
+    def test_partial_processes_unauthenticated_redirects(self, client):
+        r = client.get("/admin/_partials/processes", follow_redirects=False)
+        assert r.status_code == 303
+
+    def test_partial_processes_returns_html_fragment(self, client, auth_cookies):
+        with patch("backend.admin.routes.get_snapshot", return_value=_make_snapshot()):
+            r = client.get("/admin/_partials/processes", cookies=auth_cookies)
+        # Should return an HTML table body fragment (tr elements or "No processes" message)
+        assert b"<tr>" in r.content or b"No processes" in r.content

--- a/backend/tests/test_admin_routes.py
+++ b/backend/tests/test_admin_routes.py
@@ -274,6 +274,39 @@ class TestApiKeys:
 
 
 # ---------------------------------------------------------------------------
+# TestLicensePage — GET /admin/license (CS-3 TASK-013)
+# ---------------------------------------------------------------------------
+
+class TestLicensePage:
+    def test_license_page_returns_200(self, client, auth_cookies):
+        r = client.get("/admin/license", cookies=auth_cookies)
+        assert r.status_code == 200
+
+    def test_license_page_unauthenticated_redirects(self, client):
+        r = client.get("/admin/license", follow_redirects=False)
+        assert r.status_code == 303
+        assert "/admin/login" in r.headers["location"]
+
+    def test_license_page_shows_tier_info(self, client, auth_cookies):
+        r = client.get("/admin/license", cookies=auth_cookies)
+        assert r.status_code == 200
+        # Should contain tier label text somewhere on the page
+        assert b"Personal" in r.content or b"Team" in r.content or b"Enterprise" in r.content
+
+    def test_dashboard_shows_license_tier_card(self, client, auth_cookies):
+        with patch("backend.admin.routes.get_snapshot", return_value=_make_snapshot()):
+            r = client.get("/admin/", cookies=auth_cookies)
+        assert r.status_code == 200
+        assert b"License Tier" in r.content
+
+    def test_license_nav_link_in_base(self, client, auth_cookies):
+        r = client.get("/admin/license", cookies=auth_cookies)
+        assert r.status_code == 200
+        # The sidebar nav should contain a link to /admin/license
+        assert b"/admin/license" in r.content
+
+
+# ---------------------------------------------------------------------------
 # TestUserRoleDisable — new CS-3 routes
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_admin_routes.py
+++ b/backend/tests/test_admin_routes.py
@@ -274,6 +274,75 @@ class TestApiKeys:
 
 
 # ---------------------------------------------------------------------------
+# TestUserRoleDisable — new CS-3 routes
+# ---------------------------------------------------------------------------
+
+class TestUserRoleDisable:
+    def test_update_role_to_admin(self, client, auth_cookies, db_dir):
+        db_dir.create_user("alice", "pass", "viewer")
+        r = client.post(
+            "/admin/users/alice/role",
+            data={"role": "admin"},
+            cookies=auth_cookies,
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert db_dir.get_user("alice").role == "admin"
+
+    def test_update_role_invalid_value_redirects_with_error(self, client, auth_cookies, db_dir):
+        db_dir.create_user("alice", "pass", "viewer")
+        r = client.post(
+            "/admin/users/alice/role",
+            data={"role": "superuser"},
+            cookies=auth_cookies,
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert "error" in r.headers["location"].lower()
+
+    def test_disable_user(self, client, auth_cookies, db_dir):
+        db_dir.create_user("alice", "pass", "viewer")
+        r = client.post(
+            "/admin/users/alice/disable",
+            cookies=auth_cookies,
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert db_dir.get_user("alice").disabled is True
+
+    def test_cannot_disable_self(self, client, auth_cookies, db_dir):
+        r = client.post(
+            "/admin/users/admin/disable",
+            cookies=auth_cookies,
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert "error" in r.headers["location"].lower() or "cannot" in r.headers["location"].lower()
+        assert db_dir.get_user("admin").disabled is False
+
+    def test_enable_user(self, client, auth_cookies, db_dir):
+        db_dir.create_user("alice", "pass", "viewer")
+        db_dir.disable_user("alice")
+        r = client.post(
+            "/admin/users/alice/enable",
+            cookies=auth_cookies,
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert db_dir.get_user("alice").disabled is False
+
+    def test_role_update_unauthenticated_redirects(self, client, db_dir):
+        db_dir.create_user("alice", "pass", "viewer")
+        r = client.post(
+            "/admin/users/alice/role",
+            data={"role": "admin"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        assert "/admin/login" in r.headers["location"]
+
+
+# ---------------------------------------------------------------------------
 # TestServerPage — GET /admin/server
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_admin_user_manager.py
+++ b/backend/tests/test_admin_user_manager.py
@@ -237,3 +237,57 @@ class TestAuditLog:
 
     def test_get_audit_log_empty(self, tmp_admin_db):
         assert tmp_admin_db.get_audit_log() == []
+
+
+# ---------------------------------------------------------------------------
+# disable_user / enable_user
+# ---------------------------------------------------------------------------
+
+class TestDisableEnable:
+    def test_new_user_is_enabled_by_default(self, tmp_admin_db):
+        tmp_admin_db.create_user("alice", "pass", "viewer")
+        user = tmp_admin_db.get_user("alice")
+        assert user.disabled is False
+
+    def test_disable_user_sets_flag(self, tmp_admin_db):
+        tmp_admin_db.create_user("alice", "pass", "viewer")
+        result = tmp_admin_db.disable_user("alice")
+        assert result is True
+        user = tmp_admin_db.get_user("alice")
+        assert user.disabled is True
+
+    def test_enable_user_clears_flag(self, tmp_admin_db):
+        tmp_admin_db.create_user("alice", "pass", "viewer")
+        tmp_admin_db.disable_user("alice")
+        result = tmp_admin_db.enable_user("alice")
+        assert result is True
+        user = tmp_admin_db.get_user("alice")
+        assert user.disabled is False
+
+    def test_disable_nonexistent_returns_false(self, tmp_admin_db):
+        assert tmp_admin_db.disable_user("nobody") is False
+
+    def test_enable_nonexistent_returns_false(self, tmp_admin_db):
+        assert tmp_admin_db.enable_user("nobody") is False
+
+    def test_disabled_flag_visible_in_list_users(self, tmp_admin_db):
+        tmp_admin_db.create_user("alice", "pass", "viewer")
+        tmp_admin_db.create_user("bob", "pass", "viewer")
+        tmp_admin_db.disable_user("alice")
+        users = {u.username: u for u in tmp_admin_db.list_users()}
+        assert users["alice"].disabled is True
+        assert users["bob"].disabled is False
+
+    def test_enable_already_enabled_is_idempotent(self, tmp_admin_db):
+        tmp_admin_db.create_user("alice", "pass", "viewer")
+        # enable on an already-enabled user should not raise and should return True
+        result = tmp_admin_db.enable_user("alice")
+        assert result is True
+        assert tmp_admin_db.get_user("alice").disabled is False
+
+    def test_disable_already_disabled_is_idempotent(self, tmp_admin_db):
+        tmp_admin_db.create_user("alice", "pass", "viewer")
+        tmp_admin_db.disable_user("alice")
+        result = tmp_admin_db.disable_user("alice")
+        assert result is True
+        assert tmp_admin_db.get_user("alice").disabled is True


### PR DESCRIPTION
## Summary

- Wires `backend/server_tui/stats_client.get_trigger_stats()` into the admin dashboard
- `routes.py`: `_trigger_stats_ctx()` helper (guarded with try/except, returns `TriggerStats()` zero-value on any error); `dashboard()` passes `stats`; new `GET /admin/_partials/stats` HTMX route
- `_stats_panel.html`: 4-stat grid (triggers today / commits today / last trigger / errors 24h) with graceful-degrade message when `stats=None`
- `dashboard.html`: "Trigger Activity" card with `{% include "_stats_panel.html" %}` for initial render + `hx-trigger="every 30s"` for live refresh without page reload
- 4 new route tests in `TestTriggerStats`

## Test plan

- [x] `uv run pytest backend/tests/test_admin_routes.py -k TestTriggerStats` — 4/4 green
- [x] `uv run pytest backend/tests/ -q` — 487 passed (was 478), 1 pre-existing failure unchanged
- [x] `get_trigger_stats` import guarded with try/except — degrades gracefully when DB absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)