### PR TITLE
feat: health monitor improvements + CI Dockerfile.server fix

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -109,6 +109,7 @@ jobs:
           # Workspace templates only — never ship the live workspaces.yaml
           cp workspaces.yaml.example "dist/${ARCHIVE_DIR}/"
           cp workspaces.yaml.sample  "dist/${ARCHIVE_DIR}/"
+          cp Dockerfile.server        "dist/${ARCHIVE_DIR}/"
 
           # Management CLI and version stamp
           cp devtrack-server          "dist/${ARCHIVE_DIR}/"
@@ -167,6 +168,7 @@ jobs:
           [ -f uv.lock ]     && cp uv.lock     "$SERVER_TMP/"
           [ -f .env_sample ] && cp .env_sample "$SERVER_TMP/"
           cp workspaces.yaml.example workspaces.yaml.sample "$SERVER_TMP/"
+          cp Dockerfile.server                             "$SERVER_TMP/"
           # Ship the GitLab CI config as .gitlab-ci.yml
           cp ci/devtrack_server.gitlab-ci.yml "$SERVER_TMP/.gitlab-ci.yml"
           echo "${VER}" > "$SERVER_TMP/VERSION"


### PR DESCRIPTION
## Summary

- **Ollama health check fix**: `OLLAMA_HOST` is Ollama's bind-address env var (often `0.0.0.0` or `0.0.0.0:11434`), not a client URL. Added `normalizeOllamaHost()` to canonicalize it to `http://localhost:<port>` for outbound dials.
- **Concurrent health checks**: `RunAllChecks()` now runs all 8 checks in parallel via `sync.WaitGroup`, with `dbMu` serializing SQLite writes to avoid `SQLITE_BUSY`.
- **New monitors**: Redis (TCP dial against `REDIS_URL`) and SQLite (`os.Stat` on DB path) added to the health check suite.
- **Richer status output**: `formatHealthDetail()` now parses the JSON `Details` blob to surface `url` and `error` fields inline (e.g. `Down — http://0.0.0.0 (dial error)`).
- **CI fix**: `bump-version.yml` server sync and release archive were both missing `Dockerfile.server`, causing the GitLab docker build job to fail on every release tag.

## Test plan

- [ ] `devtrack status` shows Ollama as `up` when `OLLAMA_HOST=http://0.0.0.0:11434` and Ollama is running
- [ ] `devtrack status` shows Redis / SQLite health
- [ ] Trigger a release and confirm `devtrack_server` docker job passes on GitLab