### PR TITLE
feat(ci): auto-update wiki version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  update-wiki-version:
+    name: Bump version in wiki download page
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Clone wiki repo
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
+        run: |
+          git clone "https://oauth2:${GITLAB_TOKEN}@gitlab.com/devtrack3_cloud/devtrack_wiki.git" wiki
+          cd wiki
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update static fallback version
+        run: |
+          VERSION="${{ github.ref_name }}"
+          sed -i "s|Latest: v[0-9]*\.[0-9]*\.[0-9]*|Latest: ${VERSION}|g" wiki/wiki/download.html
+
+      - name: Commit and push
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
+        run: |
+          cd wiki
+          git diff --quiet && echo "No change needed" && exit 0
+          git add wiki/download.html
+          git commit -m "chore: bump static fallback version to ${{ github.ref_name }}"
+          git push origin main
+


### PR DESCRIPTION
## Summary

- Add `update-wiki-version` job to `release.yml` that runs after GoReleaser succeeds
- Clones the GitLab wiki repo, updates the static fallback version in `download.html`, and pushes
- Uses existing `GITLAB_SYNC_TOKEN` secret — no new secrets needed

## Why

The static fallback version in `download.html` was hardcoded and had to be updated manually on every release. This automates it so the wiki always reflects the latest release version.

## Test plan

- [ ] Push a new `v*` tag and verify the `update-wiki-version` job runs and updates `download.html` on GitLab

🤖 Generated with [Claude Code](https://claude.com/claude-code)