### PR TITLE
fix(installer): Windows install fails on hardcoded devtrack.exe name

### DIFF
--- a/devtrack_wiki/wiki/install.ps1
+++ b/devtrack_wiki/wiki/install.ps1
@@ -30,7 +30,15 @@ try {
     $archivePath = Join-Path $tmpDir $ARCHIVE
     Invoke-WebRequest -Uri $URL -OutFile $archivePath -UseBasicParsing
     Expand-Archive -Path $archivePath -DestinationPath $tmpDir -Force
-    Copy-Item -Path (Join-Path $tmpDir "devtrack.exe") `
+
+    # The archived binary may be named devtrack.exe or devtrack_windows_amd64.exe
+    # depending on how the release was packaged. Locate it regardless of name.
+    $exe = Get-ChildItem -Path $tmpDir -Filter "*.exe" -Recurse | Select-Object -First 1
+    if (-not $exe) {
+        Write-Error "Downloaded archive did not contain a devtrack executable."
+        exit 1
+    }
+    Copy-Item -Path $exe.FullName `
               -Destination (Join-Path $INSTALL_DIR "devtrack.exe") -Force
 } finally {
     Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -113,8 +113,11 @@ go build -ldflags $ldflags -o "..\$dist\devtrack_windows_amd64.exe" .
 $env:GOOS = ""; $env:GOARCH = ""; $env:CGO_ENABLED = ""
 
 Push-Location ..\$dist
-Compress-Archive -Path devtrack_windows_amd64.exe -DestinationPath devtrack_windows_amd64.zip
-Remove-Item devtrack_windows_amd64.exe
+# Rename to devtrack.exe inside the zip so the installer finds it under a stable
+# name (mirrors the macOS/Linux tarballs which archive the binary as `devtrack`).
+Rename-Item devtrack_windows_amd64.exe devtrack.exe
+Compress-Archive -Path devtrack.exe -DestinationPath devtrack_windows_amd64.zip
+Remove-Item devtrack.exe
 Pop-Location
 
 Pop-Location  # back to repo root


### PR DESCRIPTION
## Problem

Windows installs via `irm https://devtrack.cloud/install.ps1 | iex` fail with:

```
Copy-Item: Cannot find path '...\devtrack.exe' because it does not exist.
```

The release zip contains `devtrack_windows_amd64.exe` (the Go build output name), but `install.ps1` copied a hardcoded `devtrack.exe` that is not present in the archive. The macOS/Linux tarballs rename the binary to `devtrack` before archiving (`release.ps1`), but the Windows path never did — so the installer and packager disagreed on the name.

## Fix

- **`install.ps1`** — locate the `.exe` in the extracted archive via `Get-ChildItem` instead of hardcoding the name. Works with the **already-published v3.0.0 zip** (no re-release required) and any future naming.
- **`release.ps1`** — rename the Windows binary to `devtrack.exe` before zipping, mirroring the macOS/Linux convention so future zips are self-consistent.

## Verification

Tested against the live v3.0.0 zip in an isolated temp dir (no PATH/Netlify side effects): download → extract → locate `devtrack_windows_amd64.exe` → copy as `devtrack.exe` → binary runs and prints its help. PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)