### PR TITLE
feat(boardroom+plan): PM plan CLI and interactive AI boardroom

### DIFF
--- a/backend/boardroom/__init__.py
+++ b/backend/boardroom/__init__.py
@@ -1,0 +1,6 @@
+"""Boardroom — multi-persona plan review with SWOT synthesis."""
+
+from backend.boardroom.session import BoardroomSession, BoardroomReport
+from backend.boardroom.personas import PERSONAS
+
+__all__ = ["BoardroomSession", "BoardroomReport", "PERSONAS"]

--- a/backend/boardroom/interactive.py
+++ b/backend/boardroom/interactive.py
@@ -1,0 +1,279 @@
+"""
+Interactive boardroom session.
+
+Manages multi-turn conversation between the user and 7 AI personas.
+Each turn:
+  1. A lightweight moderator call selects which persona(s) should respond.
+  2. Selected personas generate in-character replies.
+  3. History is returned to the caller so the Go CLI can persist it between HTTP calls.
+
+This module is stateless — all state (history, plan_text) is passed in and
+returned on every call so the webhook endpoint stays stateless too.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Optional
+
+from backend.boardroom.personas import PERSONAS, Persona
+from backend.llm.base import LLMOptions
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Data types (plain dicts for easy JSON serialisation over HTTP)
+# ---------------------------------------------------------------------------
+
+# History entry shape:
+#   {"role": "user",    "content": "..."}
+#   {"role": "persona", "persona_id": "...", "persona_name": "...", "content": "..."}
+#   {"role": "system",  "content": "..."}   ← used for the initial boardroom summary
+
+HistoryEntry = dict  # typed alias for readability
+
+# ---------------------------------------------------------------------------
+# Persona personality snippets — make each voice distinct
+# ---------------------------------------------------------------------------
+
+_PERSONA_VOICE: dict[str, str] = {
+    "architect": (
+        "You are precise and structured. You draw diagrams in words. "
+        "You ask about component boundaries, data flows, and contract definitions. "
+        "You are collegial but will firmly push back on design choices you consider unsound."
+    ),
+    "security": (
+        "You are measured and methodical. You never catastrophise — "
+        "you quantify risk. You ask about threat models, auth flows, and data classification. "
+        "When you disagree, you cite real breach patterns, not hypotheticals."
+    ),
+    "pm": (
+        "You are user-obsessed and timeline-aware. You think in epics and sprints. "
+        "You push back on scope creep and ask 'what does the user actually need?' "
+        "You're optimistic but realistic about delivery."
+    ),
+    "devil": (
+        "You are intellectually playful and deliberately provocative. "
+        "You enjoy puncturing assumptions. You ask uncomfortable 'what if' questions. "
+        "You don't enjoy being wrong but you admit it gracefully when you are."
+    ),
+    "engineer": (
+        "You are practical and implementation-focused. You think in sprint points and "
+        "test coverage. You appreciate elegant solutions and hate tech debt. "
+        "You'll call out unrealistic timelines directly."
+    ),
+    "analyst": (
+        "You think in numbers, ROI, and business outcomes. You like KPIs and metrics. "
+        "You translate technical decisions into business risk and opportunity. "
+        "You're not afraid to say a feature isn't worth the cost."
+    ),
+    "scalability": (
+        "You've seen applications fail at 10x load. You are calm and evidence-driven. "
+        "You probe for single points of failure, connection pool limits, and cache stampedes. "
+        "You celebrate when a design is truly stateless. You are wary of premature optimisation "
+        "but merciless about ignoring known scaling failure modes."
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Moderator: select which personas respond
+# ---------------------------------------------------------------------------
+
+_SELECT_PROMPT = """\
+You are a boardroom moderator. A user is discussing a software plan with {n} expert personas.
+
+Personas available:
+{persona_list}
+
+The conversation so far (last {tail} turns):
+{history_snippet}
+
+User's latest message: "{user_message}"
+Addressed to: {addressed_to}
+
+Select 1–3 personas who should respond. Prioritise:
+- The persona most directly addressed (if any)
+- Personas whose domain is most relevant to the message
+- A persona who would naturally disagree or add tension to the discussion
+
+Respond ONLY with JSON: {{"responders": ["id1", "id2"]}}
+No prose, no fences.
+"""
+
+
+def select_responders(
+    provider,
+    history: list[HistoryEntry],
+    user_message: str,
+    addressed_to: Optional[str],
+) -> list[str]:
+    """Return a list of persona IDs that should respond to this message."""
+
+    persona_list = "\n".join(
+        f"  - {p.id}: {p.name} ({p.role})" for p in PERSONAS
+    )
+    history_snippet = _format_history_snippet(history, tail=6)
+
+    prompt = _SELECT_PROMPT.format(
+        n=len(PERSONAS),
+        persona_list=persona_list,
+        tail=6,
+        history_snippet=history_snippet,
+        user_message=user_message,
+        addressed_to=addressed_to or "nobody specific (open question to the group)",
+    )
+
+    opts = LLMOptions(temperature=0.2, max_tokens=60)
+    raw = provider.generate(prompt, opts, timeout=20) or ""
+
+    data = _parse_json(raw)
+    responders = data.get("responders", [])
+
+    # Validate: only known persona IDs, cap at 3
+    valid_ids = {p.id for p in PERSONAS}
+    responders = [r for r in responders if r in valid_ids][:3]
+
+    # Fall back to the addressed persona or the first two
+    if not responders:
+        if addressed_to and addressed_to in valid_ids:
+            responders = [addressed_to]
+        else:
+            responders = [PERSONAS[0].id, PERSONAS[3].id]
+
+    return responders
+
+
+# ---------------------------------------------------------------------------
+# Persona response generation
+# ---------------------------------------------------------------------------
+
+_PERSONA_REPLY_PROMPT = """\
+You are {name}, a {role} in an active boardroom discussion about a software plan.
+
+Your personality: {voice}
+
+Context — the plan being discussed:
+{plan_text}
+
+Conversation history:
+{history}
+
+The user just said: "{user_message}"
+
+Respond as {first_name} — in first person, conversational, 2–4 sentences max.
+Be direct. Show your personality. You can disagree, ask a question, or build on
+what another persona said. Do NOT use bullet points or headers — this is a conversation.
+Do NOT introduce yourself or explain your role — just speak.
+"""
+
+
+def generate_persona_response(
+    provider,
+    persona: Persona,
+    history: list[HistoryEntry],
+    user_message: str,
+    plan_text: str,
+) -> str:
+    """Generate one persona's in-character response."""
+    opts = LLMOptions(temperature=persona.temperature + 0.1, max_tokens=200)
+    first_name = persona.name.split()[0]
+    prompt = _PERSONA_REPLY_PROMPT.format(
+        name=persona.name,
+        role=persona.role,
+        voice=_PERSONA_VOICE.get(persona.id, ""),
+        plan_text=plan_text[:800],
+        history=_format_history_snippet(history, tail=10),
+        user_message=user_message,
+        first_name=first_name,
+    )
+    raw = provider.generate(prompt, opts, timeout=40) or ""
+    return raw.strip()
+
+
+# ---------------------------------------------------------------------------
+# Final synthesis after user gives their verdict
+# ---------------------------------------------------------------------------
+
+_FINAL_PROMPT = """\
+You are the boardroom moderator writing up the final minutes.
+
+The group has just completed an active discussion of a software plan.
+The project owner has given their final decision.
+
+Original plan:
+{plan_text}
+
+Full discussion:
+{history}
+
+Project owner's final say: "{final_say}"
+
+Write a concise closing summary (3–5 sentences) that:
+1. Acknowledges the owner's decision
+2. Captures the key points of consensus and disagreement from the discussion
+3. Lists 2–3 concrete next steps the team agreed on (or that follow logically)
+
+Write in a professional but human tone — this is meeting minutes, not a report.
+"""
+
+
+def generate_final_summary(
+    provider,
+    plan_text: str,
+    history: list[HistoryEntry],
+    final_say: str,
+) -> str:
+    """Generate a closing summary after the user gives their final say."""
+    opts = LLMOptions(temperature=0.3, max_tokens=400)
+    prompt = _FINAL_PROMPT.format(
+        plan_text=plan_text[:800],
+        history=_format_history_full(history),
+        final_say=final_say,
+    )
+    raw = provider.generate(prompt, opts, timeout=60) or ""
+    return raw.strip()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _format_history_snippet(history: list[HistoryEntry], tail: int = 6) -> str:
+    recent = history[-tail:] if len(history) > tail else history
+    lines = []
+    for entry in recent:
+        role = entry.get("role", "")
+        content = entry.get("content", "")
+        if role == "user":
+            lines.append(f"User: {content}")
+        elif role == "persona":
+            lines.append(f"{entry.get('persona_name', 'Persona')}: {content}")
+        elif role == "system":
+            lines.append(f"[Session context: {content[:100]}...]")
+    return "\n".join(lines) if lines else "(no prior conversation)"
+
+
+def _format_history_full(history: list[HistoryEntry]) -> str:
+    lines = []
+    for entry in history:
+        role = entry.get("role", "")
+        content = entry.get("content", "")
+        if role == "user":
+            lines.append(f"User: {content}")
+        elif role == "persona":
+            lines.append(f"{entry.get('persona_name', 'Persona')}: {content}")
+    return "\n".join(lines) if lines else "(no conversation)"
+
+
+def _parse_json(raw: str) -> dict:
+    text = re.sub(r"^```(?:json)?\s*", "", raw.strip())
+    text = re.sub(r"\s*```$", "", text).strip()
+    start, end = text.find("{"), text.rfind("}")
+    if start != -1 and end > start:
+        text = text[start:end + 1]
+    try:
+        return json.loads(text)
+    except Exception:
+        return {}

--- a/backend/boardroom/personas.py
+++ b/backend/boardroom/personas.py
@@ -1,0 +1,154 @@
+"""
+Boardroom persona definitions.
+
+Each persona has a distinct analytical lens. They run in parallel and their
+outputs are fed to the Moderator for SWOT synthesis.
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Persona:
+    id: str
+    name: str
+    role: str
+    focus: str          # what this persona scrutinises most
+    temperature: float  # higher = more opinionated
+
+
+PERSONAS: list[Persona] = [
+    Persona(
+        id="architect",
+        name="Alex the Architect",
+        role="Principal Software Architect",
+        focus=(
+            "System design, component boundaries, scalability, maintainability, "
+            "technical dependencies, and architectural trade-offs."
+        ),
+        temperature=0.3,
+    ),
+    Persona(
+        id="security",
+        name="Sam the Security Lead",
+        role="Application Security Engineer",
+        focus=(
+            "Attack surface, authentication/authorisation gaps, data privacy, "
+            "compliance requirements (SOC2, GDPR, HIPAA), and supply-chain risks."
+        ),
+        temperature=0.3,
+    ),
+    Persona(
+        id="pm",
+        name="Priya the Product Manager",
+        role="Senior Product Manager",
+        focus=(
+            "User value, scope creep, timeline realism, success metrics, "
+            "stakeholder alignment, and MVP vs full-build trade-offs."
+        ),
+        temperature=0.4,
+    ),
+    Persona(
+        id="devil",
+        name="Devon the Devil's Advocate",
+        role="Critical Thinker",
+        focus=(
+            "Hidden assumptions, worst-case failure modes, underestimated complexity, "
+            "team capability gaps, and external dependencies that could block delivery."
+        ),
+        temperature=0.5,
+    ),
+    Persona(
+        id="engineer",
+        name="Eva the Lead Engineer",
+        role="Senior Engineering Lead",
+        focus=(
+            "Implementation complexity, realistic effort estimates, technical debt risk, "
+            "testing strategy, deployment concerns, and developer experience."
+        ),
+        temperature=0.35,
+    ),
+    Persona(
+        id="analyst",
+        name="Ben the Business Analyst",
+        role="Business Analyst",
+        focus=(
+            "ROI, total cost of ownership, business alignment, KPIs, "
+            "opportunity cost, and measurable outcomes."
+        ),
+        temperature=0.35,
+    ),
+    Persona(
+        id="scalability",
+        name="Sofia the Scalability Engineer",
+        role="Staff Infrastructure & Scalability Engineer",
+        focus=(
+            "Horizontal and vertical scaling limits, database bottlenecks, stateless vs stateful "
+            "design, caching strategy, queue saturation, thundering-herd problems, "
+            "latency under load, and the cost of scaling — the layer where most applications fail."
+        ),
+        temperature=0.35,
+    ),
+]
+
+
+PERSONA_PROMPT_TEMPLATE = """\
+You are {name}, a {role} reviewing a software development plan.
+
+Your analytical focus: {focus}
+
+Analyze the plan below through your specific lens. Be direct, critical where warranted,
+and constructive. Respond ONLY with valid JSON — no markdown fences, no prose outside the JSON.
+
+Required JSON structure:
+{{
+  "stance": "APPROVE" | "REVISE" | "REJECT",
+  "stance_reason": "<one concise sentence>",
+  "observations": ["<observation 1>", "<observation 2>", "<observation 3>"],
+  "risks": ["<risk 1>", "<risk 2>"],
+  "recommendations": ["<recommendation 1>", "<recommendation 2>"]
+}}
+
+Rules:
+- observations: 3–5 items, specific to your role's focus
+- risks: 1–4 items you personally consider most critical
+- recommendations: 1–3 actionable items
+- All strings: concise (under 20 words each)
+
+=== PLAN ===
+{plan_text}
+=== END PLAN ===
+"""
+
+
+MODERATOR_PROMPT_TEMPLATE = """\
+You are the Boardroom Moderator. {n} expert personas have reviewed a software development plan.
+Your job: synthesize their perspectives into a balanced, actionable report.
+
+Respond ONLY with valid JSON — no markdown fences, no prose outside the JSON.
+
+Required JSON structure:
+{{
+  "pros": ["<pro 1>", "<pro 2>", "<pro 3>"],
+  "cons": ["<con 1>", "<con 2>", "<con 3>"],
+  "swot": {{
+    "strengths":     ["<strength 1>", "<strength 2>"],
+    "weaknesses":    ["<weakness 1>", "<weakness 2>"],
+    "opportunities": ["<opportunity 1>", "<opportunity 2>"],
+    "threats":       ["<threat 1>", "<threat 2>"]
+  }},
+  "implementation_approach": "<2–3 sentences on the recommended way to proceed>",
+  "open_questions": ["<question 1>", "<question 2>", "<question 3>"],
+  "verdict": "PROCEED" | "REVISE" | "RECONSIDER",
+  "verdict_summary": "<2–3 sentences explaining the verdict>"
+}}
+
+=== ORIGINAL PLAN ===
+{plan_text}
+=== END PLAN ===
+
+=== EXPERT ANALYSES ===
+{analyses}
+=== END ANALYSES ===
+"""

--- a/backend/boardroom/report.py
+++ b/backend/boardroom/report.py
@@ -1,0 +1,194 @@
+"""
+Boardroom report formatters — terminal (ANSI) and markdown.
+"""
+
+from __future__ import annotations
+
+from backend.boardroom.session import BoardroomReport, PersonaResult
+
+# Verdict colour codes (terminal)
+_VERDICT_COLOUR = {
+    "PROCEED":    "\033[92m",   # green
+    "REVISE":     "\033[93m",   # yellow
+    "RECONSIDER": "\033[91m",   # red
+}
+_STANCE_COLOUR = {
+    "APPROVE": "\033[92m",
+    "REVISE":  "\033[93m",
+    "REJECT":  "\033[91m",
+}
+_RESET = "\033[0m"
+_BOLD  = "\033[1m"
+
+
+def format_terminal(report: BoardroomReport) -> str:
+    """Return a formatted terminal string (with ANSI colours)."""
+    lines: list[str] = []
+
+    def h1(text: str) -> None:
+        lines.append(f"\n{_BOLD}{'═' * 60}{_RESET}")
+        lines.append(f"{_BOLD}  {text}{_RESET}")
+        lines.append(f"{_BOLD}{'═' * 60}{_RESET}")
+
+    def h2(text: str) -> None:
+        lines.append(f"\n{_BOLD}{text}{_RESET}")
+        lines.append("─" * 50)
+
+    def bullet(items: list[str], prefix: str = "  • ") -> None:
+        for item in items:
+            lines.append(f"{prefix}{item}")
+
+    h1("BOARDROOM REVIEW")
+
+    # ── Persona vote tally ──────────────────────────────────────────────────
+    h2("Votes")
+    approve = _colour("APPROVE", f"APPROVE: {report.approve_count}")
+    revise  = _colour("REVISE",  f"REVISE:  {report.revise_count}")
+    reject  = _colour("REJECT",  f"REJECT:  {report.reject_count}")
+    lines.append(f"  {approve}   {revise}   {reject}")
+
+    # ── Per-persona analysis ────────────────────────────────────────────────
+    h2("Expert Analyses")
+    for r in report.persona_results:
+        stance_str = _colour(r.stance, f"[{r.stance}]")
+        lines.append(f"\n  {_BOLD}{r.persona.name}{_RESET} {stance_str}")
+        lines.append(f"  {r.stance_reason}")
+        if r.observations:
+            lines.append("  Observations:")
+            bullet(r.observations, "    - ")
+        if r.risks:
+            lines.append("  Risks:")
+            bullet(r.risks, "    ⚠ ")
+        if r.recommendations:
+            lines.append("  Recommendations:")
+            bullet(r.recommendations, "    → ")
+        if r.error:
+            lines.append(f"  (parse error: {r.error})")
+
+    # ── PROs / CONs ─────────────────────────────────────────────────────────
+    h2("PROs")
+    bullet(report.pros or ["(none identified)"])
+
+    h2("CONs")
+    bullet(report.cons or ["(none identified)"])
+
+    # ── SWOT ─────────────────────────────────────────────────────────────────
+    h2("SWOT Analysis")
+    s = report.swot
+    for label, items in [
+        ("Strengths",     s.strengths),
+        ("Weaknesses",    s.weaknesses),
+        ("Opportunities", s.opportunities),
+        ("Threats",       s.threats),
+    ]:
+        lines.append(f"  {_BOLD}{label}{_RESET}")
+        bullet(items or ["—"], "    • ")
+
+    # ── Implementation approach ──────────────────────────────────────────────
+    h2("Recommended Implementation Approach")
+    if report.implementation_approach:
+        for para in report.implementation_approach.split("\n"):
+            lines.append(f"  {para}")
+
+    # ── Open questions ───────────────────────────────────────────────────────
+    if report.open_questions:
+        h2("Open Questions / Blockers")
+        bullet(report.open_questions, "  ? ")
+
+    # ── Verdict ──────────────────────────────────────────────────────────────
+    h2("Verdict")
+    verdict_col = _VERDICT_COLOUR.get(report.verdict, "")
+    lines.append(f"  {_BOLD}{verdict_col}{report.verdict}{_RESET}")
+    if report.verdict_summary:
+        lines.append(f"\n  {report.verdict_summary}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_markdown(report: BoardroomReport) -> str:
+    """Return a full markdown report suitable for saving to a file."""
+    lines: list[str] = []
+
+    lines.append("# Boardroom Review\n")
+
+    # Vote tally
+    lines.append("## Votes\n")
+    lines.append(f"| APPROVE | REVISE | REJECT |")
+    lines.append(f"|:-------:|:------:|:------:|")
+    lines.append(f"| {report.approve_count} | {report.revise_count} | {report.reject_count} |\n")
+
+    # Per-persona
+    lines.append("## Expert Analyses\n")
+    for r in report.persona_results:
+        lines.append(f"### {r.persona.name} — `{r.stance}`\n")
+        lines.append(f"*{r.stance_reason}*\n")
+        if r.observations:
+            lines.append("**Observations**")
+            for o in r.observations:
+                lines.append(f"- {o}")
+            lines.append("")
+        if r.risks:
+            lines.append("**Risks**")
+            for risk in r.risks:
+                lines.append(f"- ⚠ {risk}")
+            lines.append("")
+        if r.recommendations:
+            lines.append("**Recommendations**")
+            for rec in r.recommendations:
+                lines.append(f"- → {rec}")
+            lines.append("")
+
+    # PROs / CONs
+    lines.append("## PROs\n")
+    for p in report.pros:
+        lines.append(f"- {p}")
+    lines.append("")
+
+    lines.append("## CONs\n")
+    for c in report.cons:
+        lines.append(f"- {c}")
+    lines.append("")
+
+    # SWOT
+    lines.append("## SWOT Analysis\n")
+    s = report.swot
+    for label, items in [
+        ("Strengths",     s.strengths),
+        ("Weaknesses",    s.weaknesses),
+        ("Opportunities", s.opportunities),
+        ("Threats",       s.threats),
+    ]:
+        lines.append(f"### {label}\n")
+        for item in items:
+            lines.append(f"- {item}")
+        lines.append("")
+
+    # Implementation approach
+    lines.append("## Recommended Implementation Approach\n")
+    lines.append(report.implementation_approach or "_No recommendation generated._")
+    lines.append("")
+
+    # Open questions
+    if report.open_questions:
+        lines.append("## Open Questions / Blockers\n")
+        for q in report.open_questions:
+            lines.append(f"- {q}")
+        lines.append("")
+
+    # Verdict
+    lines.append("## Verdict\n")
+    lines.append(f"**{report.verdict}**\n")
+    lines.append(report.verdict_summary or "")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _colour(key: str, text: str) -> str:
+    col = _STANCE_COLOUR.get(key, "")
+    return f"{col}{text}{_RESET}" if col else text

--- a/backend/boardroom/session.py
+++ b/backend/boardroom/session.py
@@ -1,0 +1,253 @@
+"""
+BoardroomSession — orchestrates parallel persona analysis + moderator synthesis.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+from backend.boardroom.personas import (
+    PERSONAS,
+    Persona,
+    PERSONA_PROMPT_TEMPLATE,
+    MODERATOR_PROMPT_TEMPLATE,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PersonaResult:
+    persona: Persona
+    stance: str                          # APPROVE | REVISE | REJECT
+    stance_reason: str
+    observations: list[str]
+    risks: list[str]
+    recommendations: list[str]
+    raw: str = ""                        # raw LLM output for debugging
+    error: Optional[str] = None         # set if parsing failed
+
+
+@dataclass
+class SwotMatrix:
+    strengths: list[str] = field(default_factory=list)
+    weaknesses: list[str] = field(default_factory=list)
+    opportunities: list[str] = field(default_factory=list)
+    threats: list[str] = field(default_factory=list)
+
+
+@dataclass
+class BoardroomReport:
+    plan_text: str
+    persona_results: list[PersonaResult]
+    pros: list[str]
+    cons: list[str]
+    swot: SwotMatrix
+    implementation_approach: str
+    open_questions: list[str]
+    verdict: str                         # PROCEED | REVISE | RECONSIDER
+    verdict_summary: str
+    synthesis_raw: str = ""
+    synthesis_error: Optional[str] = None
+
+    @property
+    def approve_count(self) -> int:
+        return sum(1 for r in self.persona_results if r.stance == "APPROVE")
+
+    @property
+    def revise_count(self) -> int:
+        return sum(1 for r in self.persona_results if r.stance == "REVISE")
+
+    @property
+    def reject_count(self) -> int:
+        return sum(1 for r in self.persona_results if r.stance == "REJECT")
+
+
+# ---------------------------------------------------------------------------
+# Session
+# ---------------------------------------------------------------------------
+
+class BoardroomSession:
+    """
+    Runs a full boardroom review:
+      1. All personas analyse the plan in parallel.
+      2. The moderator synthesises their outputs into a SWOT + verdict.
+    """
+
+    def __init__(self, provider=None, timeout_secs: int = 90):
+        self._provider = provider
+        self._timeout = timeout_secs
+
+    def _get_provider(self):
+        if self._provider is None:
+            from backend.llm import get_provider
+            self._provider = get_provider()
+        return self._provider
+
+    def _llm(self, prompt: str, temperature: float = 0.3, max_tokens: int = 600) -> str:
+        from backend.llm.base import LLMOptions
+        opts = LLMOptions(temperature=temperature, max_tokens=max_tokens)
+        result = self._get_provider().generate(prompt, opts, timeout=self._timeout)
+        return result or ""
+
+    # -- persona analysis ----------------------------------------------------
+
+    def _run_persona(self, persona: Persona, plan_text: str) -> PersonaResult:
+        prompt = PERSONA_PROMPT_TEMPLATE.format(
+            name=persona.name,
+            role=persona.role,
+            focus=persona.focus,
+            plan_text=plan_text,
+        )
+        raw = self._llm(prompt, temperature=persona.temperature, max_tokens=600)
+        return _parse_persona_result(persona, raw)
+
+    async def _run_persona_async(self, persona: Persona, plan_text: str) -> PersonaResult:
+        return await asyncio.to_thread(self._run_persona, persona, plan_text)
+
+    # -- synthesis ------------------------------------------------------------
+
+    def _run_synthesis(
+        self,
+        plan_text: str,
+        results: list[PersonaResult],
+    ) -> tuple[dict, str]:
+        analyses_text = _format_analyses_for_moderator(results)
+        prompt = MODERATOR_PROMPT_TEMPLATE.format(
+            n=len(results),
+            plan_text=plan_text,
+            analyses=analyses_text,
+        )
+        raw = self._llm(prompt, temperature=0.3, max_tokens=1200)
+        return _parse_json_response(raw), raw
+
+    # -- public entry point --------------------------------------------------
+
+    async def run(
+        self,
+        plan_text: str,
+        on_persona_done: Optional[callable] = None,
+    ) -> BoardroomReport:
+        """
+        Run the full boardroom session asynchronously.
+
+        on_persona_done(persona_result) is called as each persona finishes
+        (useful for progress display).
+        """
+        # ── 1. Parallel persona calls ────────────────────────────────────────
+        tasks = [
+            asyncio.create_task(self._run_persona_async(p, plan_text))
+            for p in PERSONAS
+        ]
+
+        persona_results: list[PersonaResult] = []
+        for coro in asyncio.as_completed(tasks):
+            result = await coro
+            persona_results.append(result)
+            if on_persona_done:
+                on_persona_done(result)
+
+        # Restore original order for display consistency
+        id_order = {p.id: i for i, p in enumerate(PERSONAS)}
+        persona_results.sort(key=lambda r: id_order.get(r.persona.id, 99))
+
+        # ── 2. Synthesis ────────────────────────────────────────────────────
+        synth_dict, synth_raw = await asyncio.to_thread(
+            self._run_synthesis, plan_text, persona_results
+        )
+
+        swot_raw = synth_dict.get("swot", {})
+        swot = SwotMatrix(
+            strengths=swot_raw.get("strengths", []),
+            weaknesses=swot_raw.get("weaknesses", []),
+            opportunities=swot_raw.get("opportunities", []),
+            threats=swot_raw.get("threats", []),
+        )
+
+        return BoardroomReport(
+            plan_text=plan_text,
+            persona_results=persona_results,
+            pros=synth_dict.get("pros", []),
+            cons=synth_dict.get("cons", []),
+            swot=swot,
+            implementation_approach=synth_dict.get("implementation_approach", ""),
+            open_questions=synth_dict.get("open_questions", []),
+            verdict=synth_dict.get("verdict", "REVISE"),
+            verdict_summary=synth_dict.get("verdict_summary", ""),
+            synthesis_raw=synth_raw,
+            synthesis_error=synth_dict.get("_parse_error"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+def _parse_json_response(raw: str) -> dict:
+    """Extract and parse JSON from an LLM response, tolerating prose wrapping."""
+    text = raw.strip()
+
+    # Strip markdown code fences if present
+    text = re.sub(r"^```(?:json)?\s*", "", text)
+    text = re.sub(r"\s*```$", "", text)
+    text = text.strip()
+
+    # Find the outermost {...} block
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        text = text[start : end + 1]
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.warning(f"JSON parse error: {exc} — raw: {raw[:200]}")
+        return {"_parse_error": str(exc), "_raw": raw}
+
+
+def _parse_persona_result(persona: Persona, raw: str) -> PersonaResult:
+    data = _parse_json_response(raw)
+    if "_parse_error" in data:
+        return PersonaResult(
+            persona=persona,
+            stance="REVISE",
+            stance_reason="(parse error)",
+            observations=[],
+            risks=[],
+            recommendations=[],
+            raw=raw,
+            error=data["_parse_error"],
+        )
+    return PersonaResult(
+        persona=persona,
+        stance=data.get("stance", "REVISE").upper(),
+        stance_reason=data.get("stance_reason", ""),
+        observations=data.get("observations", []),
+        risks=data.get("risks", []),
+        recommendations=data.get("recommendations", []),
+        raw=raw,
+    )
+
+
+def _format_analyses_for_moderator(results: list[PersonaResult]) -> str:
+    lines = []
+    for r in results:
+        lines.append(f"### {r.persona.name} ({r.persona.role}) — {r.stance}")
+        lines.append(f"Stance reason: {r.stance_reason}")
+        if r.observations:
+            lines.append("Observations: " + "; ".join(r.observations))
+        if r.risks:
+            lines.append("Risks: " + "; ".join(r.risks))
+        if r.recommendations:
+            lines.append("Recommendations: " + "; ".join(r.recommendations))
+        lines.append("")
+    return "\n".join(lines)

--- a/backend/plan_parser.py
+++ b/backend/plan_parser.py
@@ -1,0 +1,175 @@
+"""
+Parses structured plan markdown files into PMAgent-compatible inputs.
+
+Expected format:
+  # Plan: <title>
+
+  ## Meta
+  platform: azure
+  project: MyProject
+
+  ## Goal
+  <problem statement — fed verbatim to the LLM>
+
+  ## Epics  (optional — used as structural hints for the LLM)
+  - Epic title
+    - Story: story title
+      - Task: task title
+
+  ## Notes  (optional — appended as constraints/context)
+  - Must comply with SOC2
+  - Target: Q3 2026
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class ParsedPlan:
+    title: str
+    platform: Optional[str]        # from ## Meta block; None if not specified
+    project: Optional[str]         # from ## Meta block; None if not specified
+    goal: str                      # from ## Goal block; required
+    epics_hint: str                # from ## Epics block; empty string if absent
+    notes: str                     # from ## Notes block; empty string if absent
+    source_file: Optional[str] = None
+
+    def to_problem_statement(self) -> str:
+        """Build a rich problem statement string to pass to PMAgent.decompose()."""
+        parts = [self.goal.strip()]
+        if self.epics_hint.strip():
+            parts.append(f"\nProposed structure (use as a guide, not a strict template):\n{self.epics_hint.strip()}")
+        if self.notes.strip():
+            parts.append(f"\nConstraints and notes:\n{self.notes.strip()}")
+        return "\n".join(parts)
+
+
+class PlanParseError(ValueError):
+    pass
+
+
+def parse_plan_file(path: str | Path) -> ParsedPlan:
+    """Parse a single structured plan markdown file."""
+    p = Path(path)
+    if not p.exists():
+        raise PlanParseError(f"File not found: {path}")
+    content = p.read_text(encoding="utf-8")
+    plan = _parse_content(content)
+    plan.source_file = str(p)
+    return plan
+
+
+def parse_plan_folder(folder: str | Path) -> list[ParsedPlan]:
+    """Parse all .md files in a folder (non-recursive)."""
+    folder_path = Path(folder)
+    if not folder_path.is_dir():
+        raise PlanParseError(f"Not a directory: {folder}")
+
+    md_files = sorted(folder_path.glob("*.md"))
+    if not md_files:
+        raise PlanParseError(f"No .md files found in: {folder}")
+
+    plans: list[ParsedPlan] = []
+    errors: list[str] = []
+    for md in md_files:
+        try:
+            plans.append(parse_plan_file(md))
+        except PlanParseError as exc:
+            errors.append(f"{md.name}: {exc}")
+
+    if errors and not plans:
+        raise PlanParseError("All files failed to parse:\n" + "\n".join(errors))
+
+    return plans
+
+
+# ---------------------------------------------------------------------------
+# Internal parsing
+# ---------------------------------------------------------------------------
+
+_SECTION_RE = re.compile(r"^#{1,3}\s+(.+)$", re.MULTILINE)
+
+
+def _parse_content(content: str) -> ParsedPlan:
+    sections = _split_sections(content)
+
+    # --- title ---
+    title = _extract_title(sections.get("__preamble__", ""))
+
+    # --- meta block ---
+    meta = _parse_meta(sections.get("meta", ""))
+
+    # --- goal (required) ---
+    goal = sections.get("goal", "").strip()
+    if not goal:
+        raise PlanParseError("## Goal section is missing or empty — it is required")
+
+    # --- epics hint (optional) ---
+    epics_hint = sections.get("epics", "").strip()
+
+    # --- notes (optional) ---
+    notes = sections.get("notes", "").strip()
+
+    return ParsedPlan(
+        title=title,
+        platform=meta.get("platform"),
+        project=meta.get("project"),
+        goal=goal,
+        epics_hint=epics_hint,
+        notes=notes,
+    )
+
+
+def _split_sections(content: str) -> dict[str, str]:
+    """Split content into a dict keyed by lowercase section name.
+
+    Only H2 (##) headings delimit sections so that the H1 document title
+    stays in __preamble__ for title extraction.
+    """
+    result: dict[str, str] = {}
+    current_key = "__preamble__"
+    current_lines: list[str] = []
+
+    for line in content.splitlines(keepends=True):
+        # Match exactly H2 (##) but not H1 (#) or H3 (###)
+        m = re.match(r"^#{2}\s+(.+)$", line.rstrip())
+        if m:
+            result[current_key] = "".join(current_lines)
+            current_key = m.group(1).lower().strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    result[current_key] = "".join(current_lines)
+    return result
+
+
+def _extract_title(preamble: str) -> str:
+    """Pull the plan title from '# Plan: <title>' or the first heading."""
+    for line in preamble.splitlines():
+        m = re.match(r"^#\s+[Pp]lan:\s*(.+)$", line.strip())
+        if m:
+            return m.group(1).strip()
+        m = re.match(r"^#\s+(.+)$", line.strip())
+        if m:
+            return m.group(1).strip()
+    return "Untitled Plan"
+
+
+def _parse_meta(meta_text: str) -> dict[str, str]:
+    """Parse 'key: value' lines from the ## Meta block."""
+    result: dict[str, str] = {}
+    for line in meta_text.splitlines():
+        line = line.strip()
+        if ":" in line:
+            key, _, val = line.partition(":")
+            key = key.strip().lower()
+            val = val.strip()
+            if key and val:
+                result[key] = val
+    return result

--- a/backend/webhook_server.py
+++ b/backend/webhook_server.py
@@ -827,6 +827,340 @@ async def http_work_session_stop(
 
 
 # ---------------------------------------------------------------------------
+# PM Agent — plan preview & create
+# ---------------------------------------------------------------------------
+
+try:
+    from backend.pm_agent import PMAgent, DecompositionPlan
+    from backend.plan_parser import parse_plan_file, parse_plan_folder, PlanParseError
+    import dataclasses, json as _json
+    _pm_agent_available = True
+except ImportError as _pm_err:
+    _pm_agent_available = False
+    logger.warning(f"PM agent not available: {_pm_err}")
+
+
+@app.post("/trigger/plan/preview")
+async def http_plan_preview(
+    request: Request,
+    _auth: None = Depends(_verify_trigger_key),
+) -> dict:
+    """
+    Decompose a problem into an Epic→Story→Task plan and return a preview.
+
+    Accepts either:
+      { "problem": "...", "platform": "azure", "project_context": "...", "notes": "..." }
+    or:
+      { "markdown": "<full plan file contents>", "platform": "azure" }
+
+    Returns:
+      { "preview": "...", "plan_token": "<json>", "total_count": N,
+        "epic_count": N, "story_count": N, "task_count": N }
+    """
+    if not _pm_agent_available:
+        raise HTTPException(status_code=503, detail="PM agent dependencies not installed")
+
+    data = await request.json()
+
+    markdown = data.get("markdown", "").strip()
+    if markdown:
+        # Parse structured markdown sent by the CLI
+        try:
+            from backend.plan_parser import _parse_content
+            parsed = _parse_content(markdown)
+            problem = parsed.to_problem_statement()
+            platform = data.get("platform") or parsed.platform or "azure"
+            project_context = parsed.project
+        except PlanParseError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+    else:
+        problem = data.get("problem", "").strip()
+        if not problem:
+            raise HTTPException(status_code=400, detail="'problem' or 'markdown' field required")
+        platform = data.get("platform", "azure")
+        project_context = data.get("project_context") or None
+
+    notes = data.get("notes", "")
+    if notes:
+        problem = f"{problem}\n\nAdditional constraints:\n{notes}"
+
+    logger.info(f"Plan preview requested — platform={platform}, problem_len={len(problem)}")
+
+    try:
+        agent = PMAgent(platform=platform, project_context=project_context)
+        plan = agent.decompose(problem)
+    except Exception as exc:
+        logger.exception("Plan decomposition failed")
+        raise HTTPException(status_code=500, detail=f"Decomposition failed: {exc}")
+
+    preview = agent.format_preview(plan)
+
+    # Serialise plan to a token so the CLI can pass it back for creation
+    plan_dict = dataclasses.asdict(plan)
+    plan_token = base64.b64encode(_json.dumps(plan_dict).encode()).decode()
+
+    return {
+        "preview": preview,
+        "plan_token": plan_token,
+        "total_count": plan.total_count,
+        "epic_count": plan.epic_count,
+        "story_count": plan.story_count,
+        "task_count": plan.task_count,
+        "platform": platform,
+    }
+
+
+@app.post("/trigger/plan/create")
+async def http_plan_create(
+    request: Request,
+    _auth: None = Depends(_verify_trigger_key),
+) -> dict:
+    """
+    Execute plan creation from a plan_token returned by /trigger/plan/preview.
+
+    Accepts: { "plan_token": "<base64 plan json>" }
+
+    Returns:
+      { "created": [ { "title": ..., "platform_id": ..., "platform_url": ... } ],
+        "failed":  [ { "title": ..., "error": ... } ] }
+    """
+    if not _pm_agent_available:
+        raise HTTPException(status_code=503, detail="PM agent dependencies not installed")
+
+    data = await request.json()
+    token = data.get("plan_token", "")
+    if not token:
+        raise HTTPException(status_code=400, detail="'plan_token' field required")
+
+    try:
+        plan_dict = _json.loads(base64.b64decode(token.encode()).decode())
+        # Reconstruct DecompositionPlan + WorkItemNode objects
+        from backend.pm_agent import WorkItemNode
+        items = [WorkItemNode(**it) for it in plan_dict.pop("items", [])]
+        plan = DecompositionPlan(**plan_dict, items=items)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid plan_token: {exc}")
+
+    logger.info(f"Plan create requested — platform={plan.platform}, items={plan.total_count}")
+
+    progress_log: list[str] = []
+
+    async def on_progress(node, status: str) -> None:
+        progress_log.append(f"{node.title}: {status}")
+        logger.debug(f"Plan progress: {node.title} → {status}")
+
+    try:
+        agent = PMAgent(platform=plan.platform)
+        created, failed = await agent.create_all(plan, on_progress=on_progress)
+    except Exception as exc:
+        logger.exception("Plan creation failed")
+        raise HTTPException(status_code=500, detail=f"Creation failed: {exc}")
+
+    return {
+        "created": [
+            {
+                "title": n.title,
+                "item_type": n.item_type,
+                "level": n.level,
+                "platform_id": n.platform_id,
+                "platform_url": n.platform_url,
+            }
+            for n in created
+        ],
+        "failed": [
+            {"title": n.title, "error": err}
+            for n, err in failed
+        ],
+        "progress": progress_log,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Boardroom — multi-persona plan review
+# ---------------------------------------------------------------------------
+
+try:
+    from backend.boardroom.session import BoardroomSession
+    from backend.boardroom.report import format_terminal, format_markdown
+    from backend.boardroom.interactive import (
+        select_responders,
+        generate_persona_response,
+        generate_final_summary,
+    )
+    _boardroom_available = True
+except ImportError as _br_err:
+    _boardroom_available = False
+    logger.warning(f"Boardroom not available: {_br_err}")
+
+
+@app.post("/trigger/boardroom")
+async def http_boardroom(
+    request: Request,
+    _auth: None = Depends(_verify_trigger_key),
+) -> dict:
+    """
+    Run a full boardroom review on a plan.
+
+    Accepts:
+      { "plan_text": "...", "output_format": "terminal"|"markdown" }
+    or:
+      { "markdown": "<plan file contents>", "output_format": "terminal"|"markdown" }
+
+    Returns:
+      { "report": "<formatted report string>",
+        "verdict": "PROCEED"|"REVISE"|"RECONSIDER",
+        "approve": N, "revise": N, "reject": N }
+    """
+    if not _boardroom_available:
+        raise HTTPException(status_code=503, detail="Boardroom dependencies not installed")
+
+    data = await request.json()
+    output_format = data.get("output_format", "terminal")
+
+    markdown_src = data.get("markdown", "").strip()
+    if markdown_src:
+        try:
+            from backend.plan_parser import _parse_content
+            parsed = _parse_content(markdown_src)
+            plan_text = parsed.to_problem_statement()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f"Plan parse error: {exc}")
+    else:
+        plan_text = data.get("plan_text", "").strip()
+        if not plan_text:
+            raise HTTPException(status_code=400, detail="'plan_text' or 'markdown' field required")
+
+    logger.info(f"Boardroom session starting — plan_len={len(plan_text)}")
+
+    session = BoardroomSession()
+    report = await session.run(plan_text)
+
+    if output_format == "markdown":
+        report_str = format_markdown(report)
+    else:
+        report_str = format_terminal(report)
+
+    return {
+        "report": report_str,
+        "verdict": report.verdict,
+        "verdict_summary": report.verdict_summary,
+        "approve": report.approve_count,
+        "revise": report.revise_count,
+        "reject": report.reject_count,
+        "pros": report.pros,
+        "cons": report.cons,
+    }
+
+
+@app.post("/trigger/boardroom/chat")
+async def http_boardroom_chat(
+    request: Request,
+    _auth: None = Depends(_verify_trigger_key),
+) -> dict:
+    """
+    One turn of an interactive boardroom conversation.
+
+    Accepts:
+      {
+        "plan_text":     "<problem/plan description>",
+        "history":       [ {role, content, persona_id?, persona_name?}, ... ],
+        "user_message":  "<what the user just typed>",
+        "addressed_to":  "<persona_id or null>",   // e.g. "security" if user typed @sam
+        "final_say":     "<text or null>"           // set to end the session
+      }
+
+    Returns:
+      {
+        "responses": [ {persona_id, persona_name, role, content}, ... ],
+        "updated_history": [ ... ],        // full history including this turn
+        "session_closed": false,
+        "closing_summary": null
+      }
+    """
+    if not _boardroom_available:
+        raise HTTPException(status_code=503, detail="Boardroom dependencies not installed")
+
+    data = await request.json()
+    plan_text    = data.get("plan_text", "")
+    history      = data.get("history", [])
+    user_message = data.get("user_message", "").strip()
+    addressed_to = data.get("addressed_to") or None
+    final_say    = data.get("final_say") or None
+
+    if not plan_text:
+        raise HTTPException(status_code=400, detail="'plan_text' is required")
+
+    from backend.llm import get_provider
+    provider = get_provider()
+
+    # ── Final-say path: close the session ───────────────────────────────────
+    if final_say:
+        closing = await asyncio.to_thread(
+            generate_final_summary, provider, plan_text, history, final_say
+        )
+        # Append final say + closing to history
+        updated = list(history)
+        updated.append({"role": "user", "content": f"[Final say] {final_say}"})
+        updated.append({"role": "system", "content": f"[Closing summary] {closing}"})
+        return {
+            "responses": [],
+            "updated_history": updated,
+            "session_closed": True,
+            "closing_summary": closing,
+        }
+
+    if not user_message:
+        raise HTTPException(status_code=400, detail="'user_message' or 'final_say' required")
+
+    # ── Normal turn: select responders ──────────────────────────────────────
+    responder_ids = await asyncio.to_thread(
+        select_responders, provider, history, user_message, addressed_to
+    )
+
+    from backend.boardroom.personas import PERSONAS as _PERSONAS
+    id_to_persona = {p.id: p for p in _PERSONAS}
+
+    # ── Generate responses in parallel ──────────────────────────────────────
+    # Append user message to history first so personas see it in context
+    turn_history = list(history) + [{"role": "user", "content": user_message}]
+
+    async def _get_response(persona_id: str):
+        persona = id_to_persona.get(persona_id)
+        if not persona:
+            return None
+        content = await asyncio.to_thread(
+            generate_persona_response,
+            provider, persona, turn_history, user_message, plan_text,
+        )
+        return {
+            "persona_id": persona.id,
+            "persona_name": persona.name,
+            "role": persona.role,
+            "content": content,
+        }
+
+    raw_responses = await asyncio.gather(*[_get_response(rid) for rid in responder_ids])
+    responses = [r for r in raw_responses if r and r["content"]]
+
+    # Build updated history
+    updated = list(turn_history)
+    for r in responses:
+        updated.append({
+            "role": "persona",
+            "persona_id": r["persona_id"],
+            "persona_name": r["persona_name"],
+            "content": r["content"],
+        })
+
+    return {
+        "responses": responses,
+        "updated_history": updated,
+        "session_closed": False,
+        "closing_summary": None,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Startup
 # ---------------------------------------------------------------------------
 

--- a/devtrack-bin/cli.go
+++ b/devtrack-bin/cli.go
@@ -24,7 +24,7 @@ func NewCLI() (*CLI, error) {
 		cmd := os.Args[1]
 		if cmd == "help" || cmd == "version" || cmd == "commit-queue" || cmd == "commits" || cmd == "queue" || cmd == "telegram-status" || cmd == "azure-check" || cmd == "gitlab-check" || cmd == "github-check" || cmd == "workspace" || cmd == "shell-init" || cmd == "is-workspace" || cmd == "enable-git" || cmd == "disable-git" || cmd == "launchd-install" || cmd == "launchd-uninstall" || cmd == "autostart-install" || cmd == "autostart-uninstall" || cmd == "autostart-status" || cmd == "alerts" || cmd == "cloud" || cmd == "tui" ||
 			cmd == "login" || cmd == "logout" || cmd == "whoami" || cmd == "license" || cmd == "terms" || cmd == "telemetry" ||
-			cmd == "reload-config" {
+			cmd == "reload-config" || cmd == "plan" || cmd == "boardroom" {
 			return &CLI{}, nil
 		}
 	}
@@ -231,6 +231,10 @@ func (cli *CLI) Execute() error {
 		return nil
 	case "init":
 		return cli.handleInit()
+	case "plan":
+		return cli.handlePlan()
+	case "boardroom":
+		return cli.handleBoardroom()
 	default:
 		// Check if it's a test command
 		if strings.HasPrefix(command, "test-") {
@@ -2893,10 +2897,21 @@ func (cli *CLI) printUsage() {
 	fmt.Println("                     ALERT_GITHUB_ENABLED, ALERT_NOTIFY_ASSIGNED,")
 	fmt.Println("                     ALERT_NOTIFY_COMMENTS, ALERT_NOTIFY_REVIEW_REQUESTED")
 	fmt.Println()
-	fmt.Println("PM AGENT (via Telegram bot):")
-	fmt.Println("  /plan <problem>    Decompose a problem into Epic → Story → Task hierarchy")
-	fmt.Println("                     Platform picker → LLM preview → confirm to create items")
-	fmt.Println("                     Supported platforms: azure, gitlab, github")
+	fmt.Println("PM AGENT:")
+	fmt.Println("  devtrack plan \"<problem>\"       Decompose a problem into Epic → Story → Task hierarchy")
+	fmt.Println("  devtrack plan --file <plan.md>  Load a structured plan file")
+	fmt.Println("  devtrack plan --folder <dir/>   Process all .md plan files in a folder")
+	fmt.Println("                                  Platform picker → LLM preview → confirm to create items")
+	fmt.Println("                                  Supported platforms: azure, gitlab, github")
+	fmt.Println("  Also available via Telegram bot: /plan <problem>")
+	fmt.Println()
+	fmt.Println("BOARDROOM (multi-persona AI plan review):")
+	fmt.Println("  devtrack boardroom \"<problem>\"               7 AI personas review the plan in parallel")
+	fmt.Println("  devtrack boardroom --file <plan.md>          Review a structured plan file")
+	fmt.Println("  devtrack boardroom --folder <dir/>           Review all .md plans in folder")
+	fmt.Println("  devtrack boardroom --file <p.md> --output <r.md>  Save report as markdown")
+	fmt.Println("  Personas: Architect · Security · PM · Devil's Advocate · Engineer · Analyst · Scalability")
+	fmt.Println("  Output:   PROs/CONs · SWOT matrix · Implementation approach · PROCEED/REVISE/RECONSIDER")
 	fmt.Println()
 	fmt.Println("OFFLINE RESILIENCE:")
 	fmt.Println("  devtrack queue             Show message queue stats")

--- a/devtrack-bin/cli_boardroom.go
+++ b/devtrack-bin/cli_boardroom.go
@@ -1,0 +1,463 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ── ANSI colours ─────────────────────────────────────────────────────────────
+
+const (
+	colReset   = "\033[0m"
+	colBold    = "\033[1m"
+	colDim     = "\033[2m"
+	colCyan    = "\033[96m"
+	colRed     = "\033[91m"
+	colGreen   = "\033[92m"
+	colMagenta = "\033[95m"
+	colBlue    = "\033[94m"
+	colYellow  = "\033[93m"
+	colWhite   = "\033[97m"
+	colOrange  = "\033[38;5;208m"
+)
+
+// Per-persona terminal colours (matched to persona IDs).
+var personaColour = map[string]string{
+	"architect":   colCyan,
+	"security":    colRed,
+	"pm":          colGreen,
+	"devil":       colMagenta,
+	"engineer":    colBlue,
+	"analyst":     colYellow,
+	"scalability": colOrange,
+}
+
+// handleBoardroom implements `devtrack boardroom` — a multi-persona AI review
+// of a plan, producing PROs/CONs, a SWOT matrix, a final verdict, and an
+// optional interactive discussion session.
+//
+// Usage:
+//
+//	devtrack boardroom "<problem>"
+//	devtrack boardroom --file  <plan.md>
+//	devtrack boardroom --folder <plans/>
+//	devtrack boardroom --file <plan.md> --output <report.md>
+//	devtrack boardroom --file <plan.md> --interactive
+func (cli *CLI) handleBoardroom() error {
+	if err := requiresManagedMode("boardroom"); err != nil {
+		return err
+	}
+
+	args := os.Args[2:]
+	if len(args) == 0 {
+		printBoardroomUsage()
+		return nil
+	}
+
+	var (
+		filePath    string
+		folderPath  string
+		outputPath  string
+		autoInteract bool
+		problemParts []string
+	)
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--file", "-f":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--file requires a path argument")
+			}
+			i++
+			filePath = args[i]
+		case "--folder", "-d":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--folder requires a path argument")
+			}
+			i++
+			folderPath = args[i]
+		case "--output", "-o":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--output requires a file path argument")
+			}
+			i++
+			outputPath = args[i]
+		case "--interactive", "-i":
+			autoInteract = true
+		default:
+			problemParts = append(problemParts, args[i])
+		}
+	}
+
+	switch {
+	case folderPath != "":
+		return cli.runBoardroomFolder(folderPath, outputPath, autoInteract)
+	case filePath != "":
+		return cli.runBoardroomFile(filePath, outputPath, autoInteract)
+	default:
+		problem := strings.Join(problemParts, " ")
+		if problem == "" {
+			printBoardroomUsage()
+			return nil
+		}
+		return cli.runBoardroomInline(problem, outputPath, autoInteract)
+	}
+}
+
+// ── Entry points ─────────────────────────────────────────────────────────────
+
+func (cli *CLI) runBoardroomInline(problem, outputPath string, autoInteract bool) error {
+	return cli.executeBoardroom(BoardroomRequest{
+		PlanText:     problem,
+		OutputFormat: boardroomOutputFormat(outputPath),
+	}, problem, outputPath, autoInteract)
+}
+
+func (cli *CLI) runBoardroomFile(path, outputPath string, autoInteract bool) error {
+	markdown, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("cannot read file %q: %w", path, err)
+	}
+	return cli.executeBoardroom(BoardroomRequest{
+		Markdown:     string(markdown),
+		OutputFormat: boardroomOutputFormat(outputPath),
+	}, string(markdown), outputPath, autoInteract)
+}
+
+func (cli *CLI) runBoardroomFolder(dir, outputPath string, autoInteract bool) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("cannot read folder %q: %w", dir, err)
+	}
+
+	var mdFiles []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(strings.ToLower(e.Name()), ".md") {
+			mdFiles = append(mdFiles, filepath.Join(dir, e.Name()))
+		}
+	}
+	if len(mdFiles) == 0 {
+		return fmt.Errorf("no .md files found in %q", dir)
+	}
+
+	fmt.Printf("Found %d plan file(s) in %s\n\n", len(mdFiles), dir)
+	for i, f := range mdFiles {
+		fmt.Printf("─── [%d/%d] %s ───\n", i+1, len(mdFiles), filepath.Base(f))
+		fileOutput := outputPath
+		if outputPath != "" {
+			info, statErr := os.Stat(outputPath)
+			if statErr == nil && info.IsDir() {
+				base := strings.TrimSuffix(filepath.Base(f), ".md")
+				fileOutput = filepath.Join(outputPath, base+"-boardroom.md")
+			}
+		}
+		if err := cli.runBoardroomFile(f, fileOutput, autoInteract); err != nil {
+			fmt.Printf("  ✗ skipped: %v\n\n", err)
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+// ── Core execution ────────────────────────────────────────────────────────────
+
+// executeBoardroom runs the initial review then optionally enters the REPL.
+// planSource is the raw text/markdown sent as context to the interactive session.
+func (cli *CLI) executeBoardroom(req BoardroomRequest, planSource, outputPath string, autoInteract bool) error {
+	client := NewHTTPTriggerClient()
+
+	fmt.Println("Convening the boardroom... (7 personas analysing in parallel)")
+	fmt.Println("This may take 30–120 seconds depending on your LLM provider.")
+	fmt.Println()
+
+	result, err := client.SendBoardroom(req)
+	if err != nil {
+		return fmt.Errorf("boardroom session failed: %w", err)
+	}
+
+	fmt.Println(result.Report)
+
+	if outputPath != "" {
+		if writeErr := os.WriteFile(outputPath, []byte(result.Report), 0o644); writeErr != nil {
+			fmt.Printf("Warning: could not save report to %q: %v\n", outputPath, writeErr)
+		} else {
+			fmt.Printf("Report saved → %s\n", outputPath)
+		}
+	}
+
+	// ── Offer / enter interactive mode ────────────────────────────────────
+	enterInteractive := autoInteract
+	if !autoInteract {
+		enterInteractive = confirmPrompt("Enter interactive boardroom discussion?")
+	}
+	if !enterInteractive {
+		return nil
+	}
+
+	// Seed history with a system entry summarising the initial review.
+	seedHistory := []BoardroomHistoryEntry{
+		{
+			Role: "system",
+			Content: fmt.Sprintf(
+				"Initial boardroom review complete. Verdict: %s. Approve: %d, Revise: %d, Reject: %d.",
+				result.Verdict, result.Approve, result.Revise, result.Reject,
+			),
+		},
+	}
+
+	// Determine plan_text to pass to the chat endpoint.
+	planText := req.PlanText
+	if planText == "" {
+		planText = planSource // fallback to the raw markdown
+	}
+
+	return cli.runInteractiveSession(client, planText, seedHistory)
+}
+
+// ── Interactive REPL ─────────────────────────────────────────────────────────
+
+func (cli *CLI) runInteractiveSession(
+	client *HTTPTriggerClient,
+	planText string,
+	history []BoardroomHistoryEntry,
+) error {
+	printInteractiveBanner()
+
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Printf("\n%sYou:%s ", colBold, colReset)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			break
+		}
+		input := strings.TrimSpace(line)
+		if input == "" {
+			continue
+		}
+
+		// ── Built-in commands ──────────────────────────────────────────────
+		if strings.EqualFold(input, "/exit") || strings.EqualFold(input, "/quit") {
+			fmt.Println("\nLeaving the boardroom. Goodbye.")
+			break
+		}
+
+		if strings.EqualFold(input, "/help") {
+			printInteractiveHelp()
+			continue
+		}
+
+		if strings.EqualFold(input, "/personas") {
+			printPersonaList()
+			continue
+		}
+
+		// /final <text> — end session with user's verdict
+		if strings.HasPrefix(strings.ToLower(input), "/final") {
+			finalText := strings.TrimSpace(input[6:])
+			if finalText == "" {
+				fmt.Print("Your final decision: ")
+				line2, _ := reader.ReadString('\n')
+				finalText = strings.TrimSpace(line2)
+			}
+			if finalText == "" {
+				fmt.Println("(No final say recorded — use /exit to leave.)")
+				continue
+			}
+			if err := cli.sendFinalSay(client, planText, history, finalText); err != nil {
+				fmt.Printf("Error recording final say: %v\n", err)
+			}
+			break
+		}
+
+		// ── Parse @mention ─────────────────────────────────────────────────
+		addressedTo, cleanMessage := parseAtMention(input)
+
+		// ── Send turn to server ────────────────────────────────────────────
+		fmt.Printf("%s(thinking...)%s\n", colDim, colReset)
+
+		resp, err := client.SendBoardroomChat(BoardroomChatRequest{
+			PlanText:    planText,
+			History:     history,
+			UserMessage: cleanMessage,
+			AddressedTo: addressedTo,
+		})
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			continue
+		}
+
+		// ── Display responses ───────────────────────────────────────────────
+		fmt.Println()
+		for _, r := range resp.Responses {
+			printPersonaMessage(r.PersonaID, r.PersonaName, r.Role, r.Content)
+		}
+
+		history = resp.UpdatedHistory
+	}
+
+	return nil
+}
+
+// sendFinalSay sends the user's closing statement and prints the summary.
+func (cli *CLI) sendFinalSay(
+	client *HTTPTriggerClient,
+	planText string,
+	history []BoardroomHistoryEntry,
+	finalSay string,
+) error {
+	fmt.Printf("%s(recording your final say and closing the session...)%s\n", colDim, colReset)
+
+	resp, err := client.SendBoardroomChat(BoardroomChatRequest{
+		PlanText: planText,
+		History:  history,
+		FinalSay: finalSay,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("\n%s%s═══ FINAL SAY ═══%s\n", colBold, colGreen, colReset)
+	fmt.Printf("%sYou:%s %s\n\n", colBold, colReset, finalSay)
+
+	if resp.ClosingSummary != "" {
+		fmt.Printf("%s%s─── Closing Summary ───%s\n", colBold, colCyan, colReset)
+		fmt.Println(resp.ClosingSummary)
+	}
+
+	fmt.Printf("\n%sThe boardroom is adjourned.%s\n", colBold, colReset)
+	return nil
+}
+
+// ── Display helpers ───────────────────────────────────────────────────────────
+
+func printPersonaMessage(personaID, personaName, role, content string) {
+	col := personaColour[personaID]
+	if col == "" {
+		col = colWhite
+	}
+	// Header line: coloured name + dim role
+	fmt.Printf("%s%s%s%s %s(%s)%s\n", colBold, col, personaName, colReset, colDim, role, colReset)
+	// Wrap content slightly indented
+	for _, para := range strings.Split(content, "\n") {
+		if strings.TrimSpace(para) != "" {
+			fmt.Printf("  %s\n", para)
+		}
+	}
+	fmt.Println()
+}
+
+// parseAtMention extracts "@id" or "@name" from the message.
+// Returns (addressedTo, cleanedMessage).
+func parseAtMention(input string) (string, string) {
+	knownIDs := map[string]string{
+		"alex": "architect", "architect": "architect",
+		"sam": "security", "security": "security",
+		"priya": "pm", "pm": "pm",
+		"devon": "devil", "devil": "devil", "advocate": "devil",
+		"eva": "engineer", "engineer": "engineer",
+		"ben": "analyst", "analyst": "analyst",
+		"sofia": "scalability", "scalability": "scalability",
+	}
+
+	words := strings.Fields(input)
+	for i, w := range words {
+		if strings.HasPrefix(w, "@") {
+			handle := strings.ToLower(strings.TrimPrefix(w, "@"))
+			if id, ok := knownIDs[handle]; ok {
+				clean := strings.Join(append(words[:i], words[i+1:]...), " ")
+				return id, strings.TrimSpace(clean)
+			}
+		}
+	}
+	return "", input
+}
+
+func printInteractiveBanner() {
+	fmt.Printf("\n%s%s╔══════════════════════════════════════════════════╗%s\n", colBold, colCyan, colReset)
+	fmt.Printf("%s%s║        BOARDROOM — Interactive Session           ║%s\n", colBold, colCyan, colReset)
+	fmt.Printf("%s%s╚══════════════════════════════════════════════════╝%s\n", colBold, colCyan, colReset)
+	fmt.Println()
+	fmt.Println("  The personas are ready to discuss. Speak your mind.")
+	fmt.Println("  Address someone with @alex, @sam, @priya, etc.")
+	fmt.Println()
+	fmt.Println("  Commands:")
+	fmt.Printf("    %s/final <decision>%s  — record your verdict and close the session\n", colBold, colReset)
+	fmt.Printf("    %s/personas%s          — list all personas\n", colBold, colReset)
+	fmt.Printf("    %s/help%s              — show this help\n", colBold, colReset)
+	fmt.Printf("    %s/exit%s              — leave without a final say\n", colBold, colReset)
+}
+
+func printInteractiveHelp() {
+	fmt.Println()
+	fmt.Println("  You can speak freely to the group or address someone directly:")
+	fmt.Println("    @alex / @architect    — Alex the Architect")
+	fmt.Println("    @sam  / @security     — Sam the Security Lead")
+	fmt.Println("    @priya / @pm          — Priya the Product Manager")
+	fmt.Println("    @devon / @devil       — Devon the Devil's Advocate")
+	fmt.Println("    @eva  / @engineer     — Eva the Lead Engineer")
+	fmt.Println("    @ben  / @analyst      — Ben the Business Analyst")
+	fmt.Println("    @sofia / @scalability — Sofia the Scalability Engineer")
+	fmt.Println()
+	fmt.Println("  /final <decision>  Close the session with your verdict")
+	fmt.Println("  /personas          Show persona colours and focus areas")
+	fmt.Println("  /exit              Leave without a final say")
+}
+
+func printPersonaList() {
+	type personaInfo struct{ id, name, role, col string }
+	personas := []personaInfo{
+		{"architect", "Alex the Architect", "system design & trade-offs", colCyan},
+		{"security", "Sam the Security Lead", "threats, compliance, attack surface", colRed},
+		{"pm", "Priya the Product Manager", "user value, scope, timeline", colGreen},
+		{"devil", "Devon the Devil's Advocate", "hidden assumptions & failure modes", colMagenta},
+		{"engineer", "Eva the Lead Engineer", "implementation complexity & effort", colBlue},
+		{"analyst", "Ben the Business Analyst", "ROI, KPIs, business alignment", colYellow},
+		{"scalability", "Sofia the Scalability Engineer", "scaling limits, bottlenecks, load failures", colOrange},
+	}
+	fmt.Println()
+	for _, p := range personas {
+		fmt.Printf("  %s%s%s%s — %s%s%s\n",
+			colBold, p.col, p.name, colReset,
+			colDim, p.role, colReset)
+	}
+	fmt.Println()
+}
+
+// ── Misc ─────────────────────────────────────────────────────────────────────
+
+func boardroomOutputFormat(outputPath string) string {
+	if strings.HasSuffix(strings.ToLower(outputPath), ".md") {
+		return "markdown"
+	}
+	return "terminal"
+}
+
+func printBoardroomUsage() {
+	fmt.Println(`Usage:
+  devtrack boardroom "<problem>"                     Run boardroom review on an inline problem
+  devtrack boardroom --file <plan.md>               Run boardroom review on a plan file
+  devtrack boardroom --folder <dir/>                Review all .md plan files in a folder
+  devtrack boardroom --file <plan.md> --output <r.md>  Save report to file
+  devtrack boardroom --file <plan.md> --interactive  Auto-enter interactive discussion
+
+Interactive mode (available after every review):
+  Speak freely to all 7 personas or address one directly:
+    @alex  @sam  @priya  @devon  @eva  @ben  @sofia
+
+  /final <decision>   Record your verdict and close with a summary
+  /personas           List all personas with focus areas
+  /exit               Leave the boardroom
+
+Personas (7):
+  Alex the Architect          — system design & trade-offs
+  Sam the Security Lead       — threats, compliance, attack surface
+  Priya the Product Manager   — user value, scope, timeline
+  Devon the Devil's Advocate  — hidden assumptions & failure modes
+  Eva the Lead Engineer       — implementation complexity & effort
+  Ben the Business Analyst    — ROI, KPIs, business alignment
+  Sofia the Scalability Eng.  — scaling limits, bottlenecks, load failures`)
+}

--- a/devtrack-bin/cli_plan.go
+++ b/devtrack-bin/cli_plan.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// handlePlan implements `devtrack plan` — decompose a problem into an
+// Epic → Story → Task hierarchy and create items on the chosen platform.
+//
+// Usage:
+//
+//	devtrack plan "<problem statement>"
+//	devtrack plan --file  <plan.md>
+//	devtrack plan --folder <plans/>
+func (cli *CLI) handlePlan() error {
+	if err := requiresManagedMode("plan"); err != nil {
+		return err
+	}
+
+	args := os.Args[2:]
+
+	switch {
+	case len(args) == 0:
+		printPlanUsage()
+		return nil
+
+	case args[0] == "--file" || args[0] == "-f":
+		if len(args) < 2 {
+			return fmt.Errorf("--file requires a path argument")
+		}
+		return cli.runPlanFile(args[1])
+
+	case args[0] == "--folder" || args[0] == "-d":
+		if len(args) < 2 {
+			return fmt.Errorf("--folder requires a path argument")
+		}
+		return cli.runPlanFolder(args[1])
+
+	default:
+		// Treat all remaining args as the inline problem statement.
+		problem := strings.Join(args, " ")
+		return cli.runPlanInline(problem)
+	}
+}
+
+// runPlanInline handles `devtrack plan "<problem>"`.
+func (cli *CLI) runPlanInline(problem string) error {
+	platform, err := promptPlatform()
+	if err != nil {
+		return err
+	}
+	return cli.executePlan(PlanPreviewRequest{
+		Problem:  problem,
+		Platform: platform,
+	})
+}
+
+// runPlanFile handles `devtrack plan --file <path>`.
+func (cli *CLI) runPlanFile(path string) error {
+	markdown, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("cannot read file %q: %w", path, err)
+	}
+	// Platform may come from the ## Meta block; prompt only if not present.
+	parsed := extractMetaPlatform(string(markdown))
+	platform := parsed
+	if platform == "" {
+		var promptErr error
+		platform, promptErr = promptPlatform()
+		if promptErr != nil {
+			return promptErr
+		}
+	} else {
+		fmt.Printf("Platform from plan file: %s\n", platform)
+	}
+	return cli.executePlan(PlanPreviewRequest{
+		Markdown: string(markdown),
+		Platform: platform,
+	})
+}
+
+// runPlanFolder handles `devtrack plan --folder <dir>`.
+// Each .md file in the folder is treated as a separate plan.
+func (cli *CLI) runPlanFolder(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("cannot read folder %q: %w", dir, err)
+	}
+
+	var mdFiles []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(strings.ToLower(e.Name()), ".md") {
+			mdFiles = append(mdFiles, filepath.Join(dir, e.Name()))
+		}
+	}
+
+	if len(mdFiles) == 0 {
+		return fmt.Errorf("no .md files found in %q", dir)
+	}
+
+	fmt.Printf("Found %d plan file(s) in %s\n\n", len(mdFiles), dir)
+
+	for i, f := range mdFiles {
+		fmt.Printf("─── [%d/%d] %s ───\n", i+1, len(mdFiles), filepath.Base(f))
+		if err := cli.runPlanFile(f); err != nil {
+			fmt.Printf("  ✗ skipped: %v\n\n", err)
+			continue
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+// executePlan runs the two-step preview → confirm → create flow.
+func (cli *CLI) executePlan(req PlanPreviewRequest) error {
+	client := NewHTTPTriggerClient()
+
+	// ── Step 1: decompose & preview ────────────────────────────────────────
+	fmt.Println("Decomposing plan...")
+	preview, err := client.SendPlanPreview(req)
+	if err != nil {
+		return fmt.Errorf("plan preview failed: %w", err)
+	}
+
+	platformLabel := strings.ToUpper(preview.Platform)
+	fmt.Printf("\nPlan Preview  (%s)\n", platformLabel)
+	fmt.Println(strings.Repeat("─", 50))
+	fmt.Println(preview.Preview)
+	fmt.Println(strings.Repeat("─", 50))
+	fmt.Printf("Total: %d item(s) — %d epic(s), %d story/feature(s), %d task(s)\n\n",
+		preview.TotalCount, preview.EpicCount, preview.StoryCount, preview.TaskCount)
+
+	// ── Step 2: confirm ────────────────────────────────────────────────────
+	if !confirmPrompt(fmt.Sprintf("Create all %d items in %s?", preview.TotalCount, platformLabel)) {
+		fmt.Println("Cancelled.")
+		return nil
+	}
+
+	// ── Step 3: create ─────────────────────────────────────────────────────
+	fmt.Printf("\nCreating %d items in %s...\n", preview.TotalCount, platformLabel)
+	result, err := client.SendPlanCreate(preview.PlanToken)
+	if err != nil {
+		return fmt.Errorf("plan creation failed: %w", err)
+	}
+
+	fmt.Printf("\nDone — %d created, %d failed\n\n", len(result.Created), len(result.Failed))
+
+	indent := map[int]string{0: "", 1: "  ", 2: "    "}
+	for _, item := range result.Created {
+		ind := indent[item.Level]
+		if ind == "" {
+			ind = ""
+		}
+		urlPart := ""
+		if item.PlatformURL != "" {
+			urlPart = "  → " + item.PlatformURL
+		} else if item.PlatformID != "" {
+			urlPart = "  #" + item.PlatformID
+		}
+		fmt.Printf("  ✓ %s%s: %s%s\n", ind, item.ItemType, item.Title, urlPart)
+	}
+
+	if len(result.Failed) > 0 {
+		fmt.Printf("\nFailed (%d):\n", len(result.Failed))
+		for _, f := range result.Failed {
+			fmt.Printf("  ✗ %s: %s\n", f.Title, f.Error)
+		}
+	}
+
+	return nil
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+// promptPlatform shows a numbered menu and returns the chosen platform string.
+func promptPlatform() (string, error) {
+	platforms := []string{"azure", "gitlab", "github"}
+	labels := []string{"Azure DevOps", "GitLab", "GitHub"}
+
+	fmt.Println("Choose target platform:")
+	for i, l := range labels {
+		fmt.Printf("  %d) %s\n", i+1, l)
+	}
+	fmt.Print("Enter choice [1-3]: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("reading input: %w", err)
+	}
+	input = strings.TrimSpace(input)
+
+	switch input {
+	case "1":
+		return platforms[0], nil
+	case "2":
+		return platforms[1], nil
+	case "3":
+		return platforms[2], nil
+	default:
+		// Also accept direct names.
+		lower := strings.ToLower(input)
+		for _, p := range platforms {
+			if lower == p {
+				return p, nil
+			}
+		}
+		return "", fmt.Errorf("invalid choice %q — enter 1, 2, or 3", input)
+	}
+}
+
+// confirmPrompt asks a yes/no question and returns true for y/Y/yes.
+func confirmPrompt(question string) bool {
+	fmt.Printf("%s [y/N]: ", question)
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	input = strings.TrimSpace(strings.ToLower(input))
+	return input == "y" || input == "yes"
+}
+
+// extractMetaPlatform does a quick scan of markdown content for a
+// "platform: <value>" line inside a ## Meta block, without a full parse.
+func extractMetaPlatform(content string) string {
+	inMeta := false
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.EqualFold(trimmed, "## meta") || strings.EqualFold(trimmed, "## Meta") {
+			inMeta = true
+			continue
+		}
+		if inMeta {
+			if strings.HasPrefix(trimmed, "#") {
+				break // left the Meta section
+			}
+			if strings.HasPrefix(strings.ToLower(trimmed), "platform:") {
+				val := strings.TrimSpace(trimmed[len("platform:"):])
+				val = strings.ToLower(val)
+				switch val {
+				case "azure", "gitlab", "github":
+					return val
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func printPlanUsage() {
+	fmt.Println(`Usage:
+  devtrack plan "<problem>"          Decompose a problem statement
+  devtrack plan --file <plan.md>    Load a structured plan file
+  devtrack plan --folder <dir/>     Process all .md plan files in a folder
+
+Plan file format (structured markdown):
+  # Plan: <title>
+
+  ## Meta
+  platform: azure   # azure | gitlab | github
+  project: MyProject
+
+  ## Goal
+  Describe what needs to be built.
+
+  ## Epics  (optional — used as hints for the AI)
+  - Epic title
+    - Story: story title
+      - Task: task title
+
+  ## Notes  (optional)
+  - Must comply with SOC2`)
+}

--- a/devtrack-bin/http_trigger.go
+++ b/devtrack-bin/http_trigger.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"time"
@@ -108,6 +109,201 @@ func (c *HTTPTriggerClient) SendWorkSessionStop(sessionID int64) error {
 	return c.post("/trigger/work_session_stop", map[string]interface{}{
 		"session_id": sessionID,
 	})
+}
+
+// PlanPreviewRequest is the payload sent to POST /trigger/plan/preview.
+type PlanPreviewRequest struct {
+	Problem        string `json:"problem,omitempty"`
+	Markdown       string `json:"markdown,omitempty"`
+	Platform       string `json:"platform,omitempty"`
+	ProjectContext string `json:"project_context,omitempty"`
+	Notes          string `json:"notes,omitempty"`
+}
+
+// PlanPreviewResponse is the response from POST /trigger/plan/preview.
+type PlanPreviewResponse struct {
+	Preview    string `json:"preview"`
+	PlanToken  string `json:"plan_token"`
+	TotalCount int    `json:"total_count"`
+	EpicCount  int    `json:"epic_count"`
+	StoryCount int    `json:"story_count"`
+	TaskCount  int    `json:"task_count"`
+	Platform   string `json:"platform"`
+}
+
+// PlanCreatedItem is one successfully created work item.
+type PlanCreatedItem struct {
+	Title       string `json:"title"`
+	ItemType    string `json:"item_type"`
+	Level       int    `json:"level"`
+	PlatformID  string `json:"platform_id"`
+	PlatformURL string `json:"platform_url"`
+}
+
+// PlanFailedItem is one work item that failed to be created.
+type PlanFailedItem struct {
+	Title string `json:"title"`
+	Error string `json:"error"`
+}
+
+// PlanCreateResponse is the response from POST /trigger/plan/create.
+type PlanCreateResponse struct {
+	Created  []PlanCreatedItem `json:"created"`
+	Failed   []PlanFailedItem  `json:"failed"`
+	Progress []string          `json:"progress"`
+}
+
+// SendPlanPreview calls POST /trigger/plan/preview and returns the parsed response.
+func (c *HTTPTriggerClient) SendPlanPreview(req PlanPreviewRequest) (*PlanPreviewResponse, error) {
+	var resp PlanPreviewResponse
+	if err := c.postWithResult("/trigger/plan/preview", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SendPlanCreate calls POST /trigger/plan/create and returns the parsed response.
+func (c *HTTPTriggerClient) SendPlanCreate(planToken string) (*PlanCreateResponse, error) {
+	var resp PlanCreateResponse
+	payload := map[string]string{"plan_token": planToken}
+	if err := c.postWithResult("/trigger/plan/create", payload, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// BoardroomRequest is the payload for POST /trigger/boardroom.
+type BoardroomRequest struct {
+	PlanText     string `json:"plan_text,omitempty"`
+	Markdown     string `json:"markdown,omitempty"`
+	OutputFormat string `json:"output_format"` // "terminal" | "markdown"
+}
+
+// BoardroomResponse is the response from POST /trigger/boardroom.
+type BoardroomResponse struct {
+	Report        string   `json:"report"`
+	Verdict       string   `json:"verdict"`
+	VerdictSummary string  `json:"verdict_summary"`
+	Approve       int      `json:"approve"`
+	Revise        int      `json:"revise"`
+	Reject        int      `json:"reject"`
+	Pros          []string `json:"pros"`
+	Cons          []string `json:"cons"`
+}
+
+// SendBoardroom calls POST /trigger/boardroom and returns the parsed response.
+// Uses a longer timeout (180s) since 7 parallel LLM calls + synthesis can be slow.
+func (c *HTTPTriggerClient) SendBoardroom(req BoardroomRequest) (*BoardroomResponse, error) {
+	// Build a client with a longer timeout for boardroom sessions.
+	longClient := *c
+	longClient.httpClient = &http.Client{
+		Timeout:   180 * time.Second,
+		Transport: c.httpClient.Transport,
+	}
+	var resp BoardroomResponse
+	if err := longClient.postWithResult("/trigger/boardroom", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// BoardroomHistoryEntry is one message in the interactive boardroom conversation.
+type BoardroomHistoryEntry struct {
+	Role        string `json:"role"`                   // "user" | "persona" | "system"
+	Content     string `json:"content"`
+	PersonaID   string `json:"persona_id,omitempty"`
+	PersonaName string `json:"persona_name,omitempty"`
+}
+
+// BoardroomChatRequest is the payload for POST /trigger/boardroom/chat.
+type BoardroomChatRequest struct {
+	PlanText    string                   `json:"plan_text"`
+	History     []BoardroomHistoryEntry  `json:"history"`
+	UserMessage string                   `json:"user_message,omitempty"`
+	AddressedTo string                   `json:"addressed_to,omitempty"`
+	FinalSay    string                   `json:"final_say,omitempty"`
+}
+
+// BoardroomPersonaResponse is one persona's reply in a chat turn.
+type BoardroomPersonaResponse struct {
+	PersonaID   string `json:"persona_id"`
+	PersonaName string `json:"persona_name"`
+	Role        string `json:"role"`
+	Content     string `json:"content"`
+}
+
+// BoardroomChatResponse is the response from POST /trigger/boardroom/chat.
+type BoardroomChatResponse struct {
+	Responses      []BoardroomPersonaResponse `json:"responses"`
+	UpdatedHistory []BoardroomHistoryEntry    `json:"updated_history"`
+	SessionClosed  bool                       `json:"session_closed"`
+	ClosingSummary string                     `json:"closing_summary"`
+}
+
+// SendBoardroomChat sends one interactive chat turn to the boardroom.
+func (c *HTTPTriggerClient) SendBoardroomChat(req BoardroomChatRequest) (*BoardroomChatResponse, error) {
+	longClient := *c
+	longClient.httpClient = &http.Client{
+		Timeout:   120 * time.Second,
+		Transport: c.httpClient.Transport,
+	}
+	var resp BoardroomChatResponse
+	if err := longClient.postWithResult("/trigger/boardroom/chat", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// postWithResult POSTs payload as JSON and decodes the response body into dest.
+func (c *HTTPTriggerClient) postWithResult(path string, payload interface{}, dest interface{}) error {
+	if c.serverURL == "" {
+		return fmt.Errorf("DEVTRACK_SERVER_URL is not set")
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", c.serverURL+path, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("X-DevTrack-API-Key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST %s%s: %w", c.serverURL, path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Try to extract a detail message from FastAPI error shape.
+		var errResp struct {
+			Detail string `json:"detail"`
+		}
+		if jsonErr := json.Unmarshal(respBody, &errResp); jsonErr == nil && errResp.Detail != "" {
+			return fmt.Errorf("server error (HTTP %d): %s", resp.StatusCode, errResp.Detail)
+		}
+		return fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
+	}
+
+	if dest != nil {
+		if err := json.Unmarshal(respBody, dest); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+
+	log.Printf("✓ Request sent via HTTP → %s%s (%d)", c.serverURL, path, resp.StatusCode)
+	return nil
 }
 
 func (c *HTTPTriggerClient) post(path string, payload interface{}) error {

--- a/uv.lock
+++ b/uv.lock
@@ -534,10 +534,8 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "azure-identity" },
-    { name = "chromadb" },
     { name = "dateparser" },
     { name = "duckdb" },
-    { name = "en-core-web-sm" },
     { name = "fastapi", extra = ["standard"] },
     { name = "fuzzywuzzy" },
     { name = "motor" },
@@ -546,25 +544,26 @@ dependencies = [
     { name = "openai" },
     { name = "openpyxl" },
     { name = "pandas" },
-    { name = "pandas-stubs" },
     { name = "psutil" },
     { name = "pygithub" },
     { name = "pyjwt" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "python-dotenv" },
     { name = "python-levenshtein" },
     { name = "python-telegram-bot" },
     { name = "requests" },
     { name = "runtime-narrative" },
-    { name = "sentence-transformers" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
-    { name = "spacy" },
     { name = "textual" },
 ]
 
 [package.optional-dependencies]
+ai = [
+    { name = "chromadb" },
+    { name = "en-core-web-sm" },
+    { name = "sentence-transformers" },
+    { name = "spacy" },
+]
 anthropic = [
     { name = "anthropic" },
 ]
@@ -582,16 +581,23 @@ openai = [
     { name = "openai" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pandas-stubs" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.13" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.25.0" },
     { name = "anthropic", marker = "extra == 'cloud'", specifier = ">=0.25.0" },
     { name = "azure-identity", specifier = ">=1.23.0" },
-    { name = "chromadb", specifier = ">=0.4.0" },
+    { name = "chromadb", marker = "extra == 'ai'", specifier = ">=0.4.0" },
     { name = "dateparser", specifier = ">=1.2.0" },
     { name = "duckdb", specifier = ">=1.3.1" },
-    { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
+    { name = "en-core-web-sm", marker = "extra == 'ai'", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
     { name = "fuzzywuzzy", specifier = ">=0.18.0" },
     { name = "motor", specifier = ">=3.7.1" },
@@ -603,25 +609,29 @@ requires-dist = [
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=2.3.0" },
-    { name = "pandas-stubs", specifier = "==2.3.2.250926" },
     { name = "plyer", marker = "extra == 'notifications'", specifier = ">=2.1" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pygithub", specifier = ">=2.6.1" },
     { name = "pyjwt", specifier = ">=2.8.0" },
-    { name = "pytest", specifier = ">=7.4.0" },
-    { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "python-levenshtein", specifier = ">=0.21.0" },
     { name = "python-telegram-bot", specifier = ">=22.7" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "runtime-narrative", specifier = ">=0.1.0" },
-    { name = "sentence-transformers", specifier = ">=2.2.0" },
+    { name = "sentence-transformers", marker = "extra == 'ai'", specifier = ">=2.2.0" },
     { name = "slack-bolt", specifier = ">=1.18.0" },
     { name = "slack-sdk", specifier = ">=3.27.0" },
-    { name = "spacy", specifier = ">=3.7.0" },
+    { name = "spacy", marker = "extra == 'ai'", specifier = ">=3.7.0" },
     { name = "textual", specifier = ">=0.65.0" },
 ]
-provides-extras = ["openai", "anthropic", "cloud", "mongodb", "notifications"]
+provides-extras = ["ai", "openai", "anthropic", "cloud", "mongodb", "notifications"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pandas-stubs", specifier = "==2.3.2.250926" },
+    { name = "pytest", specifier = ">=7.4.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21.0" },
+]
 
 [[package]]
 name = "distro"


### PR DESCRIPTION
## Summary

- **`devtrack plan`** — expose the PM Agent as a CLI command; supports inline problem strings, `--file <plan.md>`, and `--folder <dir/>` for batch creation; interactive platform picker (Azure / GitLab / GitHub); two-step preview → confirm → create flow with item counts shown before committing
- **`devtrack boardroom`** — 7 parallel AI personas (Architect, Security, PM, Devil''s Advocate, Engineer, Analyst, Scalability) review a plan and produce PROs/CONs, SWOT analysis, per-persona stances, and a PROCEED/REVISE/RECONSIDER verdict
- **Interactive boardroom REPL** (`-i` flag) — converse with the personas post-review; @mention individuals by name, use `/final` to give your decision and receive AI-generated closing meeting minutes; fully stateless per-turn design

## Files changed

### New Python
- `backend/plan_parser.py` — parses structured markdown plan files (`## Meta / ## Goal / ## Epics / ## Notes`)
- `backend/boardroom/__init__.py` — package exports
- `backend/boardroom/personas.py` — 7 persona definitions + prompt templates
- `backend/boardroom/session.py` — async parallel persona execution + synthesis
- `backend/boardroom/report.py` — ANSI terminal and markdown report formatters
- `backend/boardroom/interactive.py` — per-turn responder selection, persona reply generation, closing summary

### Modified Python
- `backend/webhook_server.py` — adds `POST /trigger/plan/preview`, `/trigger/plan/create`, `/trigger/boardroom`, `/trigger/boardroom/chat`

### New Go
- `devtrack-bin/cli_plan.go` — `devtrack plan` command handler
- `devtrack-bin/cli_boardroom.go` — `devtrack boardroom` command + interactive REPL with ANSI colours and @mention parsing

### Modified Go
- `devtrack-bin/http_trigger.go` — `postWithResult()`, plan/boardroom request-response structs, `SendPlanPreview`, `SendPlanCreate`, `SendBoardroom` (180s timeout), `SendBoardroomChat` (120s timeout)
- `devtrack-bin/cli.go` — register `plan` and `boardroom` commands; update usage text

## Test plan

- [ ] `devtrack plan "build a user auth system"` — shows preview with item counts, prompts platform, creates items on confirm
- [ ] `devtrack plan --file plan.md` — parses structured markdown, reads platform from `## Meta` block
- [ ] `devtrack plan --folder plans/` — processes all `.md` files in folder
- [ ] `devtrack boardroom --file plan.md` — runs 7 personas in parallel, prints coloured report
- [ ] `devtrack boardroom --file plan.md -i` — enters REPL; @alex routes to Architect; `/final "ship it"` prints closing minutes
- [ ] Backend health: `POST /trigger/boardroom` returns `report`, `verdict`, `pros`, `cons` in JSON
- [ ] Daemon not required for `plan` and `boardroom` commands (both in no-daemon list)

Generated with [Claude Code](https://claude.ai/claude-code)