### PR TITLE
release: v2.2.11 — health monitor improvements + CI fixes

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -109,6 +109,7 @@ jobs:
           # Workspace templates only — never ship the live workspaces.yaml
           cp workspaces.yaml.example "dist/${ARCHIVE_DIR}/"
           cp workspaces.yaml.sample  "dist/${ARCHIVE_DIR}/"
+          cp Dockerfile.server        "dist/${ARCHIVE_DIR}/"
 
           # Management CLI and version stamp
           cp devtrack-server          "dist/${ARCHIVE_DIR}/"
@@ -167,6 +168,7 @@ jobs:
           [ -f uv.lock ]     && cp uv.lock     "$SERVER_TMP/"
           [ -f .env_sample ] && cp .env_sample "$SERVER_TMP/"
           cp workspaces.yaml.example workspaces.yaml.sample "$SERVER_TMP/"
+          cp Dockerfile.server                             "$SERVER_TMP/"
           # Ship the GitLab CI config as .gitlab-ci.yml
           cp ci/devtrack_server.gitlab-ci.yml "$SERVER_TMP/.gitlab-ci.yml"
           echo "${VER}" > "$SERVER_TMP/VERSION"


### PR DESCRIPTION
## Summary

- Ollama health check normalization (`0.0.0.0` → `localhost:11434`)
- Concurrent health checks for all 8 services via `sync.WaitGroup`
- Redis and SQLite monitors added to health check suite
- Richer `devtrack status` output with URL + error inline for down services
- `Dockerfile.server` added to GitLab server sync and GitHub release archive (fixes docker build CI failure on every release tag)

Merging to `main` will trigger `bump-version.yml` to auto-release `v2.2.11` for both client and server.