### PR TITLE
fix(lint): modernize range loop, drop unused params, use max() builtin

### DIFF
--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -45,6 +45,42 @@ All other work subcommands (start/stop/adjust/status) are pure Go/SQLite and rem
 
 ---
 
+### [2026-05-01 12:00] Lint cleanup — fix(lint): modernize range loop, drop unused params, use max() builtin
+
+**Branch**: fix/lint-cleanup (based off origin/dev)
+**Original message**: "fix(lint): modernize range loop, drop unused params, use max() builtin"
+**DevTrack enhanced it to**: N/A — daemon cannot start without .env; used raw git per fallback protocol
+**Ticket auto-linked**: NO
+**PM system updated**: YES — engineer_log.md updated; PR #88 posted
+**Time**: ~10 minutes
+**Friction**: LOW — all changes are purely mechanical style modernization
+
+**Changes made**:
+- `cli_work.go` line ~119: replaced 3-line if/else negative clamp with `max(durationMins, 0)` builtin (Go 1.21+)
+- `setup.go`: removed unused `envPath string` param from `printAutostartInstructions()` and `printSetupComplete()`; updated both call sites (lines ~319 and ~326)
+- `setup.go`: replaced `for i := 0; i < 6; i++` with `for range 6` in `detectProjectRoot()` (line ~343)
+
+**Results**:
+- `go build ./...` — PASS
+- `go vet ./...` — PASS
+- PR: https://github.com/sraj0501/Devtrack_/pull/88 (targeting dev)
+
+**Notes**: devtrack daemon not runnable in this environment (no .env file present). Used `GIT_NO_DEVTRACK=1 git commit` per fallback protocol. Local `dev` branch had diverged from `origin/dev` (194 commits behind); created branch directly from `origin/dev` to avoid conflict cascade.
+
+[DEVTRACK PAUSED — using raw git for this commit; daemon cannot start without .env]
+
+## Task Summary — Lint cleanup: modernize range loop, drop unused params, use max() — 2026-05-01
+
+- Total commits: 1 (5512149)
+- Files changed: 2 (cli_work.go, setup.go)
+- Tickets auto-updated: 0 (devtrack daemon not running)
+- Estimated daily time saved: ~0 min (style-only; no behaviour change)
+- Blockers encountered: local dev branch diverged — resolved by branching from origin/dev directly
+- One thing that still feels rough: "devtrack daemon still not runnable locally without a fully populated .env; every commit falls back to raw git."
+- Ready for PM review: YES
+
+---
+
 ### [2026-04-30] TASK-025 — fix(build): Windows native build support via platform-split syscall files
 
 **Branch**: fix/TASK-025-windows-native-build

--- a/devtrack-bin/cli_work.go
+++ b/devtrack-bin/cli_work.go
@@ -116,9 +116,7 @@ func (cli *CLI) handleWorkStop() error {
 		}
 	}
 	durationMins := int(time.Since(startTime).Minutes())
-	if durationMins < 0 {
-		durationMins = 0
-	}
+	durationMins = max(durationMins, 0)
 
 	endedAt := time.Now().UTC().Format("2006-01-02 15:04:05")
 	if err := db.EndWorkSession(active.ID, endedAt, durationMins); err != nil {

--- a/devtrack-bin/setup.go
+++ b/devtrack-bin/setup.go
@@ -316,14 +316,14 @@ func RunSetup() error {
 	fmt.Print("Set up autostart now? [Y/n]: ")
 	autostartAnswer := readLine(reader)
 	if autostartAnswer == "" || strings.ToLower(autostartAnswer) == "y" {
-		printAutostartInstructions(projectRoot, envPath)
+		printAutostartInstructions()
 	}
 
 	// ── Done ──────────────────────────────────────────────────────────────────
 	// Record all current migrations as applied — setup already did everything they do.
 	MarkAllMigrationsApplied()
 
-	printSetupComplete(projectRoot, envPath, cfg.Mode)
+	printSetupComplete(projectRoot, cfg.Mode)
 	return nil
 }
 
@@ -340,7 +340,7 @@ func detectProjectRoot() (string, error) {
 	if err == nil {
 		execPath, _ = filepath.Abs(execPath)
 		searchDir := filepath.Dir(execPath)
-		for i := 0; i < 6; i++ {
+		for range 6 {
 			if _, err := os.Stat(filepath.Join(searchDir, "backend")); err == nil {
 				return searchDir, nil
 			}
@@ -882,7 +882,7 @@ func devtrackDataHome() (string, error) {
 }
 
 // printAutostartInstructions shows the autostart command.
-func printAutostartInstructions(projectRoot, envPath string) {
+func printAutostartInstructions() {
 	fmt.Println()
 	fmt.Println("Run the following to install autostart:")
 	fmt.Println()
@@ -906,7 +906,7 @@ func printSetupHeader() {
 }
 
 // printSetupComplete prints the completion summary.
-func printSetupComplete(projectRoot, envPath string, mode DevTrackMode) {
+func printSetupComplete(projectRoot string, mode DevTrackMode) {
 	fmt.Println()
 	fmt.Println("╔══════════════════════════════════════════════════════════════════╗")
 	fmt.Println("║  Setup complete!                                                ║")


### PR DESCRIPTION
## Summary

- `cli_work.go`: Replace 3-line if/else clamp with `max(durationMins, 0)` builtin (Go 1.21+)
- `setup.go`: Remove unused `projectRoot` and `envPath` parameters from `printAutostartInstructions()` and `envPath` from `printSetupComplete()`; update both call sites
- `setup.go`: Replace C-style `for i := 0; i < 6; i++` with idiomatic `for range 6`

All changes are pure lint/style modernization — no behaviour change.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Reviewer: confirm no callers of `printAutostartInstructions` or `printSetupComplete` outside `setup.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)