### PR TITLE
refactor(config): remove dead GetPythonBridgePath function (TASK-026)

### DIFF
--- a/devtrack-bin/config_env.go
+++ b/devtrack-bin/config_env.go
@@ -238,23 +238,6 @@ func GetIPCAddress() string {
 	return config.IPCHost + ":" + config.IPCPort
 }
 
-// GetPythonBridgePath returns the path to python_bridge.py.
-// Returns an error instead of calling os.Exit so Lightweight mode callers can
-// handle the missing file gracefully.
-func GetPythonBridgePath() (string, error) {
-	config, err := LoadEnvConfig()
-	if err != nil {
-		return "", fmt.Errorf("config load failed: %w", err)
-	}
-
-	path := filepath.Join(config.ProjectRoot, config.PythonBridgeScript)
-	if !fileExists(path) {
-		return "", fmt.Errorf("Python bridge script not found at %s", path)
-	}
-
-	return path, nil
-}
-
 // GetEmailReporterPath returns the path to backend/email_reporter.py.
 // Returns an error instead of calling os.Exit so Lightweight mode callers can
 // handle the missing backend gracefully.


### PR DESCRIPTION
## Summary
- Removes the unused `GetPythonBridgePath()` function from `devtrack-bin/config_env.go`
- No callers exist after the TASK-024 refactor (verified with grep before deletion)
- `go build ./...`, `go vet ./...`, `go test ./...` all pass

## Test plan
- [x] `grep -rn "GetPythonBridgePath" devtrack-bin/` returns no matches
- [x] `go build ./...` passes (clean)
- [x] `go vet ./...` passes (clean)
- [x] `go test ./...` passes (cached ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)