### PR TITLE
fix(admin): eliminate hardcoded scrypt params and session cookie max_age (TASK-016)

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -526,6 +526,14 @@ Session lifetime in hours (default: 8)
 
 ADMIN_SESSION_HOURS=8
 
+# Scrypt password-hashing parameters (used when hashing/verifying admin passwords).
+# n: CPU/memory cost factor — must be a power of 2 (e.g. 16384, 32768).
+# r: block size. p: parallelisation factor. dklen: derived key length in bytes.
+SCRYPT_N=16384
+SCRYPT_R=8
+SCRYPT_P=1
+SCRYPT_DKLEN=32
+
 # ── Telemetry ─────────────────────────────────────────────────────────────────
 # Anonymous install/active ping endpoint. Set to empty string to disable pings
 # without running `devtrack telemetry off`. Default: https://ping.devtrack.dev

--- a/backend/admin/auth.py
+++ b/backend/admin/auth.py
@@ -36,10 +36,22 @@ def _secret_key() -> str:
     return key
 
 
+from backend.config import (
+    get_scrypt_n,
+    get_scrypt_r,
+    get_scrypt_p,
+    get_scrypt_dklen,
+)
+
 _SECRET = _secret_key()
 _ALGORITHM = "HS256"
 _SESSION_HOURS = int(_cfg("ADMIN_SESSION_HOURS", "8"))
 COOKIE_NAME = "devtrack_admin_session"
+
+_SCRYPT_N    = get_scrypt_n()
+_SCRYPT_R    = get_scrypt_r()
+_SCRYPT_P    = get_scrypt_p()
+_SCRYPT_DKLEN = get_scrypt_dklen()
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +61,8 @@ COOKIE_NAME = "devtrack_admin_session"
 def hash_password(plain: str) -> str:
     """Hash password with scrypt (stdlib, no external deps)."""
     salt = secrets.token_hex(16)
-    key = hashlib.scrypt(plain.encode(), salt=salt.encode(), n=16384, r=8, p=1, dklen=32)
+    key = hashlib.scrypt(plain.encode(), salt=salt.encode(),
+                         n=_SCRYPT_N, r=_SCRYPT_R, p=_SCRYPT_P, dklen=_SCRYPT_DKLEN)
     return f"scrypt${salt}${key.hex()}"
 
 
@@ -57,7 +70,8 @@ def verify_password(plain: str, hashed: str) -> bool:
     try:
         if hashed.startswith("scrypt$"):
             _, salt, stored_hex = hashed.split("$", 2)
-            key = hashlib.scrypt(plain.encode(), salt=salt.encode(), n=16384, r=8, p=1, dklen=32)
+            key = hashlib.scrypt(plain.encode(), salt=salt.encode(),
+                                 n=_SCRYPT_N, r=_SCRYPT_R, p=_SCRYPT_P, dklen=_SCRYPT_DKLEN)
             return hmac.compare_digest(key.hex(), stored_hex)
         # Legacy plain-text check (migration path)
         return hmac.compare_digest(plain, hashed)

--- a/backend/admin/routes.py
+++ b/backend/admin/routes.py
@@ -61,6 +61,9 @@ def startup() -> None:
         ensure_default_admin(admin_user, admin_pass)
 
 
+from backend.config import get_admin_session_hours as _get_admin_session_hours
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -105,7 +108,8 @@ async def login(
     log_action(username, "login", ip=request.client.host if request.client else "")
     token = create_token(username)
     resp = RedirectResponse("/admin/", status_code=303)
-    resp.set_cookie(COOKIE_NAME, token, httponly=True, samesite="lax", max_age=8 * 3600)
+    resp.set_cookie(COOKIE_NAME, token, httponly=True, samesite="lax",
+                    max_age=_get_admin_session_hours() * 3600)
     return resp
 
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -1010,6 +1010,76 @@ def get_admin_embed() -> bool:
     return get_bool("ADMIN_EMBED", False)
 
 
+def get_admin_session_hours() -> int:
+    """Admin console session lifetime in hours. REQUIRED: ADMIN_SESSION_HOURS."""
+    val = get("ADMIN_SESSION_HOURS")
+    if not val:
+        raise ValueError("ADMIN_SESSION_HOURS environment variable required (e.g., 8)")
+    try:
+        hours = int(val)
+        if hours <= 0:
+            raise ValueError(f"ADMIN_SESSION_HOURS must be > 0, got {hours}")
+        return hours
+    except ValueError as e:
+        raise ValueError(f"ADMIN_SESSION_HOURS must be a positive integer: {e}")
+
+
+def get_scrypt_n() -> int:
+    """Scrypt CPU/memory cost factor. REQUIRED: SCRYPT_N (must be a power of 2, >= 2)."""
+    val = get("SCRYPT_N")
+    if not val:
+        raise ValueError("SCRYPT_N environment variable required (e.g., 16384)")
+    try:
+        n = int(val)
+    except ValueError:
+        raise ValueError(f"SCRYPT_N must be an integer, got: {val!r}")
+    if n < 2 or (n & (n - 1)) != 0:
+        raise ValueError(f"SCRYPT_N must be a power of 2 and >= 2, got {n}")
+    return n
+
+
+def get_scrypt_r() -> int:
+    """Scrypt block size. REQUIRED: SCRYPT_R (must be > 0)."""
+    val = get("SCRYPT_R")
+    if not val:
+        raise ValueError("SCRYPT_R environment variable required (e.g., 8)")
+    try:
+        r = int(val)
+        if r <= 0:
+            raise ValueError(f"SCRYPT_R must be > 0, got {r}")
+        return r
+    except ValueError as e:
+        raise ValueError(f"SCRYPT_R must be a positive integer: {e}")
+
+
+def get_scrypt_p() -> int:
+    """Scrypt parallelisation factor. REQUIRED: SCRYPT_P (must be > 0)."""
+    val = get("SCRYPT_P")
+    if not val:
+        raise ValueError("SCRYPT_P environment variable required (e.g., 1)")
+    try:
+        p = int(val)
+        if p <= 0:
+            raise ValueError(f"SCRYPT_P must be > 0, got {p}")
+        return p
+    except ValueError as e:
+        raise ValueError(f"SCRYPT_P must be a positive integer: {e}")
+
+
+def get_scrypt_dklen() -> int:
+    """Scrypt derived key length in bytes. REQUIRED: SCRYPT_DKLEN (must be > 0)."""
+    val = get("SCRYPT_DKLEN")
+    if not val:
+        raise ValueError("SCRYPT_DKLEN environment variable required (e.g., 32)")
+    try:
+        dklen = int(val)
+        if dklen <= 0:
+            raise ValueError(f"SCRYPT_DKLEN must be > 0, got {dklen}")
+        return dklen
+    except ValueError as e:
+        raise ValueError(f"SCRYPT_DKLEN must be a positive integer: {e}")
+
+
 # --- GitHub (call-site use) ---
 
 def get_github_token() -> str:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,7 @@
 """
 Pytest configuration and fixtures for DevTrack backend tests.
 """
+import os
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -11,6 +12,15 @@ import pytest
 project_root = Path(__file__).resolve().parent.parent.parent
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
+
+# Set required scrypt env vars before any auth module is imported.
+# These match the production defaults and must be present at import time
+# because backend/admin/auth.py reads them into module-level constants.
+os.environ.setdefault("SCRYPT_N", "16384")
+os.environ.setdefault("SCRYPT_R", "8")
+os.environ.setdefault("SCRYPT_P", "1")
+os.environ.setdefault("SCRYPT_DKLEN", "32")
+os.environ.setdefault("ADMIN_SESSION_HOURS", "8")
 
 
 def pytest_configure(config):

--- a/backend/tests/test_admin_auth.py
+++ b/backend/tests/test_admin_auth.py
@@ -140,3 +140,53 @@ class TestCheckCredentials:
         from backend.admin import auth as _auth
         assert _auth.check_credentials("admin", "mypassword") is True
         assert _auth.check_credentials("admin", "wrong") is False
+
+
+# ---------------------------------------------------------------------------
+# Scrypt config accessor validation
+# ---------------------------------------------------------------------------
+
+class TestScryptConfig:
+    def test_get_scrypt_n_raises_when_unset(self, monkeypatch):
+        """get_scrypt_n() must raise ValueError when SCRYPT_N is not set."""
+        monkeypatch.delenv("SCRYPT_N", raising=False)
+        # Force re-import of config to avoid cached module state
+        import importlib
+        import backend.config as cfg
+        importlib.reload(cfg)
+        with pytest.raises(ValueError, match="SCRYPT_N"):
+            cfg.get_scrypt_n()
+
+    def test_get_scrypt_n_raises_for_non_power_of_two(self, monkeypatch):
+        """get_scrypt_n() must raise ValueError when SCRYPT_N is not a power of 2."""
+        monkeypatch.setenv("SCRYPT_N", "100")
+        import importlib
+        import backend.config as cfg
+        importlib.reload(cfg)
+        with pytest.raises(ValueError, match="power of 2"):
+            cfg.get_scrypt_n()
+
+    def test_get_scrypt_n_accepts_valid_power_of_two(self, monkeypatch):
+        """get_scrypt_n() returns the integer when SCRYPT_N is a valid power of 2."""
+        monkeypatch.setenv("SCRYPT_N", "16384")
+        import importlib
+        import backend.config as cfg
+        importlib.reload(cfg)
+        assert cfg.get_scrypt_n() == 16384
+
+    def test_get_admin_session_hours_raises_when_unset(self, monkeypatch):
+        """get_admin_session_hours() must raise ValueError when ADMIN_SESSION_HOURS is not set."""
+        monkeypatch.delenv("ADMIN_SESSION_HOURS", raising=False)
+        import importlib
+        import backend.config as cfg
+        importlib.reload(cfg)
+        with pytest.raises(ValueError, match="ADMIN_SESSION_HOURS"):
+            cfg.get_admin_session_hours()
+
+    def test_get_admin_session_hours_returns_value(self, monkeypatch):
+        """get_admin_session_hours() returns the configured integer."""
+        monkeypatch.setenv("ADMIN_SESSION_HOURS", "12")
+        import importlib
+        import backend.config as cfg
+        importlib.reload(cfg)
+        assert cfg.get_admin_session_hours() == 12


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `n=16384, r=8, p=1, dklen=32` scrypt literals in `auth.py` (`hash_password` and `verify_password`) with module-level constants sourced from four new typed config accessors: `get_scrypt_n/r/p/dklen()`
- Replaces `max_age=8 * 3600` in the login route with `get_admin_session_hours() * 3600`
- Adds `SCRYPT_N`, `SCRYPT_R`, `SCRYPT_P`, `SCRYPT_DKLEN` to `.env_sample` with comments
- `get_scrypt_n()` validates that the value is a power of 2 and >= 2; all others validate > 0
- Adds 5 new tests in `TestScryptConfig`; suite is 497 passed (was 492)

## Test plan

- [ ] `uv run pytest backend/tests/test_admin_auth.py -v` — 24/24 pass
- [ ] `uv run pytest backend/tests/ -q` — 497 passed, 1 pre-existing failure unchanged
- [ ] `grep -n "n=16384\|r=8, p=1\|dklen=32\|8 \* 3600" backend/admin/auth.py backend/admin/routes.py` returns no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)