### PR TITLE
fix(ci): GoReleaser and Docker CI fixes for v2.2.17

### DIFF
--- a/devtrack_client/.goreleaser.yaml
+++ b/devtrack_client/.goreleaser.yaml
@@ -9,7 +9,6 @@ before:
 builds:
   - id: devtrack
     main: .
-    dir: devtrack_client
     binary: devtrack
     goos:
       - linux

--- a/devtrack_client/.goreleaser.yaml
+++ b/devtrack_client/.goreleaser.yaml
@@ -33,8 +33,6 @@ archives:
     ids:
       - devtrack
     name_template: "devtrack_{{ .Os }}_{{ .Arch }}"
-    files:
-      - LICENSE
 
 checksum:
   name_template: "checksums.txt"

--- a/devtrack_server/.gitlab-ci.yml
+++ b/devtrack_server/.gitlab-ci.yml
@@ -50,7 +50,7 @@ docker:
   before_script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
   script:
-    - docker build -t $IMAGE -t $IMAGE_LATEST -f Dockerfile.server .
+    - docker build -t $IMAGE -t $IMAGE_LATEST -f Dockerfile .
     - docker push $IMAGE
     - docker push $IMAGE_LATEST
   rules:


### PR DESCRIPTION
## Summary

- Fix `devtrack_server` Docker build: `Dockerfile.server` → `Dockerfile` (file is named `Dockerfile`)
- Fix GoReleaser: remove `dir: devtrack_client` which caused double-nested path lookup since action already sets `workdir: devtrack_client`
- Fix GoReleaser: remove `files: [LICENSE]` from archive config — no LICENSE file exists in the repo

## Context

All three issues surfaced during the v2.2.17 release pipeline. All CI/CD jobs now pass.

## Test plan

- [x] GoReleaser release job — all 5 targets built and archived successfully
- [x] GitLab devtrack_server Docker build job — passes on v2.2.17 tag
- [x] GitLab devtrack_client test job — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)