### PR TITLE
chore(docs): bump all version refs to v3.0.10; add Phase 0 board tasks

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,6 +1,6 @@
 # DevTrack Project Memory
 
-_Last updated: 2026-06-10_ | v3.0.9 | GitHub sole source of truth; devtrack.cloud live on Netlify
+_Last updated: 2026-06-14_ | v3.0.10 | GitHub sole source of truth; devtrack.cloud live on Netlify
 
 DevTrack: offline-first Go daemon + Python backend — monitors git/timers, enriches with AI, routes to PM systems.
 
@@ -14,7 +14,7 @@ DevTrack: offline-first Go daemon + Python backend — monitors git/timers, enri
 - [feedback_rules.md](feedback_rules.md) — Git/PR/commit rules, offline-first, CLI-only, no hardcoded values, GIT_NO_DEVTRACK, ARCHITECTURE.md boundary, uv not pip
 
 ## Project State
-- [project_current_state.md](project_current_state.md) — post-pivot direction (Bible Phase 0→8); v3.0.9 shipped; PG-5/Redis deprioritised; Azure WIQL date quirk; notify interface pitfall
+- [project_current_state.md](project_current_state.md) — post-pivot direction (Bible Phase 0→8); v3.0.10 shipped (significant Windows fixes); PG-5/Redis deprioritised; Azure WIQL date quirk; notify interface pitfall
 
 ## Project Context
 - [project_platform_modes.md](project_platform_modes.md) — Managed/Lightweight/External modes; Windows WSL2 dev; ARM64 .syso fix shipped

--- a/.claude/memory/project_current_state.md
+++ b/.claude/memory/project_current_state.md
@@ -1,10 +1,10 @@
 ---
 name: Project current state
-description: Post-pivot (2026-06-10) — direction now PRODUCT_BIBLE.md Phase 0→8; v3.0.9 shipped; platform quirks
+description: Post-pivot (2026-06-10) — direction now PRODUCT_BIBLE.md Phase 0→8; v3.0.10 shipped; platform quirks
 type: project
 ---
 
-**Version:** v3.0.9 (latest tag). Active branch: `dev`. GitHub (`sraj0501/Devtrack_`) sole source. Releases: `.\scripts\release.ps1 [-Bump patch|minor|major]`.
+**Version:** v3.0.10 (latest tag). Active branch: `dev`. GitHub (`sraj0501/Devtrack_`) sole source. Releases: `.\scripts\release.ps1 [-Bump patch|minor|major]`.
 
 **Migration COMPLETE (2026-06-10):** GitLab→GitHub migration achieved. The `migration` branch and the `gitlab-client` / `gitlab-server` / `gitlab-wiki` remotes are now vestigial — safe to remove. (Former "do NOT delete `migration`" protection lifted.)
 
@@ -12,7 +12,7 @@ type: project
 
 **Go internal packages** (`devtrack_client/internal/`): `config`, `db`, `health`, `learning`, `trigger`, `infra`, `daemon`, `tui`, `match`, `alerts`, `notify`, `telegram`. Layer: config/db/health/learning ← trigger ← infra ← daemon; trigger ← tui.
 
-**Recently shipped (v3.0 line):** `motor` optional dep; `upgrade.go` → GitHub API + semver guard; Telegram bot migrated to Go (`internal/telegram/`); boardroom + `devtrack plan` live; Windows CLI parity + autostart (Task Scheduler); automated GitHub Actions release pipeline; stale-health fix (migration 005 prunes legacy Redis/MongoDB rows); v3.0.9 `skip_issues` workspace field for dual-platform (GitHub+ADO) duplicate-ticket fix (`ResolveWorkspaceForPath` prefers non-skip at equal depth).
+**Recently shipped (v3.0 line):** `motor` optional dep; `upgrade.go` → GitHub API + semver guard; Telegram bot migrated to Go (`internal/telegram/`); boardroom + `devtrack plan` live; Windows CLI parity + autostart (Task Scheduler); automated GitHub Actions release pipeline; stale-health fix (migration 005 prunes legacy Redis/MongoDB rows); v3.0.9 `skip_issues` workspace field for dual-platform (GitHub+ADO) duplicate-ticket fix; v3.0.10 significant Windows fixes (isatty via mattn/go-isatty, editor-commit BeforeCommit/AfterCommit hooks, background auto-enhance via `DEVTRACK_AUTO_ENHANCE=true`).
 
 **NEXT — driven by PRODUCT_BIBLE.md (pivot 2026-06-10):** Phase 0 remove TUI prompts from trigger flow (silent daemon) → Phase 1 pending actions queue (the trust primitive) → Phase 2 opinionated ticket extractor (branch→ticket) → Phase 3 silent commit handler → Phase 4 EOD pipeline → Phases 5-8 voice training, dialectic self-improvement, TUI-as-visibility, PR-review puppet master. See `Data/agent_logs/project_board.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ PM connectors, gitsage, and alerts are Go-native and work in all modes.
 - **Board & history:** `Data/agent_logs/project_board.md` (current tasks) and `feature_tracker.md`.
 - **Shipped (v3.x):** three-codebase split (EPIC-SPLIT); client-server decoupling (Go-native
   connectors, gitsage, alerts, Telegram bot); CS-1 HTTP transport; CS-3 admin UI; boardroom + plan;
-  automated release pipeline; v3.0.9 `skip_issues`.
+  automated release pipeline; v3.0.9 `skip_issues`; v3.0.10 Windows fixes (isatty, editor hooks, auto-enhance).
 - **Docs:** `docs/ARCHITECTURE.md`, `docs/CAPABILITIES_OWNERSHIP.md`,
   `docs/CLIENT_SERVER_DECOUPLING_PLAN.md`, `docs/TELEGRAM_BOT.md`, `docs/split-manifest.md`.
 

--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -2,6 +2,18 @@
 
 ---
 
+### [2026-06-14 15:13] Ad-hoc — docs(bible): merge Phase 1+7; add second brain vision, #13 non-negotiable, Phase 8 MCP server
+
+**Original message**: "docs(bible): merge Phase 1+7; add second brain vision, #13 non-negotiable, Phase 8 MCP server"
+**DevTrack enhanced it to**: "feat(docs): Merge Phase 1, 7 & add Second Brain/MCP vision"
+**Ticket auto-linked**: NO
+**PM system updated**: YES — engineer_log.md updated; pushed to origin/dev
+**Time**: ~3 minutes
+**Friction**: LOW — stash/checkout dev/stash-pop required (change was on main); daemon needed a start; otherwise clean
+**Notes**: PRODUCT_BIBLE.md-only commit. Changes: (1) "second brain" + MCP positioning paragraph added to The Vision section; (2) non-negotiable #13 added (client is sole interface to all server capabilities, rolling capability audit); (3) Phase 1 expanded to "Pending Queue + TUI Confidence Layer" — former Phase 7 merged in as the adoption gate; (4) old Phase 7 removed; (5) old Phase 8 → Phase 7; (6) new Phase 8 = MCP Server + Headless Integration with 7 MCP tools specified; (7) version history row added for 2026-06-14. File: 80 insertions, 14 deletions. Commit hash: feaea28.
+
+---
+
 ### [2026-06-14 14:19] SESSION — feat(gitsage): Windows isatty fix, editor-commit hooks, background auto-enhance
 
 **Original message**: "feat(gitsage): fix Windows isatty, fire hooks on editor commits, add background auto-enhance ..."

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1,9 +1,9 @@
 # DevTrack Project Board
 
-_Last updated: 2026-06-14 by engineer_
-_Next DevTrack task ID: TASK-057_
+_Last updated: 2026-06-14 by PM (Phase 0 decomposition)_
+_Next DevTrack task ID: TASK-060_
 _Active branch: `dev`_
-_Shipped: v3.0.9 (2026-06-09) — skip_issues dual-platform fix._
+_Shipped: v3.0.10 (2026-06-14) — significant Windows fixes + gitsage improvements._
 _Direction: **PRODUCT_BIBLE.md** (pivot 2026-06-10) — `../../PRODUCT_BIBLE.md`_
 
 **[2026-06-14] Ad-hoc session commit** — commit `0a9d9a7` on dev, pushed; PR #161 (dev → main) opened.
@@ -34,7 +34,145 @@ Existing PM sync, LLM pipeline, and git monitor remain untouched.
 
 **Exit criterion**: Daemon runs for a full day with no prompts shown.
 
-**Status**: NOT STARTED — next up. Tasks to be decomposed by project-vision.
+**Status**: DECOMPOSED — 3 tasks ready to dispatch.
+
+---
+
+### TASK-057 — Silence handleTrigger stdout in integrated.go
+**Priority**: HIGH
+**Phase**: Phase 0
+**Depends on**: none
+**Branch**: `fix/TASK-057-silence-handle-trigger`
+
+**Spec**:
+The function `handleTrigger` in `devtrack_client/internal/infra/integrated.go`
+(lines 347–479) prints a full decorative banner to stdout on every commit and
+timer trigger. This banner (15–20 `fmt.Print*` calls) violates PRODUCT_BIBLE.md
+Non-Negotiable #1 ("no prompts in the main flow") and is the only active source
+of terminal output in the trigger flow.
+
+Changes required, **all inside `handleTrigger()`**:
+
+1. Replace every `fmt.Print*` call with `log.Printf` / `log.Println` (which go
+   to the log file, not the terminal). The information (commit hash, message,
+   author, files, workspace, trigger count, interval) is still useful in the log;
+   keep it as a structured log line.
+2. The decorative separator lines (`strings.Repeat("═", 60)`) and "What happens
+   next:" paragraph are redundant in the log — remove them entirely. One log line
+   per trigger is enough.
+3. The "Waiting for next event..." line must be removed entirely.
+4. `strings` import may become unused after the change — remove it if so (run
+   `go vet ./...` to verify). Other uses of `strings` in the same file
+   (`strings.EqualFold`, `strings.TrimSpace`, `strings.Join`) must be checked
+   before dropping the import.
+5. The `TestIntegrated()` function lower in the file also contains `fmt.Print*`
+   calls — those are in a dev-test helper, not the live trigger path. Leave them
+   as-is; the function is never called in production.
+
+After the change, `handleTrigger` must contain zero `fmt.Print*` calls.
+The function must still: log the trigger type + key fields at `log.Printf` level,
+persist the trigger record to SQLite, and send the HTTP trigger to the Python
+server — all unchanged.
+
+**Acceptance criteria**:
+- [ ] `grep -n "fmt\.Print" devtrack_client/internal/infra/integrated.go` returns
+      only matches inside `TestIntegrated()` (line ~510 onward), zero matches in
+      `handleTrigger`.
+- [ ] `go build ./...` passes with no errors from `devtrack_client/`.
+- [ ] `go vet ./...` passes clean.
+- [ ] The daemon log (`Data/logs/daemon.log`) still shows commit/timer events as
+      log lines when the daemon runs.
+- [ ] No terminal output appears when a commit fires while the daemon is running
+      in the background.
+
+**Engineer status**: not started
+**Blockers**: none
+
+---
+
+### TASK-058 — Remove or gate user_prompt.py from trigger path (Python server)
+**Priority**: MEDIUM
+**Phase**: Phase 0
+**Depends on**: TASK-057 (can be worked in parallel — different file, different codebase)
+**Branch**: `fix/TASK-058-remove-user-prompt-trigger`
+
+**Spec**:
+`devtrack_server/backend/user_prompt.py` defines `DevTrackTUI` and
+`prompt_work_update()`, which can block the process waiting for stdin input.
+Current state: `TriggerProcessor.process_commit()` and `process_timer()` in
+`webhook_server.py` do NOT call `user_prompt` — the trigger path is already clean.
+However, the module still exists and could be accidentally re-introduced.
+
+Changes required:
+
+1. Search the entire `devtrack_server/backend/` tree for any remaining import of
+   `user_prompt` or call to `DevTrackTUI` / `prompt_work_update` / `prompt_user`
+   outside of test files and the `__main__` block in `user_prompt.py` itself.
+   Command: `grep -rn "user_prompt\|DevTrackTUI\|prompt_work_update\|prompt_for_work_update" devtrack_server/backend/ --include="*.py"`
+2. If any non-test file imports `user_prompt` for use in a trigger path, remove
+   or replace that call with a `logger.info()`.
+3. Add a module-level docstring to `user_prompt.py` (top of file, after the
+   existing docstring) noting:
+   `# STATUS: Legacy module. Not called from any trigger path as of Phase 0.`
+   `# Safe to delete once the TUI correction interface (Phase 7) is implemented.`
+   Do NOT delete the file — it will be repurposed for the Phase 7 TUI visibility
+   interface.
+4. Run `uv run pytest backend/tests/ -q` to confirm no tests regress.
+
+**Acceptance criteria**:
+- [ ] `grep -rn "user_prompt\|DevTrackTUI\|prompt_work_update" devtrack_server/backend/ --include="*.py"` returns zero hits outside `user_prompt.py` itself and `test_user_prompt.py`.
+- [ ] `uv run pytest backend/tests/ -q` passes (or has the same pre-existing
+      failures as before this task — document any pre-existing failures in the
+      engineer log).
+- [ ] The module-level status comment is present at the top of `user_prompt.py`.
+
+**Engineer status**: not started
+**Blockers**: none
+
+---
+
+### TASK-059 — Verify Phase 0 exit criterion: daemon silent for a full session
+**Priority**: HIGH
+**Phase**: Phase 0
+**Depends on**: TASK-057, TASK-058
+**Branch**: `fix/TASK-059-phase0-verification`
+
+**Spec**:
+This is the verification and cleanup task that closes Phase 0. It produces no new
+feature code — only a verification run, any small fixes found during verification,
+and the board/log updates that mark Phase 0 done.
+
+Steps:
+
+1. Build the client binary from `devtrack_client/`: `go build -o devtrack .`
+2. Start the daemon: `devtrack start`
+3. Make at least 2 commits in a watched repo (can be empty commits:
+   `git commit --allow-empty -m "phase0 test 1"`).
+4. Wait for at least one timer trigger to fire (set `PROMPT_INTERVAL=1` in `.env`
+   for the test, restore after).
+5. Check `Data/logs/daemon.log`: confirm trigger events appear as log lines.
+6. Check the terminal where the daemon was launched (or attached to): confirm
+   zero trigger banners / prompts appear.
+7. Run `grep -n "fmt\.Print" devtrack_client/internal/infra/integrated.go` and
+   confirm no matches in `handleTrigger`.
+8. Run the full hardcoded-values scan (PM responsibility, run before closing):
+   ```
+   grep -rn "localhost:[0-9]\|127\.0\.0\.1:[0-9]" devtrack_client/ --include="*.go" | grep -v "_test\|#\|config\|Get"
+   grep -rn "os\.getenv\b" devtrack_server/backend/ --include="*.py" | grep -v "config\.py\|conftest\|test_"
+   ```
+9. Update `Data/agent_logs/feature_tracker.md` with Phase 0 completion entry.
+10. Open a PR targeting `dev` with title "Phase 0: silent daemon trigger flows".
+
+**Acceptance criteria**:
+- [ ] Zero terminal output from daemon during normal commit/timer operation.
+- [ ] `Data/logs/daemon.log` contains structured log lines for each trigger.
+- [ ] Hardcoded-values scan is clean (no new violations).
+- [ ] `go build ./...` and `go vet ./...` pass clean.
+- [ ] PR opened targeting `dev` (never `main`).
+- [ ] Feature tracker updated.
+
+**Engineer status**: not started
+**Blockers**: TASK-057 and TASK-058 must be complete
 
 ---
 
@@ -74,6 +212,7 @@ Product Bible phases — not cancelled, just not now.
 ### v3.x line (2026-05 → 2026-06)
 | Version | What |
 |---|---|
+| v3.0.10 | Significant Windows fixes: isatty via mattn/go-isatty; editor-commit hooks; auto-enhance (`DEVTRACK_AUTO_ENHANCE=true`) |
 | v3.0.9 | TASK-056 — `skip_issues` flag; dual-platform duplicate-ticket fix |
 | v3.0.8 | Stale health snapshot fix; migration 005 prunes legacy Redis/MongoDB rows |
 | v3.0.7 | Automated GitHub Actions release pipeline (`release.yml`) |

--- a/PRODUCT_BIBLE.md
+++ b/PRODUCT_BIBLE.md
@@ -47,6 +47,15 @@ PR review queues clear autonomously.
 > You write code. DevTrack handles the rest — silently, accurately, in your voice,
 > getting better every day.
 
+As DevTrack accumulates context — commits, ticket interactions, approvals, edits,
+corrections — it becomes the developer's **second brain**: the local knowledge layer
+that knows what was worked on, what was decided, what is pending, and how the developer
+communicates. This context is exposed to other AI tools via MCP (Model Context Protocol),
+making DevTrack the context layer for every AI assistant in the developer's environment.
+Claude Code knows the active ticket without being told. Copilot understands what is
+in-flight. Any MCP-capable tool inherits the developer's history and voice automatically.
+DevTrack does not replace AI coding assistants — it is the memory they lack.
+
 ---
 
 ## Non-Negotiables
@@ -123,6 +132,16 @@ earned by track record, not assumed from day one.
 The CLI, TUI, Telegram bot, and email are delivery channels for daemon output.
 Features live in the daemon. Removing an interface removes visibility — it never
 removes capability.
+
+### 13. The client is the sole user-facing interface to all capabilities
+Every capability the Python server exposes — report generation, NLP pipeline,
+personalization sync, boardroom, plan review, voice management — must be reachable
+via a `devtrack` CLI command. The server is a backend; the client is the gateway.
+No feature is server-exclusive. The capability surface of the CLI and the server must
+stay in sync: when a server capability is added, the client command is added in the
+same phase. Exceptions are permitted only for security-administrative functions
+(admin UI, license management) that require server-direct access by nature. The
+capability audit is a rolling checklist, updated with each phase.
 
 ---
 
@@ -425,12 +444,34 @@ fully silent. The daemon no longer asks anything during normal operation.
 Existing PM sync, LLM pipeline, and git monitor remain untouched.
 **Exit criterion:** Daemon runs for a full day with no prompts shown.
 
-### Phase 1 — Pending actions queue
-New SQLite table: `pending_actions`. Every outbound PM action staged here. Configurable
-timeout with auto-approve. Confidence score on every action. TUI and Telegram show queue.
-Nothing posts to external systems without clearing this table.
-**Exit criterion:** Developer can run for a week, review the queue each evening, and
-trust that nothing unexpected posted.
+### Phase 1 — Pending Queue + TUI Confidence Layer
+New SQLite table: `pending_actions`. Every outbound PM action staged here before it
+touches any external system. Confidence score on every action. Configurable timeout
+with auto-approve. Nothing posts without clearing this table.
+
+The TUI confidence layer is built alongside the queue — not deferred to a later phase.
+A developer who can see exactly what DevTrack is about to post, with a countdown timer
+and one-keystroke approve/reject, builds trust far faster than one who discovers what
+posted after the fact. This is the adoption gate: without visible, controllable pending
+actions the product cannot earn the permission to act autonomously.
+
+**TUI panels shipped in this phase:**
+- Pending queue: confidence scores, countdown timers, approve / reject / edit controls
+- Activity feed: last 24 hours of daemon actions
+- Low-confidence flags requiring a glance
+- Today's summary: commits, tickets touched, actions taken
+- System health: daemon status, LLM availability, PM connectivity
+
+Telegram also surfaces the queue and accepts approve/reject commands. Channel parity
+rule (non-negotiable #4) applies from day one: every correction action in the TUI must
+also be available via Telegram or CLI. The TUI is a read + correct interface only — it
+never asks for input, never gates features, never blocks the developer.
+
+**Exit criterion:** Developer runs for a week, opens TUI at any time, immediately
+understands everything DevTrack did in the last 24 hours and everything it is about
+to do, approves or rejects pending actions in one keystroke, and trusts that nothing
+unexpected posted. At least one auto-approve timeout has been extended based on
+observed accuracy.
 
 ### Phase 2 — Opinionated ticket extractor
 Branch regex → ticket ID. Commit message keyword parsing. Active ticket fallback.
@@ -475,20 +516,44 @@ evidence. Developer can correct wrong inferences directly.
 text is measurably lower than day 1. At least three autonomous skills have emerged
 without developer input. Developer has extended at least one auto-approve threshold.
 
-### Phase 7 — TUI as visibility and correction layer
-Reframe TUI entirely: activity feed, pending queue with confidence indicators,
-correction interface for low-confidence actions, today's stats, system health.
-Remove all input prompts. The TUI is a read + correct interface, never an input interface.
-**Exit criterion:** Developer can open TUI at any time and immediately understand
-everything DevTrack did in the last 24 hours and everything it is about to do.
-
-### Phase 8 — PR review loop (puppet master)
+### Phase 7 — PR review loop (puppet master)
 PR review event detection via existing alert poller. LLM classification of each
 comment. Headless invocation of Claude Code CLI or Copilot CLI. Fix-commit-push loop.
 Escalation to developer with full context when stuck. Developer notified only on
 completion or genuine blocker.
 **Exit criterion:** Developer pushes a PR with formatting and naming review comments,
 moves to next ticket, receives "PR approved" notification without touching the PR again.
+
+### Phase 8 — MCP Server + Headless Integration
+DevTrack exposes itself as an MCP (Model Context Protocol) server so AI coding
+assistants — Claude Code, GitHub Copilot, Cursor, or any MCP-capable client — can
+call DevTrack's context and capabilities programmatically. Phase 7 runs DevTrack →
+Claude Code (DevTrack orchestrates Claude Code for PR fixes). This phase adds the
+other direction: Claude Code → DevTrack (Claude Code queries DevTrack for developer
+context during any task).
+
+**MCP tools exposed:**
+
+| Tool | What it returns |
+|---|---|
+| `get_active_context` | Current active ticket, branch, today's commits, confidence |
+| `get_today_commits` | All commits today, grouped by ticket, with metadata |
+| `get_pending_actions` | Queue contents: action type, generated text, confidence, expiry |
+| `stage_action` | Stage a new pending action from an external agent |
+| `get_voice_profile` | Developer's inferred writing style for a given context type |
+| `get_ticket_context` | Full context for a named ticket: recent commits, comments, state |
+| `get_eod_summary` | Today's EOD narrative draft |
+
+**Transport:** MCP server runs over stdio (for Claude Code CLI integration) and
+optionally over HTTP with SSE (for IDE extensions). The Go client hosts the MCP
+server — no Python dependency required for context access, since all context data
+lives in SQLite. Generation calls proxy to the Python server only when LLM output
+is needed.
+
+**Exit criterion:** Developer runs Claude Code on a task; Claude Code automatically
+knows the active ticket, the developer's commit voice, and what is in the pending
+queue without any manual context-setting. DevTrack and Claude Code operate as
+complementary layers — DevTrack is the memory Claude Code lacks.
 
 ---
 
@@ -547,4 +612,5 @@ to be reworked, not patched.
 | 2026-06-10 | Initial version | Shashank Raj + Claude |
 | 2026-06-10 | Learning system: dialectic user modeling pattern (inspired by Honcho/Hermes Agent); voice layer: persona model pattern (inspired by Nous Hermes); profile as mirror not mask | Shashank Raj + Claude |
 | 2026-06-10 | Layer 3: channel parity rule for corrections — approve/reject/edit must exist on at least one non-TUI channel. Justification: the TUI-optional principle (non-negotiables #4, #12) is only enforceable if corrections are never TUI-exclusive. | Shashank Raj + Claude |
+| 2026-06-14 | Second brain positioning added to Vision. Non-negotiable #13: client is sole interface to all server capabilities (rolling capability audit). Phase 1 expanded to include TUI confidence layer (merged former Phase 7) — adoption gate: pending queue and TUI ship together. Phases renumbered: old Phase 7 removed, old Phase 8 → Phase 7, new Phase 8 = MCP server + headless integration. | Shashank Raj + Claude |
 

--- a/devtrack_wiki/wiki/download.html
+++ b/devtrack_wiki/wiki/download.html
@@ -279,7 +279,7 @@
     <div class="section-label">Download</div>
     <h1 class="dl-title">DevTrack <span class="grad-text">CLI</span></h1>
     <p class="dl-sub">Single self-contained binary. Works standalone for git tracking, smart commits, and PM sync — add the optional Python server for AI work updates, reporting, and personalization.</p>
-    <div id="version-badge">Latest: v3.0.8</div>
+    <div id="version-badge">Latest: v3.0.10</div>
   </div>
 
   <!-- ── Platform cards ── -->

--- a/devtrack_wiki/wiki/wiki.html
+++ b/devtrack_wiki/wiki/wiki.html
@@ -556,7 +556,7 @@
         </div>
       </a>
       <div class="sidebar-version">
-        <span class="sidebar-version-tag">v3.0.9</span>
+        <span class="sidebar-version-tag">v3.0.10</span>
         <span class="sidebar-version-status">
           <span class="sidebar-version-dot"></span>
           live
@@ -587,7 +587,7 @@
         <span class="current" id="breadcrumbCurrent">Home</span>
       </div>
       <div class="topbar-actions">
-        <span class="version-chip">v3.0.9</span>
+        <span class="version-chip">v3.0.10</span>
         <button class="icon-btn" id="themeToggle" title="Toggle theme">
           <svg id="themeIcon" viewBox="0 0 20 20" fill="currentColor"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
         </button>
@@ -1707,7 +1707,18 @@ devtrack start</code></pre>
 
   WHATS_NEW: `<div class="md-body">
 <h1>What's New</h1>
-<div class="home-badge" style="margin-bottom:24px;background:var(--callout-tip);border-color:var(--callout-tip-border);color:#166534;">v3.0.9 — latest</div>
+<div class="home-badge" style="margin-bottom:24px;background:var(--callout-tip);border-color:var(--callout-tip-border);color:#166534;">v3.0.10 — latest</div>
+
+<h2>v3.0.10 — Windows Fixes &amp; gitsage Improvements</h2>
+<p>Significant quality-of-life improvements for Windows users and gitsage power users. Terminal detection is now reliable on Windows, the editor-commit workflow gained lifecycle hooks, and commit enhancement can now run in the background automatically.</p>
+<div class="feature-list" style="margin-bottom:32px;">
+  <div class="feature-item"><div class="feature-dot">1</div><div><h4>Windows terminal detection fixed (isatty)</h4><p>The daemon and CLI previously misdetected Windows terminals, causing incorrect colour/prompt decisions. Switched to <code>mattn/go-isatty</code> for reliable cross-platform TTY detection — no more garbled output or missing colour on Windows Terminal and PowerShell.</p></div></div>
+  <div class="feature-item"><div class="feature-dot">2</div><div><h4>Editor-commit lifecycle hooks</h4><p><code>devtrack git commit</code> now fires <code>BeforeCommit</code> and <code>AfterCommit</code> hooks around the editor session, enabling pre-commit validation and post-commit automation without blocking the interactive editor flow.</p></div></div>
+  <div class="feature-item"><div class="feature-dot">3</div><div><h4>Background auto-enhance (opt-in)</h4><p>Set <code>DEVTRACK_AUTO_ENHANCE=true</code> in <code>.env</code> to have commit messages automatically enhanced in the background after every commit — no manual <code>devtrack git commit</code> required. Enhancement failures degrade silently; your original message is never lost.</p></div></div>
+</div>
+
+<hr>
+<div class="home-badge" style="margin-bottom:24px;background:var(--callout-tip);border-color:var(--callout-tip-border);color:#166534;">v3.0.9 — previous</div>
 
 <h2>v3.0.9 — Dual-Platform Workspace Deduplication</h2>
 <p>When a project uses both GitHub (for code review) and Azure DevOps (for project management), two workspace entries share the same repository path. <code>devtrack issues</code> previously iterated all enabled workspaces and concatenated results, producing a duplicate-looking ticket list. The new <code>skip_issues: true</code> field marks a workspace as code-only so it is excluded from <code>devtrack issues</code>, ticket sync, and the commit-time ticket picker.</p>
@@ -3856,7 +3867,7 @@ function renderHome() {
   const content = document.getElementById('content');
   content.innerHTML = `
     <div class="home-hero">
-      <div class="home-badge">Local-First · v3.0.9</div>
+      <div class="home-badge">Local-First · v3.0.10</div>
       <h1 class="home-title">Developer automation<br>that handles the <span>overhead</span>.</h1>
       <p class="home-sub">DevTrack monitors your Git activity, prompts for work updates, routes them through AI, and keeps your project management systems in sync — all running locally on your machine.</p>
     </div>
@@ -3864,7 +3875,7 @@ function renderHome() {
     <div class="home-grid">
       ${[
         // ── Get Started ────────────────────────────────────────────────────────
-        { id:'WHATS_NEW',        icon:'🎉', title:"What's New",         desc:'v3.0.9: <code>skip_issues: true</code> workspace flag prevents duplicate tickets when a project uses both GitHub and Azure DevOps. v3.0.8: Stale Redis/MongoDB health rows fixed. v3.0.7: Automated release pipeline via GitHub Actions.' },
+        { id:'WHATS_NEW',        icon:'🎉', title:"What's New",         desc:'v3.0.10: Significant Windows fixes — terminal detection via mattn/go-isatty, editor-commit hooks, and background auto-enhance. v3.0.9: <code>skip_issues: true</code> workspace flag prevents duplicate tickets when a project uses both GitHub and Azure DevOps. v3.0.8: Stale Redis/MongoDB health rows fixed.' },
         { id:'DEVTRACK_SERVER',  icon:'🖥️', title:'devtrack-server CLI', desc:'Standalone management CLI for headless server deployments. Bundled in the <code>devtrack-server-*.tar.gz</code> release tarball. Handles install, setup wizard, and daemon lifecycle without cloning the repo.' },
         { id:'UPGRADE',          icon:'⬆️', title:'Self-Update',         desc:'<code>devtrack upgrade</code> downloads the latest binary from GitHub Releases (Windows gets <code>.zip</code>), runs versioned migrations, and auto-restarts the daemon. Unix: <code>sudo cp</code> fallback for root-owned paths. Windows: Administrator guidance.' },
         { id:'UNINSTALL',        icon:'🗑️', title:'Uninstall',           desc:'<code>devtrack uninstall [--yes]</code> — clean, interactive removal: stops daemon, removes autostart, deletes <code>Data/</code> and <code>~/.devtrack/</code>, and removes the binary. Cross-platform (macOS/Linux/Windows). Your <code>.env</code> and git repos are left intact.' },


### PR DESCRIPTION
## Summary
- **Wiki** (devtrack.cloud): download page, sidebar, topbar, home hero, and What's New section all updated to v3.0.10; new v3.0.10 changelog entry added (isatty fix, editor-commit hooks, background auto-enhance)
- **CLAUDE.md**: Project Status shipped line mentions v3.0.10 Windows fixes
- **Project board** (`project_board.md`): Phase 0 decomposed into TASK-057/058/059, v3.0.10 added to shipped history table
- **Memory** (`.claude/memory/`): version and state updated to v3.0.10

## Test plan
- [ ] devtrack.cloud wiki shows v3.0.10 in sidebar, topbar, and home badge after Netlify deploy
- [ ] What's New page leads with v3.0.10 entry
- [ ] Download page shows "Latest: v3.0.10"
- [ ] No broken layout (new release block uses identical HTML pattern to v3.0.9 block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)