### PR TITLE
fix(wiki): fix Windows installer — .exe not .zip

### DIFF
--- a/devtrack_wiki/wiki/download.html
+++ b/devtrack_wiki/wiki/download.html
@@ -312,8 +312,8 @@
       <div class="platform-icon">🪟</div>
       <div class="platform-name">Windows</div>
       <div class="platform-arch">x86_64 · amd64</div>
-      <a class="dl-btn dl-btn-secondary" href="#" id="dl-windows-amd64" data-platform="windows" data-arch="amd64" data-ext="zip">
-        ↓ Download .zip
+      <a class="dl-btn dl-btn-secondary" href="#" id="dl-windows-amd64" data-platform="windows" data-arch="amd64" data-ext="exe">
+        ↓ Download .exe
       </a>
       <div style="font-size:.75rem;color:var(--muted);margin-top:4px;">or use the PowerShell one-liner below</div>
     </div>

--- a/devtrack_wiki/wiki/install.ps1
+++ b/devtrack_wiki/wiki/install.ps1
@@ -15,36 +15,24 @@ try {
     exit 1
 }
 
-$ARCHIVE = "devtrack_windows_amd64.zip"
-$URL     = "https://github.com/$REPO/releases/download/$VERSION/$ARCHIVE"
+$EXE = "devtrack_windows_amd64.exe"
+$URL = "https://github.com/$REPO/releases/download/$VERSION/$EXE"
 
 Write-Host "Detected: windows/amd64"
 Write-Host "Downloading DevTrack $VERSION..."
 
 New-Item -ItemType Directory -Force -Path $INSTALL_DIR | Out-Null
 
-$tmpDir = Join-Path $env:TEMP "devtrack_install_$([System.IO.Path]::GetRandomFileName())"
-New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+$destPath = Join-Path $INSTALL_DIR "devtrack.exe"
 
 try {
-    $archivePath = Join-Path $tmpDir $ARCHIVE
-    Invoke-WebRequest -Uri $URL -OutFile $archivePath -UseBasicParsing
-    Expand-Archive -Path $archivePath -DestinationPath $tmpDir -Force
-
-    # The archived binary may be named devtrack.exe or devtrack_windows_amd64.exe
-    # depending on how the release was packaged. Locate it regardless of name.
-    $exe = Get-ChildItem -Path $tmpDir -Filter "*.exe" -Recurse | Select-Object -First 1
-    if (-not $exe) {
-        Write-Error "Downloaded archive did not contain a devtrack executable."
-        exit 1
-    }
-    Copy-Item -Path $exe.FullName `
-              -Destination (Join-Path $INSTALL_DIR "devtrack.exe") -Force
-} finally {
-    Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+    Invoke-WebRequest -Uri $URL -OutFile $destPath -UseBasicParsing
+} catch {
+    Write-Error "Download failed: $_"
+    exit 1
 }
 
-Write-Host "Installed to $INSTALL_DIR\devtrack.exe"
+Write-Host "Installed to $destPath"
 
 # Add install dir to user PATH if not already present
 $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")


### PR DESCRIPTION
## Summary
- `install.ps1` was trying to download `devtrack_windows_amd64.zip` and `Expand-Archive` it, but the release pipeline only publishes a raw `.exe` — causing a 404 and a broken one-liner
- Download button on `download.html` was also linking to the non-existent `.zip`

## Changes
- `install.ps1`: downloads `devtrack_windows_amd64.exe` directly, writes it to `%LOCALAPPDATA%\DevTrack\devtrack.exe`
- `download.html`: `data-ext="zip"` → `data-ext="exe"`, button label updated to `.exe`

## Test plan
- [ ] `irm https://devtrack.cloud/install.ps1 | iex` succeeds on Windows (fetches the `.exe` asset)
- [ ] Windows download button on devtrack.cloud/download links to `devtrack_windows_amd64.exe`
- [ ] Linux/macOS flows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)