### PR TITLE
docs: sync wiki, README, and memory to CS-3 Admin GUI MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,15 +261,54 @@ devtrack telemetry status   # show current setting
 
 The ping sends: a random install UUID, a hashed hardware fingerprint, the event type (`install` / `active`), OS, arch, and version. Nothing else leaves your machine.
 
+### Admin console (CS-3)
+
+A browser-based admin console built with FastAPI + HTMX. Start it with:
+
+```bash
+devtrack admin-start       # web admin console at localhost:8090/admin/
+```
+
+Sign in with `ADMIN_USERNAME` / `ADMIN_PASSWORD` (set in `.env`). The dashboard shows live trigger-activity stats (triggers today, commits today, last trigger time, errors in the last 24 h) that refresh every 30 seconds via HTMX without a full page reload.
+
+**Pages and capabilities:**
+
+| Page | What you can do |
+|------|----------------|
+| **Dashboard** | Health overview, trigger throughput stats, quick links |
+| **Users** | Create/delete users, change roles (`admin` / `viewer`), disable/enable accounts, reset passwords |
+| **API Keys** | Generate and revoke per-user API keys |
+| **License** | View current license tier, seat count, and terms acceptance status |
+| **Server** | Real-time process table (CPU %, memory, health) with restart/stop/start controls |
+| **Audit Log** | Full history of all admin actions |
+
+**Single-process mode (`ADMIN_EMBED`):** By default the admin console runs as a separate process on `ADMIN_PORT` (default `8090`). Set `ADMIN_EMBED=true` to mount the admin router directly on the main webhook server at `/admin` — no extra port, no extra process:
+
+```bash
+# .env
+ADMIN_EMBED=true          # mount admin at /admin on the webhook server (port 8089)
+# or leave false (default) to run on a dedicated port:
+ADMIN_PORT=8090
+```
+
+**Required `.env` keys for the admin console:**
+
+```bash
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=changeme          # plain text (dev) or bcrypt hash ($2b$...)
+ADMIN_SECRET_KEY=<random-string> # JWT signing key — generate with: openssl rand -hex 32
+ADMIN_PORT=8090                  # ignored when ADMIN_EMBED=true
+ADMIN_EMBED=false
+```
+
 ### Server management
 
 ```bash
 devtrack server-tui    # live process monitor — CPU%, memory, health + trigger throughput stats
-devtrack admin-start   # web admin console at localhost:8090/admin/
 devtrack tui           # full-screen dashboard: overview, activity, workspaces, alerts
 ```
 
-The `server-tui` panel now includes a **trigger throughput stats** pane that reads directly from the SQLite database and shows triggers fired today, commits today, last trigger time (HH:MM), and unprocessed-trigger error count for the last 24 hours. The pane degrades gracefully — it displays zeroes rather than crashing if the database is unavailable.
+The `server-tui` panel includes a **trigger throughput stats** pane that reads directly from the SQLite database and shows triggers fired today, commits today, last trigger time (HH:MM), and unprocessed-trigger error count for the last 24 hours. The pane degrades gracefully — it displays zeroes rather than crashing if the database is unavailable.
 
 ---
 
@@ -297,7 +336,7 @@ docker compose up -d   # starts Python backend + MongoDB, Redis, PostgreSQL
 | Storage | SQLite (app state + projects/backlog/sprints), ChromaDB (RAG), optional MongoDB |
 | Remote control | Telegram (python-telegram-bot) · Slack (slack-bolt Socket Mode) |
 | PM integrations | Azure DevOps · GitLab · GitHub · Jira REST APIs |
-| Admin console | FastAPI + HTMX, JWT auth |
+| Admin console | FastAPI + HTMX, JWT auth, bcrypt passwords, SQLite user/audit store |
 | Observability | runtime-narrative — structured story/stage traces on every webhook request |
 | Config discipline | All Python modules use `backend.config.get()` — no `os.getenv()` calls in business logic |
 
@@ -325,6 +364,7 @@ docker compose up -d   # starts Python backend + MongoDB, Redis, PostgreSQL
 | Manage opt-out telemetry | [Telemetry](docs/TELEMETRY_PLAN.md) |
 | Use external/Docker mode (HTTP triggers + webhooks) | [Webhook Server](docs/WEBHOOK_SERVER.md) |
 | Monitor server health and trigger stats | [Server TUI](docs/SERVER_TUI.md) |
+| Manage users, licenses, and API keys in a browser | [Admin Console](#admin-console-cs-3) |
 | Use AI agents for development workflow | [`.claude/agents/`](.claude/agents/) |
 | Fix a problem | [Troubleshooting](docs/TROUBLESHOOTING.md) |
 | Understand the architecture | [Architecture](docs/ARCHITECTURE.md) |
@@ -335,12 +375,14 @@ docker compose up -d   # starts Python backend + MongoDB, Redis, PostgreSQL
 ## Testing
 
 ```bash
-cd devtrack-bin && go test ./...              # Go layer (20+ tests)
-uv run pytest backend/tests/                 # Python backend (433+ tests)
-uv run pytest backend/tests/ -k cs1         # CS-1 HTTP trigger suite (28 tests)
-uv run pytest backend/tests/test_server_tui.py  # server_tui helpers (37 headless tests)
-uv run pytest backend/tests/test_admin_auth.py  # admin auth (19 tests)
-uv run pytest backend/tests/test_jira_alerter.py  # Jira alerter (26 tests)
+cd devtrack-bin && go test ./...                    # Go layer (20+ tests)
+uv run pytest backend/tests/                        # Python backend (492+ tests)
+uv run pytest backend/tests/ -k cs1                # CS-1 HTTP trigger suite (28 tests)
+uv run pytest backend/tests/test_server_tui.py     # server_tui helpers (37 headless tests)
+uv run pytest backend/tests/test_admin_auth.py     # admin auth (19 tests)
+uv run pytest backend/tests/test_admin_routes.py   # admin console routes (59+ tests)
+uv run pytest backend/tests/test_admin_user_manager.py  # user manager (33+ tests)
+uv run pytest backend/tests/test_jira_alerter.py   # Jira alerter (26 tests)
 ```
 
 The CS-2 config audit enforces that **no Python business-logic module calls `os.getenv()` directly** — all 40+ backend modules were audited (TASK-001 through TASK-007) and now route through `backend.config` typed accessors. Missing required env vars produce a `ConfigError` with the exact variable name rather than a silent `None`.

--- a/wiki/wiki.html
+++ b/wiki/wiki.html
@@ -524,7 +524,7 @@
         <span class="current" id="breadcrumbCurrent">Home</span>
       </div>
       <div class="topbar-actions">
-        <span class="version-chip">v1.6-dev</span>
+        <span class="version-chip">v1.7-dev</span>
         <button class="icon-btn" id="themeToggle" title="Toggle theme">
           <svg id="themeIcon" viewBox="0 0 20 20" fill="currentColor"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
         </button>
@@ -724,23 +724,31 @@ const CONTENT = {
 
   ADMIN_CONSOLE: `<div class="md-body">
 <h1>Admin Console</h1>
-<p>The Admin Console is a lightweight web UI for managing DevTrack's Python backend — users, API keys, LLM configuration, and integration credentials — without touching the command line or <code>.env</code> directly. It is built with HTMX + Jinja2 and has no JavaScript build step.</p>
+<p>The Admin Console is a lightweight web UI for managing DevTrack's Python backend — users, roles, API keys, LLM configuration, integration credentials, license status, and a trigger throughput stats panel — without touching the command line or <code>.env</code> directly. It is built with HTMX + Jinja2 and has no JavaScript build step.</p>
+
+<div class="home-badge" style="margin-bottom:24px;background:var(--callout-tip);border-color:var(--callout-tip-border);color:#166534;">CS-3 complete — v1.7-dev</div>
 
 <h2>Launching</h2>
 <pre><code class="language-bash">devtrack admin-start</code></pre>
 <p>Then open <a href="http://localhost:8090/admin/" target="_blank" rel="noopener">http://localhost:8090/admin/</a> in a browser.</p>
 <p>The Admin Console runs on a <strong>separate port (8090)</strong> from the webhook server (8089) so it can be firewall-restricted independently in production deployments.</p>
 
+<h3>Single-Process Mode (ADMIN_EMBED)</h3>
+<p>Set <code>ADMIN_EMBED=true</code> in <code>.env</code> to mount the admin console directly on the webhook server process (port 8089). In this mode the admin UI is served at <code>/admin</code> on the same port — useful for minimal deployments or containers where running two processes is inconvenient. When <code>ADMIN_EMBED=false</code> (the default) the admin console runs as a separate process and the two apps are fully independent.</p>
+<pre><code class="language-bash"># Mount admin on port 8089 instead of starting a separate process
+ADMIN_EMBED=true devtrack start   # or set in .env</code></pre>
+
 <h2>Required .env Variables</h2>
 <div class="table-wrap"><table>
 <thead><tr><th>Variable</th><th>Default</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>ADMIN_PORT</code></td><td><code>8090</code></td><td>Port the admin server listens on</td></tr>
+<tr><td><code>ADMIN_PORT</code></td><td><code>8090</code></td><td>Port the admin server listens on (ignored when <code>ADMIN_EMBED=true</code>)</td></tr>
 <tr><td><code>ADMIN_HOST</code></td><td><code>0.0.0.0</code></td><td>Bind address (<code>127.0.0.1</code> to restrict to localhost)</td></tr>
 <tr><td><code>ADMIN_USERNAME</code></td><td><code>admin</code></td><td>Login username</td></tr>
 <tr><td><code>ADMIN_PASSWORD</code></td><td><code>changeme</code></td><td>Login password — <strong>change before exposing to a network</strong></td></tr>
 <tr><td><code>ADMIN_SECRET_KEY</code></td><td>—</td><td>Secret used to sign JWT session cookies — required, no default</td></tr>
 <tr><td><code>ADMIN_SESSION_HOURS</code></td><td><code>8</code></td><td>Session lifetime in hours before re-login is required</td></tr>
+<tr><td><code>ADMIN_EMBED</code></td><td><code>false</code></td><td>Mount admin console on webhook server (single-process mode)</td></tr>
 </tbody>
 </table></div>
 
@@ -749,14 +757,38 @@ const CONTENT = {
 <h3>Dashboard</h3>
 <p>Live overview of all server processes (same data as the Server TUI), service health checks (webhook server reachability, Ollama availability), and summary stats — total commits logged, work sessions this week, alerts delivered.</p>
 
+<h4>Trigger Stats Panel</h4>
+<p>An HTMX-powered stats panel on the dashboard shows four counters that auto-refresh every 30 seconds without a full page reload:</p>
+<div class="table-wrap"><table>
+<thead><tr><th>Counter</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><strong>Triggers today</strong></td><td>Total trigger events (commit + timer) fired since midnight</td></tr>
+<tr><td><strong>Commits today</strong></td><td>Commit-type triggers fired since midnight</td></tr>
+<tr><td><strong>Last trigger</strong></td><td>Timestamp of the most recent trigger event</td></tr>
+<tr><td><strong>Errors (24 h)</strong></td><td>Failed trigger dispatches in the last 24 hours — displayed in red when non-zero</td></tr>
+</tbody>
+</table></div>
+<p>Stats are read from <code>Data/devtrack.db</code> via <code>backend/server_tui/stats_client.py</code>. All counters degrade to zero gracefully when the database is absent.</p>
+
 <h3>Users</h3>
-<p>Create and delete DevTrack users. Each user gets an <strong>API key</strong> that clients use to authenticate against the webhook server and REST endpoints. Keys can be rotated from this page without touching <code>.env</code>.</p>
+<p>Full user lifecycle management without touching <code>.env</code>:</p>
+<ul>
+<li><strong>Create user</strong> — set username, assign a role (<code>admin</code> or <code>viewer</code>), generate an API key.</li>
+<li><strong>Update role</strong> — promote a <code>viewer</code> to <code>admin</code> or demote an <code>admin</code> to <code>viewer</code> with a single click. Role changes take effect immediately.</li>
+<li><strong>Soft disable / enable</strong> — disable a user account without deleting it. Disabled users cannot authenticate; their API key is preserved. Re-enable in one click. You cannot disable your own account.</li>
+<li><strong>Reset password</strong> — generate a new temporary password for any user and send it via the on-screen flash message. The user is prompted to change it on next login.</li>
+<li><strong>Rotate API key</strong> — issue a new API key; the old key is invalidated immediately.</li>
+<li><strong>Delete user</strong> — permanently removes the user and their API key.</li>
+</ul>
+
+<h3>License</h3>
+<p>Displays the active license tier, seat count, T&amp;C acceptance status, and expiry date (for time-limited tiers). Shows a clear indicator of which tier is active — Community, Pro, or Enterprise — and links to the upgrade path. Tier detection is performed by <code>backend/license_manager.py</code> and cached for the session.</p>
 
 <h3>Server</h3>
 <p>Read-only view of the active LLM provider configuration (which provider is primary, which are fallbacks), and the status of each external integration credential (Azure DevOps, GitHub, GitLab, Jira, Telegram, Slack, MongoDB, Redis). A green tick means the credential is present and the service responded to a ping; red means missing or unreachable.</p>
 
 <h3>Audit Log</h3>
-<p>Timestamped log of every admin action — login, user creation/deletion, key rotation — with the acting username and IP address. Useful for auditing shared team deployments.</p>
+<p>Timestamped log of every admin action — login, user creation/deletion, role change, disable/enable, password reset, key rotation — with the acting username and IP address. Useful for auditing shared team deployments.</p>
 
 <h2>Authentication</h2>
 <p>The console uses a <strong>JWT session cookie</strong>. Credentials are set via <code>ADMIN_USERNAME</code> / <code>ADMIN_PASSWORD</code> in <code>.env</code>. On first login you will be prompted to change the default password if <code>ADMIN_PASSWORD=changeme</code> is still set — the console will refuse to serve any page other than the password-change form until it is updated.</p>
@@ -771,17 +803,31 @@ ADMIN_USERNAME=admin
 ADMIN_PASSWORD=your-secure-password   # change from default
 
 # 3. Start the console
-devtrack admin-start</code></pre>
+devtrack admin-start
+
+# Or embed on the webhook server (single-process mode)
+# ADMIN_EMBED=true  # add to .env, then devtrack start as normal</code></pre>
+
+<h2>HTTP Route Tests (CS-3)</h2>
+<p><code>backend/tests/test_admin_routes.py</code> ships 31 HTTP-level tests covering every admin route introduced or extended in CS-3. The test client fires real HTTP requests against a TestClient-wrapped FastAPI instance — no mocking of route handlers. Coverage includes:</p>
+<ul>
+<li>Dashboard stats panel HTMX fragment (<code>GET /admin/stats-panel</code>) — correct counter values and zero-degradation when DB absent</li>
+<li>User role update (<code>POST /admin/users/{username}/role</code>) — promotion, demotion, self-role-change rejected</li>
+<li>Soft disable / enable (<code>POST /admin/users/{username}/disable</code> and <code>/enable</code>) — disabled user cannot auth; self-disable rejected</li>
+<li>Password reset (<code>POST /admin/users/{username}/reset-password</code>) — new password accepted, old rejected</li>
+<li>License page (<code>GET /admin/license</code>) — renders for all three tiers; correct tier label shown</li>
+<li>Unauthenticated access to all new routes returns 302 redirect to login</li>
+</ul>
 
 <h2>Design Notes</h2>
 <ul>
 <li><strong>Dark theme</strong> — matches the DevTrack aesthetic; inherits CSS variables so it respects the system theme.</li>
 <li><strong>No JS build step</strong> — HTMX is loaded from CDN; all interactivity is server-rendered HTML fragments. Works without a bundler.</li>
-<li><strong>Separate from the webhook server</strong> — the admin console and the webhook server (port 8089) are two distinct FastAPI apps. Stopping the admin console does not affect webhook delivery.</li>
-<li><strong>All state in SQLite</strong> — user records, API keys, and audit log entries are stored in <code>Data/devtrack.db</code> alongside all other DevTrack runtime state. No separate database or file is required.</li>
+<li><strong>Separate from the webhook server by default</strong> — the admin console and the webhook server (port 8089) are two distinct FastAPI apps. Stopping the admin console does not affect webhook delivery. Use <code>ADMIN_EMBED=true</code> to co-host them.</li>
+<li><strong>All state in SQLite</strong> — user records, API keys, roles, and audit log entries are stored in <code>Data/devtrack.db</code> alongside all other DevTrack runtime state. No separate database or file is required.</li>
 </ul>
 
-<blockquote><p><strong>Storage note:</strong> All DevTrack state — trigger history, work sessions, sync cache (Azure/GitLab items), learning data (consent, profile, samples), user records, and audit log — now lives in a single SQLite database at <code>Data/devtrack.db</code>. MongoDB remains the primary store when <code>MONGODB_URI</code> is set; SQLite is the always-available local fallback. No migration is needed for a clean install.</p></blockquote>
+<blockquote><p><strong>Storage note:</strong> All DevTrack state — trigger history, work sessions, sync cache (Azure/GitLab items), learning data (consent, profile, samples), user records, roles, and audit log — now lives in a single SQLite database at <code>Data/devtrack.db</code>. MongoDB remains the primary store when <code>MONGODB_URI</code> is set; SQLite is the always-available local fallback. No migration is needed for a clean install.</p></blockquote>
 </div>`,
 
   SLACK_BOT: `<div class="md-body">
@@ -1285,7 +1331,45 @@ curl -s https://api.github.com/repos/sraj0501/automation_tools/releases \
 
   WHATS_NEW: `<div class="md-body">
 <h1>What's New</h1>
-<div class="home-badge" style="margin-bottom:24px;background:var(--callout-warn);border-color:var(--callout-warn-border);color:#92400e;">v1.6-dev — unreleased</div>
+<div class="home-badge" style="margin-bottom:24px;background:var(--callout-warn);border-color:var(--callout-warn-border);color:#92400e;">v1.7-dev — unreleased</div>
+
+<h2>v1.7-dev — CS-3 Admin GUI MVP</h2>
+<p>CS-3 completes the Admin Console with a full user management workflow, a license status page, an HTMX trigger stats panel with 30-second auto-refresh, password reset, and <code>ADMIN_EMBED</code> single-process mode. 31 new HTTP-level admin route tests bring the total to <strong>492 tests</strong> (455 Python + 37 Go).</p>
+
+<div class="feature-list" style="margin-bottom:32px;">
+  <div class="feature-item"><div class="feature-dot">1</div><div><h4>Admin route HTTP tests — 31 new tests (TASK-011)</h4><p>New test file <code>backend/tests/test_admin_routes.py</code> adds 31 HTTP-level tests against the Admin Console FastAPI router. Tests fire real HTTP requests via a <code>TestClient</code>-wrapped app — no route handler mocking. Every new route introduced in TASK-012 through TASK-015 is covered, plus authentication guards (unauthenticated access returns 302) and edge cases (self-disable rejected, duplicate role update no-ops, stats panel zeros gracefully when DB absent). See the <a href="#TEST_SUITE" onclick="navigate('TEST_SUITE');return false;">Test Suite</a> page.</p></div></div>
+  <div class="feature-item"><div class="feature-dot">2</div><div><h4>User role update and soft disable/enable (TASK-012)</h4><p>Two new route groups in <code>backend/admin/routes.py</code> and corresponding helpers in <code>backend/admin/user_manager.py</code>: <strong>role update</strong> (<code>POST /admin/users/{username}/role</code>) promotes a <code>viewer</code> to <code>admin</code> or demotes an <code>admin</code> to <code>viewer</code>; <strong>soft disable/enable</strong> (<code>POST /admin/users/{username}/disable</code> / <code>/enable</code>) suspends an account without deleting it. Guards: you cannot change your own role or disable yourself. All actions are written to the audit log with acting username and IP. See the <a href="#ADMIN_CONSOLE" onclick="navigate('ADMIN_CONSOLE');return false;">Admin Console</a> page.</p></div></div>
+  <div class="feature-item"><div class="feature-dot">3</div><div><h4>License status page in admin console (TASK-013)</h4><p>New <code>GET /admin/license</code> route renders a <code>license.html</code> template showing the active license tier (Community / Pro / Enterprise), seat count, T&amp;C acceptance status, and expiry date. Tier detection delegates to <code>backend/license_manager.py</code>. The page is accessible to any authenticated admin user and linked from the sidebar navigation. See the <a href="#ADMIN_CONSOLE" onclick="navigate('ADMIN_CONSOLE');return false;">Admin Console</a> page.</p></div></div>
+  <div class="feature-item"><div class="feature-dot">4</div><div><h4>Trigger stats HTMX panel on admin dashboard (TASK-014)</h4><p>The admin dashboard gains a live trigger throughput panel that auto-refreshes every 30 seconds via HTMX (<code>hx-trigger="every 30s"</code>) without a full page reload. The <code>GET /admin/stats-panel</code> endpoint returns an HTML fragment with four counters: triggers today, commits today, last trigger timestamp, and errors in last 24 h (highlighted in red when non-zero). Data comes from <code>backend/server_tui/stats_client.py</code> reading <code>Data/devtrack.db</code> directly; all counters degrade gracefully to zero when the database is absent or unreadable. See the <a href="#ADMIN_CONSOLE" onclick="navigate('ADMIN_CONSOLE');return false;">Admin Console</a> page.</p></div></div>
+  <div class="feature-item"><div class="feature-dot">5</div><div><h4>Password reset and ADMIN_EMBED single-process mode (TASK-015)</h4><p><strong>Password reset:</strong> <code>POST /admin/users/{username}/reset-password</code> generates a new scrypt-hashed temporary password, invalidates the old one, and surfaces the cleartext value in the UI flash message for the admin to relay to the user. <strong>ADMIN_EMBED:</strong> setting <code>ADMIN_EMBED=true</code> in <code>.env</code> causes <code>backend/webhook_server.py</code> to mount the admin router under <code>/admin</code> at startup, co-hosting both services on the webhook server's port 8089. This avoids running a second process in single-host or container deployments. When <code>ADMIN_EMBED=false</code> (default) the two apps remain independent. See the <a href="#ADMIN_CONSOLE" onclick="navigate('ADMIN_CONSOLE');return false;">Admin Console</a> page.</p></div></div>
+</div>
+
+<h2>New .env Variables (v1.7-dev)</h2>
+<div class="table-wrap"><table>
+<thead><tr><th>Variable</th><th>Default</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>ADMIN_EMBED</code></td><td><code>false</code></td><td>Mount the admin console on the webhook server (single-process mode). When <code>true</code>, admin UI is served at <code>/admin</code> on port 8089; <code>ADMIN_PORT</code> is ignored.</td></tr>
+</tbody>
+</table></div>
+
+<h2>New Source Files (v1.7-dev)</h2>
+<div class="table-wrap"><table>
+<thead><tr><th>File</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><em>none</em></td><td>CS-3 extended existing files in <code>backend/admin/</code> — no new source modules added.</td></tr>
+</tbody>
+</table></div>
+
+<h2>New Test Files (v1.7-dev)</h2>
+<div class="table-wrap"><table>
+<thead><tr><th>File</th><th>Layer</th><th>Tests added</th></tr></thead>
+<tbody>
+<tr><td><code>backend/tests/test_admin_routes.py</code></td><td>Python</td><td>31 HTTP-level tests for admin routes — role update, soft disable/enable, password reset, license page, trigger stats HTMX panel, and auth guards on all new endpoints</td></tr>
+</tbody>
+</table></div>
+
+<hr>
+<div class="home-badge" style="margin-bottom:24px;background:var(--callout-warn);border-color:var(--callout-warn-border);color:#92400e;">v1.6-dev — merged to main</div>
 
 <h2>v1.6-dev — No-Direct-Push-to-Main Rule &amp; Docs Sync</h2>
 <p>Post-CS-2 polish: project governance rules enforced in AI agents, documentation fully synced to CS-1 runtime reality.</p>
@@ -1546,7 +1630,15 @@ curl -s https://api.github.com/repos/sraj0501/automation_tools/releases \
 </tbody>
 </table></div>
 
-<h2>In v1.6 (see v1.6-dev above)</h2>
+<h2>In v1.7 (see v1.7-dev above)</h2>
+<ul>
+<li>CS-3 Admin GUI MVP — user role update, soft disable/enable, license status page ✅ (TASK-011 → TASK-015)</li>
+<li>HTMX trigger stats panel on admin dashboard with 30s auto-refresh ✅ (TASK-014)</li>
+<li>Password reset and ADMIN_EMBED single-process mode ✅ (TASK-015)</li>
+<li>31 new HTTP-level admin route tests; 492 total tests ✅ (TASK-011)</li>
+</ul>
+
+<h2>In v1.6 (merged to main — see v1.6-dev above)</h2>
 <ul>
 <li>No-direct-push-to-main rule enforced in PM and Engineer AI agents ✅</li>
 <li>CLAUDE.md + README synced to CS-1 architecture reality (TASK-010) ✅</li>
@@ -1835,7 +1927,7 @@ SENTIMENT_ANALYSIS_WINDOW_MINUTES=120</code></pre>
 
   TEST_SUITE: `<div class="md-body">
 <h1>Test Suite</h1>
-<p>DevTrack ships a comprehensive test suite covering the Go daemon, the Python backend, and the HTTP trigger layer. As of <strong>v1.5-dev</strong>, the suite contains <strong>433 tests</strong> (396 Python + 37 Go) spread across Go and Python, with full coverage of HTTP trigger validation, admin authentication, user management, license enforcement, Jira alerter polling, and server_tui helper modules.</p>
+<p>DevTrack ships a comprehensive test suite covering the Go daemon, the Python backend, and the HTTP trigger layer. As of <strong>v1.7-dev</strong>, the suite contains <strong>492 tests</strong> (455 Python + 37 Go) spread across Go and Python, with full coverage of HTTP trigger validation, admin authentication, user management, admin routes, license enforcement, Jira alerter polling, and server_tui helper modules.</p>
 
 <h2>Running the Tests</h2>
 <h3>Go tests</h3>
@@ -1854,6 +1946,7 @@ uv run pytest backend/tests/
 uv run pytest backend/tests/test_http_triggers.py
 uv run pytest backend/tests/test_admin_auth.py
 uv run pytest backend/tests/test_admin_user_manager.py
+uv run pytest backend/tests/test_admin_routes.py
 uv run pytest backend/tests/test_license_manager.py
 uv run pytest backend/tests/test_jira_alerter.py
 uv run pytest backend/tests/test_server_tui.py
@@ -1872,6 +1965,7 @@ uv run pytest backend/tests/ -k test_name</code></pre>
 <tr><td><code>backend/tests/test_license_manager.py</code></td><td>Python</td><td>License tier detection, T&amp;C acceptance recording and re-prompt logic, offline vs SaaS mode enforcement, <code>DEVTRACK_AUTO_ACCEPT_TERMS</code> flag behaviour</td></tr>
 <tr><td><code>backend/tests/test_jira_alerter.py</code></td><td>Python</td><td>26 tests for <code>JiraAlerter</code> — assigned polling, comment detection, status-change events, deduplication, and all edge cases. No real network calls — all <code>JiraClient</code> methods are mocked.</td></tr>
 <tr><td><code>backend/tests/test_server_tui.py</code></td><td>Python</td><td>37 headless tests for server_tui helpers — <code>ProcessMonitor</code> (process discovery, CPU/MEM sampling, start/stop), <code>log_viewer</code> (tail, rotation, missing file), <code>stats_client</code> (SQLite reads, graceful degradation when DB absent), <code>health_client</code> (HTTP health probes, timeout handling). All fixtures use POSIX <code>tmp_path</code>; no macOS-specific dependencies — runs on Linux CI.</td></tr>
+<tr><td><code>backend/tests/test_admin_routes.py</code></td><td>Python</td><td>31 HTTP-level tests for admin console routes — user role update, soft disable/enable, password reset, license status page, trigger stats HTMX panel (<code>GET /admin/stats-panel</code>), and auth guards on all new endpoints. Uses <code>TestClient</code>-wrapped FastAPI app; no route handler mocking.</td></tr>
 </tbody>
 </table></div>
 
@@ -2301,7 +2395,7 @@ function renderHome() {
   const content = document.getElementById('content');
   content.innerHTML = `
     <div class="home-hero">
-      <div class="home-badge">Local-First · v1.6-dev</div>
+      <div class="home-badge">Local-First · v1.7-dev</div>
       <h1 class="home-title">Developer automation<br>that handles the <span>overhead</span>.</h1>
       <p class="home-sub">DevTrack monitors your Git activity, prompts for work updates, routes them through AI, and keeps your project management systems in sync — all running locally on your machine.</p>
     </div>
@@ -2309,7 +2403,7 @@ function renderHome() {
     <div class="home-grid">
       ${[
         // ── Get Started ────────────────────────────────────────────────────────
-        { id:'WHATS_NEW',        icon:'🎉', title:"What's New",         desc:'v1.6-dev: no-direct-push-to-main enforced in AI agents; CLAUDE.md + README synced to CS-1 reality (TASK-010); env-first startup docs corrected. v1.5-dev (merged to main): config refactor — all os.getenv violations eliminated; trigger throughput stats panel; 433 tests. v1.4-dev: webhook+trigger server, Jira alerter, env-first config, autostart env-baking.' },
+        { id:'WHATS_NEW',        icon:'🎉', title:"What's New",         desc:'v1.7-dev: CS-3 Admin GUI MVP — user role update, soft disable/enable, license status page, trigger stats HTMX panel (30s auto-refresh), password reset, ADMIN_EMBED single-process mode, 31 new HTTP-level admin route tests (492 total). v1.6-dev (merged): no-direct-push-to-main in AI agents; CLAUDE.md + README synced to CS-1 reality. v1.5-dev: config refactor; 433 tests.' },
         { id:'GETTING_STARTED',  icon:'🚀', title:'Getting Started',    desc:'New to DevTrack? Start here — concepts, setup, and first run.' },
         { id:'QUICK_START',      icon:'⚡', title:'Quick Start',        desc:'Get running in 5 minutes with the minimal setup guide.' },
         // ── Reference ─────────────────────────────────────────────────────────
@@ -2336,7 +2430,7 @@ function renderHome() {
         // ── System Integration ────────────────────────────────────────────────
         { id:'AUTOSTART',       icon:'🔌', title:'Auto-Start',          desc:'Auto-start DevTrack at login — OS-aware. Run <code>devtrack autostart-install</code>: launchd LaunchAgent on macOS, systemd user service on Linux/WSL, or a shell profile block on WSL without systemd. <strong>v1.4-dev:</strong> all env vars are now baked into the plist/unit at install time — no separate <code>.env</code> file needed at runtime.' },
         { id:'SERVER_TUI',      icon:'🖥️', title:'Server TUI',          desc:'Textual process monitor for the Python backend. Shows all server processes with live CPU/MEM/status, a health bar, and a trigger throughput stats panel (triggers today, commits today, errors in last 24 h). Navigate with ↑↓, restart with r, toggle logs with l.' },
-        { id:'ADMIN_CONSOLE',   icon:'🛡️', title:'Admin Console',       desc:'Web UI at <code>http://localhost:8090/admin/</code> — manage users, API keys, review server health, LLM config, integration credentials, and a full audit log. Run with <code>devtrack admin-start</code>.' },
+        { id:'ADMIN_CONSOLE',   icon:'🛡️', title:'Admin Console',       desc:'Web UI at <code>http://localhost:8090/admin/</code> — manage users, roles, API keys; soft disable/enable users; reset passwords; license status page; HTMX trigger stats panel (30s auto-refresh); LLM config, integration credentials, and a full audit log. Run with <code>devtrack admin-start</code> or set <code>ADMIN_EMBED=true</code> to co-host on port 8089.' },
         { id:'TELEMETRY',       icon:'📊', title:'Telemetry',           desc:'Optional usage tracking: download counts, command frequencies, version adoption. Fully transparent, no PII. Designed for a real-time admin dashboard via Server-Sent Events. See the plan in <code>docs/TELEMETRY_PLAN.md</code>.' },
         { id:'CLOUD_MODE',      icon:'☁️', title:'Cloud Mode',          desc:'Connect your local daemon to a remote managed backend. <code>devtrack cloud login --url URL --key KEY</code> saves credentials to <code>~/.devtrack/cloud.json</code>. Bypasses cert-pinning for CA-signed remote certs.' },
         { id:'TUI_DASHBOARD',   icon:'📟', title:'TUI Dashboard',       desc:'Bubble Tea full-screen dashboard. 4 tabs: Overview (uptime, latency, counts), Activity (last 30 triggers), Workspaces (all repos + PM platform), Alerts (last 30 notifications). Tab/1–4 to switch, <code>r</code> refresh, <code>q</code> quit.' },


### PR DESCRIPTION
- wiki: bump to v1.7-dev, add WHATS_NEW section for TASK-011–015, expand ADMIN_CONSOLE page, update test count to 492
- README: add Admin Console section with ADMIN_EMBED mode, update test counts
- memory: add project_cs3_admin_gui.md with full task/route/test inventory