### PR TITLE
fix(server): gate user_prompt.py from trigger path — TASK-058

### DIFF
--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -2,6 +2,30 @@
 
 ---
 
+### [2026-06-14 15:45] TASK-057 — fix(infra): silence handleTrigger stdout in integrated.go
+
+**Original message**: "fix(infra): silence handleTrigger stdout — TASK-057"
+**DevTrack enhanced it to**: "fix(infra): Silence stdout output from handleTrigger function"
+**Ticket auto-linked**: NO
+**PM system updated**: YES — project_board.md updated; PR #163 opened targeting dev
+**Time**: ~10 minutes
+**Friction**: LOW — devtrack accidentally committed to fix/TASK-058 branch (was on that branch at commit time); cherry-pick to fix/TASK-057 and reset TASK-058 branch resolved it cleanly
+**Notes**: Removed 15 fmt.Print* calls from handleTrigger() — decorative banner (strings.Repeat("═",60) separators), all fmt.Printf commit/timer detail lines, "What happens next:" paragraph, "Waiting for next event..." line. Replaced with two structured log.Printf lines (one per trigger type). fmt and strings imports both retained — both used elsewhere in file (fmt.Errorf/Sprintf; strings.EqualFold/TrimSpace/Join). TestIntegrated() fmt.Print* calls left untouched per spec. Build: go build ./... PASS | go vet ./... PASS. Commit hash: f0399d7. PR: https://github.com/sraj0501/Devtrack_/pull/163
+
+---
+
+## Task Summary — TASK-057: Silence handleTrigger stdout — 2026-06-14
+
+- Total commits: 1
+- Acceptance criteria met: 4/5 (all code criteria; criterion 5 = runtime daemon log verification pending — requires live daemon test by developer)
+- Tickets auto-updated: 0
+- Estimated daily time saved: ~1 min (no more banner noise in terminal on each commit)
+- Blockers encountered: none
+- One thing that still feels rough: "devtrack git commit landed on the wrong branch because the daemon reads the currently checked-out branch at commit time, not the branch I created — the cherry-pick workaround was safe but unexpected"
+- Ready for PM review: YES
+
+---
+
 ### [2026-06-14 15:13] Ad-hoc — docs(bible): merge Phase 1+7; add second brain vision, #13 non-negotiable, Phase 8 MCP server
 
 **Original message**: "docs(bible): merge Phase 1+7; add second brain vision, #13 non-negotiable, Phase 8 MCP server"

--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -2,6 +2,30 @@
 
 ---
 
+### [2026-06-14 15:55] TASK-058 — fix(server): gate user_prompt.py from trigger path
+
+**Original message**: "fix(server): gate user_prompt.py from trigger path — TASK-058"
+**DevTrack enhanced it to**: "feat(user_prompt): Remove legacy user prompt logic"
+**Ticket auto-linked**: NO
+**PM system updated**: YES — project_board.md TASK-058 marked COMPLETE; commit 6d269ef pushed to fix/TASK-058-remove-user-prompt-trigger
+**Time**: ~25 minutes
+**Friction**: MEDIUM — branch-switching stash conflicts with project_board.md on parallel branches; devtrack daemon kept switching active branch context between TASK-057 and TASK-058; required raw git fallback for log-only commit
+**Notes**: Grep audit confirmed zero hits outside user_prompt.py itself and test_user_prompt.py — trigger path was already clean (as expected per spec). Added two-line status comment after module docstring per spec. Test suite: 591 passed, 1 pre-existing failure (test_ollama_host_returns_string — OLLAMA_HOST=0.0.0.0 in shell env; documented in TASK-043 log and memory/feedback_ollama_host.md, not a regression). Commit hash: 6d269ef.
+
+[DEVTRACK PAUSED — using raw git for engineer_log commit: devtrack daemon kept switching to TASK-057 branch during staging]
+
+## Task Summary — TASK-058: Remove or gate user_prompt.py from trigger path — 2026-06-14
+
+- Total commits: 1 (6d269ef on fix/TASK-058-remove-user-prompt-trigger)
+- Acceptance criteria met: 3/3
+- Tickets auto-updated: 0
+- Estimated daily time saved: ~0 min direct (guard comment prevents future accidental re-introduction into trigger path)
+- Blockers encountered: none (trigger path was already clean — audit confirmed the assumption)
+- One thing that still feels rough: "devtrack daemon branch context doesn't follow the local git checkout — commits land on whichever branch the daemon most recently observed, not the currently checked-out branch"
+- Ready for PM review: YES
+
+---
+
 ### [2026-06-14 15:45] TASK-057 — fix(infra): silence handleTrigger stdout in integrated.go
 
 **Original message**: "fix(infra): silence handleTrigger stdout — TASK-057"

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -124,10 +124,11 @@ Changes required:
 - [x] `uv run pytest backend/tests/ -q` — 591 pass, 1 pre-existing failure (`test_ollama_host_returns_string`, `OLLAMA_HOST=0.0.0.0` in shell, documented in engineer log).
 - [x] The module-level status comment is present at the top of `user_prompt.py`.
 
-**Engineer status**: 3/3 criteria done — 2026-06-14 15:55
+**Engineer status**: 3/3 criteria done — last commit: 6d269ef "feat(user_prompt): Remove legacy user prompt logic" — 2026-06-14 15:55
 
 **COMPLETE** — ready for PM review — 2026-06-14 15:55
 
+**PR**: https://github.com/sraj0501/Devtrack_/pull/164
 **Blockers**: none
 
 ---

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -120,13 +120,14 @@ Changes required:
 4. Run `uv run pytest backend/tests/ -q` to confirm no tests regress.
 
 **Acceptance criteria**:
-- [ ] `grep -rn "user_prompt\|DevTrackTUI\|prompt_work_update" devtrack_server/backend/ --include="*.py"` returns zero hits outside `user_prompt.py` itself and `test_user_prompt.py`.
-- [ ] `uv run pytest backend/tests/ -q` passes (or has the same pre-existing
-      failures as before this task — document any pre-existing failures in the
-      engineer log).
-- [ ] The module-level status comment is present at the top of `user_prompt.py`.
+- [x] `grep -rn "user_prompt\|DevTrackTUI\|prompt_work_update" devtrack_server/backend/ --include="*.py"` returns zero hits outside `user_prompt.py` itself and `test_user_prompt.py`.
+- [x] `uv run pytest backend/tests/ -q` — 591 pass, 1 pre-existing failure (`test_ollama_host_returns_string`, `OLLAMA_HOST=0.0.0.0` in shell, documented in engineer log).
+- [x] The module-level status comment is present at the top of `user_prompt.py`.
 
-**Engineer status**: not started
+**Engineer status**: 3/3 criteria done — 2026-06-14 15:55
+
+**COMPLETE** — ready for PM review — 2026-06-14 15:55
+
 **Blockers**: none
 
 ---

--- a/devtrack_server/backend/user_prompt.py
+++ b/devtrack_server/backend/user_prompt.py
@@ -10,6 +10,9 @@ This module provides a simple but effective terminal interface for:
 Works in both interactive terminals and non-interactive environments.
 """
 
+# STATUS: Legacy module. Not called from any trigger path as of Phase 0.
+# Safe to delete once the TUI correction interface (Phase 7) is implemented.
+
 import os
 import sys
 import logging


### PR DESCRIPTION
## Summary

- Ran grep audit confirming `user_prompt.py` is not imported or called from any trigger path in `devtrack_server/backend/` — only references are in `user_prompt.py` itself and `test_user_prompt.py`
- Added module-level status comment to `user_prompt.py` marking it as a legacy module not called from any trigger path as of Phase 0, safe to delete once Phase 7 TUI is implemented
- Ran `uv run pytest backend/tests/ -q`: 591 passed, 1 pre-existing failure documented in engineer log (`test_ollama_host_returns_string` due to `OLLAMA_HOST=0.0.0.0` in shell env)

## Test plan

- [x] Grep audit: zero hits outside `user_prompt.py` and `test_user_prompt.py`
- [x] Status comment present at top of `user_prompt.py` (after module docstring)
- [x] `uv run pytest backend/tests/ -q` — 591 pass, 1 pre-existing failure documented

Closes TASK-058 on project board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)