### PR TITLE
TASK-066: Modern TUI redesign with Charm libraries

### DIFF
--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1177,6 +1177,8 @@ in each tab's `Init()`. Forward `spinner.TickMsg` in each `Update()` so the dot 
 
 ---
 
+---
+
 ## DEPRIORITISED (pivot 2026-06-10)
 
 These sat on the old v3.x "Polish & Growth" board. The pivot moved them below the

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1177,8 +1177,6 @@ in each tab's `Init()`. Forward `spinner.TickMsg` in each `Update()` so the dot 
 
 ---
 
----
-
 ## DEPRIORITISED (pivot 2026-06-10)
 
 These sat on the old v3.x "Polish & Growth" board. The pivot moved them below the

--- a/devtrack_client/go.mod
+++ b/devtrack_client/go.mod
@@ -15,6 +15,8 @@ require (
 	modernc.org/sqlite v1.39.1
 )
 
+require github.com/charmbracelet/bubbles v1.0.0 // indirect
+
 require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/devtrack_client/go.sum
+++ b/devtrack_client/go.sum
@@ -11,6 +11,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
+github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco3ej+ngLk1kk=

--- a/devtrack_client/internal/tui/styles.go
+++ b/devtrack_client/internal/tui/styles.go
@@ -1,0 +1,34 @@
+package tui
+
+import "github.com/charmbracelet/lipgloss"
+
+// Adaptive color palette — light/dark terminal safe.
+var (
+	ColorAccent  = lipgloss.AdaptiveColor{Light: "#7C3AED", Dark: "#A78BFA"}
+	ColorSuccess = lipgloss.AdaptiveColor{Light: "#059669", Dark: "#34D399"}
+	ColorWarning = lipgloss.AdaptiveColor{Light: "#D97706", Dark: "#FCD34D"}
+	ColorDanger  = lipgloss.AdaptiveColor{Light: "#DC2626", Dark: "#F87171"}
+	ColorInfo    = lipgloss.AdaptiveColor{Light: "#0284C7", Dark: "#38BDF8"}
+	ColorMuted   = lipgloss.AdaptiveColor{Light: "#6B7280", Dark: "#9CA3AF"}
+	ColorSubtle  = lipgloss.AdaptiveColor{Light: "#D1D5DB", Dark: "#374151"}
+	ColorFlash   = lipgloss.AdaptiveColor{Light: "#6D28D9", Dark: "#C4B5FD"}
+)
+
+// StyleCard is a rounded-border panel with subtle border color and inner padding.
+var StyleCard = lipgloss.NewStyle().
+	Border(lipgloss.RoundedBorder()).
+	BorderForeground(ColorSubtle).
+	Padding(0, 1)
+
+// StyleBadge returns a background-colored inline badge with white text.
+func StyleBadge(color lipgloss.TerminalColor) lipgloss.Style {
+	return lipgloss.NewStyle().
+		Background(color).
+		Foreground(lipgloss.Color("#FFFFFF")).
+		Padding(0, 1).
+		Bold(true)
+}
+
+var StyleHeader = lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
+var StyleMuted = lipgloss.NewStyle().Foreground(ColorMuted)
+var StyleSection = lipgloss.NewStyle().Bold(true).Foreground(ColorMuted)

--- a/devtrack_client/internal/tui/tui.go
+++ b/devtrack_client/internal/tui/tui.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -25,26 +26,36 @@ var tuiTabNames = []string{"Overview", "Activity", "Workspaces", "Alerts", "Queu
 
 type tuiTickMsg time.Time
 
+// tuiFlashMsg is fired 150ms after a tab switch to clear the flash state.
+type tuiFlashMsg struct{}
+
 type tuiModel struct {
-	activeTab  tuiTab
-	db         *db.Database
-	overview   overviewModel
-	activity   activityModel
-	workspaces workspacesModel
-	alerts     alertsModel
-	queue      queueModel
-	width      int
-	height     int
+	activeTab      tuiTab
+	db             *db.Database
+	overview       overviewModel
+	activity       activityModel
+	workspaces     workspacesModel
+	alerts         alertsModel
+	queue          queueModel
+	width          int
+	height         int
+	refreshSpinner spinner.Model
+	refreshing     bool
+	flash          bool
 }
 
-func newTUIModel(db *db.Database) tuiModel {
+func newTUIModel(database *db.Database) tuiModel {
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	sp.Style = lipgloss.NewStyle().Foreground(ColorAccent)
 	return tuiModel{
-		db:         db,
-		overview:   newOverviewModel(db),
-		activity:   newActivityModel(db),
-		workspaces: newWorkspacesModel(),
-		alerts:     newAlertsModel(db),
-		queue:      newQueueModel(db),
+		db:             database,
+		overview:       newOverviewModel(database),
+		activity:       newActivityModel(database),
+		workspaces:     newWorkspacesModel(),
+		alerts:         newAlertsModel(database),
+		queue:          newQueueModel(database),
+		refreshSpinner: sp,
 	}
 }
 
@@ -55,6 +66,12 @@ func (m tuiModel) Init() tea.Cmd {
 		m.workspaces.load(),
 		m.alerts.load(),
 		m.queue.load(),
+		m.overview.spinner.Tick,
+		m.activity.spinner.Tick,
+		m.workspaces.spinner.Tick,
+		m.alerts.spinner.Tick,
+		m.queue.spinner.Tick,
+		m.refreshSpinner.Tick,
 		tea.Tick(30*time.Second, func(t time.Time) tea.Msg { return tuiTickMsg(t) }),
 	)
 }
@@ -72,25 +89,69 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.workspaces.width, m.workspaces.height = msg.Width, contentH
 		m.alerts.width, m.alerts.height = msg.Width, contentH
 		m.queue.width, m.queue.height = msg.Width, contentH
+		// Forward window resize to tabs that manage a viewport.
+		var aCmd, alCmd tea.Cmd
+		m.activity, aCmd = m.activity.Update(msg)
+		m.alerts, alCmd = m.alerts.Update(msg)
+		if aCmd != nil {
+			cmds = append(cmds, aCmd)
+		}
+		if alCmd != nil {
+			cmds = append(cmds, alCmd)
+		}
+
+	case spinner.TickMsg:
+		// Forward spinner tick to root refresh spinner and all tab spinners.
+		var spCmd tea.Cmd
+		m.refreshSpinner, spCmd = m.refreshSpinner.Update(msg)
+		if spCmd != nil {
+			cmds = append(cmds, spCmd)
+		}
+		var ovCmd, actCmd, wsCmd, alCmd, qCmd tea.Cmd
+		m.overview, ovCmd = m.overview.Update(msg)
+		m.activity, actCmd = m.activity.Update(msg)
+		m.workspaces, wsCmd = m.workspaces.Update(msg)
+		m.alerts, alCmd = m.alerts.Update(msg)
+		m.queue, qCmd = m.queue.Update(msg)
+		for _, c := range []tea.Cmd{ovCmd, actCmd, wsCmd, alCmd, qCmd} {
+			if c != nil {
+				cmds = append(cmds, c)
+			}
+		}
+
+	case tuiFlashMsg:
+		m.flash = false
 
 	case tea.KeyMsg:
-		// Route navigation keys to queue tab when active.
+		// Queue tab gets its own key handling for cursor/approve/reject.
 		if m.activeTab == tabQueue {
 			switch msg.String() {
 			case "q", "ctrl+c":
 				return m, tea.Quit
 			case "tab":
 				m.activeTab = (m.activeTab + 1) % tuiTab(len(tuiTabNames))
+				m.flash = true
+				cmds = append(cmds, tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg { return tuiFlashMsg{} }))
 			case "1":
 				m.activeTab = tabOverview
+				m.flash = true
+				cmds = append(cmds, tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg { return tuiFlashMsg{} }))
 			case "2":
 				m.activeTab = tabActivity
+				m.flash = true
+				cmds = append(cmds, tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg { return tuiFlashMsg{} }))
 			case "3":
 				m.activeTab = tabWorkspaces
+				m.flash = true
+				cmds = append(cmds, tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg { return tuiFlashMsg{} }))
 			case "4":
 				m.activeTab = tabAlerts
+				m.flash = true
+				cmds = append(cmds, tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg { return tuiFlashMsg{} }))
 			case "5":
 				m.activeTab = tabQueue
+				m.flash = true
+				cmds = append(cmds, tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg { return tuiFlashMsg{} }))
 			default:
 				var qCmd tea.Cmd
 				m.queue, qCmd = m.queue.Update(msg)
@@ -104,23 +165,37 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			case "tab":
 				m.activeTab = (m.activeTab + 1) % tuiTab(len(tuiTabNames))
+				m.flash = true
+				cmds = append(cmds, tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg { return tuiFlashMsg{} }))
 			case "1":
 				m.activeTab = tabOverview
+				m.flash = true
+				cmds = append(cmds, tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg { return tuiFlashMsg{} }))
 			case "2":
 				m.activeTab = tabActivity
+				m.flash = true
+				cmds = append(cmds, tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg { return tuiFlashMsg{} }))
 			case "3":
 				m.activeTab = tabWorkspaces
+				m.flash = true
+				cmds = append(cmds, tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg { return tuiFlashMsg{} }))
 			case "4":
 				m.activeTab = tabAlerts
+				m.flash = true
+				cmds = append(cmds, tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg { return tuiFlashMsg{} }))
 			case "5":
 				m.activeTab = tabQueue
+				m.flash = true
+				cmds = append(cmds, tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg { return tuiFlashMsg{} }))
 			case "r":
+				m.refreshing = true
 				cmds = append(cmds,
 					m.overview.load(),
 					m.activity.load(),
 					m.workspaces.load(),
 					m.alerts.load(),
 					m.queue.load(),
+					m.refreshSpinner.Tick,
 				)
 			}
 		}
@@ -130,7 +205,7 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.overview.load(),
 			tea.Tick(30*time.Second, func(t time.Time) tea.Msg { return tuiTickMsg(t) }),
 		)
-		// Fan tickMsg to queue for its auto-refresh countdown.
+		// Fan tickMsg to queue for its auto-refresh and pulse countdown.
 		var qCmd tea.Cmd
 		m.queue, qCmd = m.queue.Update(msg)
 		if qCmd != nil {
@@ -139,6 +214,7 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case overviewDataMsg:
 		m.overview, _ = m.overview.Update(msg)
+		m.refreshing = false
 	case activityDataMsg:
 		m.activity, _ = m.activity.Update(msg)
 	case workspacesDataMsg:
@@ -157,7 +233,9 @@ func (m tuiModel) View() string {
 		return "Loading…"
 	}
 
-	header := renderTUITabBar(m.activeTab, m.width)
+	header := m.renderHeader()
+	tabBar := m.renderTabBar()
+	sep := lipgloss.NewStyle().Foreground(ColorSubtle).Render(strings.Repeat("─", m.width))
 
 	var body string
 	switch m.activeTab {
@@ -173,43 +251,67 @@ func (m tuiModel) View() string {
 		body = m.queue.View()
 	}
 
-	footer := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Render("  Tab / 1-5: switch tab   r: refresh   q: quit")
+	var footer string
+	if m.refreshing {
+		footer = StyleMuted.Render("  " + m.refreshSpinner.View() + " Refreshing…   Tab/1-5: switch   q: quit")
+	} else {
+		footer = StyleMuted.Render("  Tab/1-5: switch   r: refresh   q: quit")
+	}
 
-	return header + "\n" + body + "\n" + footer
+	return header + "\n" + tabBar + "\n" + sep + "\n" + body + "\n" + footer
 }
 
-func renderTUITabBar(active tuiTab, width int) string {
-	activeStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("255")).
-		Background(lipgloss.Color("63")).
-		Padding(0, 2)
-	inactiveStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Padding(0, 2)
+// renderHeader renders the top bar with branding and mode/version right-aligned.
+func (m tuiModel) renderHeader() string {
+	brand := StyleHeader.Render("  ◆ DevTrack")
+	right := StyleMuted.Render("managed  v3.0.10  ")
+	spacer := m.width - lipgloss.Width(brand) - lipgloss.Width(right)
+	if spacer < 0 {
+		spacer = 0
+	}
+	return brand + strings.Repeat(" ", spacer) + right
+}
 
+// renderTabBar renders the pill-style tab row.
+func (m tuiModel) renderTabBar() string {
 	var sb strings.Builder
 	for i, name := range tuiTabNames {
-		if tuiTab(i) == active {
-			sb.WriteString(activeStyle.Render(fmt.Sprintf("%d %s", i+1, name)))
-		} else {
-			sb.WriteString(inactiveStyle.Render(fmt.Sprintf("%d %s", i+1, name)))
-		}
+		sb.WriteString(m.renderTabLabel(tuiTab(i), name))
 	}
-	return lipgloss.NewStyle().Width(width).Render(sb.String())
+	return lipgloss.NewStyle().Width(m.width).Render(sb.String())
+}
+
+// renderTabLabel renders a single pill-style tab button.
+// Active tab uses Accent background; during flash it uses ColorFlash background.
+func (m tuiModel) renderTabLabel(t tuiTab, name string) string {
+	isActive := m.activeTab == t
+	label := fmt.Sprintf("%d %s", int(t)+1, name)
+	if isActive {
+		var bg lipgloss.TerminalColor
+		if m.flash {
+			bg = ColorFlash
+		} else {
+			bg = ColorAccent
+		}
+		return lipgloss.NewStyle().
+			Background(bg).
+			Foreground(lipgloss.Color("#FFFFFF")).
+			Bold(true).
+			Padding(0, 2).
+			Render(label)
+	}
+	return StyleMuted.Padding(0, 2).Render(label)
 }
 
 // RunTUI opens the Bubble Tea TUI dashboard.
 func RunTUI() error {
-	db, err := db.NewDatabase()
+	database, err := db.NewDatabase()
 	if err != nil {
 		return fmt.Errorf("could not open database: %w", err)
 	}
-	defer db.Close()
+	defer database.Close()
 
-	m := newTUIModel(db)
+	m := newTUIModel(database)
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	_, err = p.Run()
 	return err

--- a/devtrack_client/internal/tui/tui_activity.go
+++ b/devtrack_client/internal/tui/tui_activity.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -13,13 +15,21 @@ import (
 type activityDataMsg []db.TriggerRecord
 
 type activityModel struct {
-	db     *db.Database
-	items  []db.TriggerRecord
-	width  int
-	height int
+	db      *db.Database
+	vp      viewport.Model
+	items   []db.TriggerRecord
+	spinner spinner.Model
+	loading bool
+	width   int
+	height  int
 }
 
-func newActivityModel(db *db.Database) activityModel { return activityModel{db: db} }
+func newActivityModel(database *db.Database) activityModel {
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	sp.Style = lipgloss.NewStyle().Foreground(ColorAccent)
+	return activityModel{db: database, spinner: sp, loading: true}
+}
 
 func (m activityModel) load() tea.Cmd {
 	return func() tea.Msg {
@@ -32,29 +42,53 @@ func (m activityModel) load() tea.Cmd {
 }
 
 func (m activityModel) Update(msg tea.Msg) (activityModel, tea.Cmd) {
-	if d, ok := msg.(activityDataMsg); ok {
-		m.items = []db.TriggerRecord(d)
+	switch msg := msg.(type) {
+	case activityDataMsg:
+		m.items = []db.TriggerRecord(msg)
+		m.loading = false
+		// Build viewport content.
+		content := m.buildContent()
+		m.vp.SetContent(content)
+		return m, nil
+
+	case tea.WindowSizeMsg:
+		contentH := msg.Height - 5 // leave room for header, tabs, sep, footer
+		if contentH < 1 {
+			contentH = 1
+		}
+		m.vp = viewport.New(msg.Width, contentH)
+		m.vp.SetContent(m.buildContent())
+		return m, nil
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	default:
+		// Forward other messages (scroll keys) to the viewport.
+		var cmd tea.Cmd
+		m.vp, cmd = m.vp.Update(msg)
+		return m, cmd
 	}
-	return m, nil
 }
 
-func (m activityModel) View() string {
+func (m activityModel) buildContent() string {
 	if len(m.items) == 0 {
 		return "\n  No recent activity logged yet."
 	}
 
-	muted := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	commitStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("33"))
-	timerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("220"))
+	commitBadge := StyleBadge(ColorInfo).Render(" commit ")
+	timerBadge := StyleBadge(ColorWarning).Render(" timer  ")
 
 	var sb strings.Builder
 	sb.WriteString("\n")
 	for _, r := range m.items {
-		icon := commitStyle.Render("⬡ commit")
+		badge := commitBadge
 		if r.TriggerType == "timer" {
-			icon = timerStyle.Render("⏱ timer ")
+			badge = timerBadge
 		}
-		ts := r.Timestamp.Format("01/02 15:04")
+		ts := StyleMuted.Render(r.Timestamp.Format("01/02 15:04"))
 		msg := r.CommitMessage
 		if len(msg) > 60 {
 			msg = msg[:57] + "…"
@@ -68,10 +102,16 @@ func (m activityModel) View() string {
 			if len(h) > 7 {
 				h = h[:7]
 			}
-			hash = muted.Render(" " + h)
+			hash = StyleMuted.Render(" " + h)
 		}
-		sb.WriteString(fmt.Sprintf("  %s  %s  %s%s\n",
-			muted.Render(ts), icon, msg, hash))
+		sb.WriteString(fmt.Sprintf("  %s  %s  %s%s\n", ts, badge, msg, hash))
 	}
 	return sb.String()
+}
+
+func (m activityModel) View() string {
+	if m.loading {
+		return "\n  " + m.spinner.View() + " Loading activity…"
+	}
+	return m.vp.View()
 }

--- a/devtrack_client/internal/tui/tui_alerts.go
+++ b/devtrack_client/internal/tui/tui_alerts.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -13,13 +15,21 @@ import (
 type alertsDataMsg []db.NotificationRecord
 
 type alertsModel struct {
-	db     *db.Database
-	items  []db.NotificationRecord
-	width  int
-	height int
+	db      *db.Database
+	vp      viewport.Model
+	items   []db.NotificationRecord
+	spinner spinner.Model
+	loading bool
+	width   int
+	height  int
 }
 
-func newAlertsModel(db *db.Database) alertsModel { return alertsModel{db: db} }
+func newAlertsModel(database *db.Database) alertsModel {
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	sp.Style = lipgloss.NewStyle().Foreground(ColorAccent)
+	return alertsModel{db: database, spinner: sp, loading: true}
+}
 
 func (m alertsModel) load() tea.Cmd {
 	return func() tea.Msg {
@@ -32,56 +42,84 @@ func (m alertsModel) load() tea.Cmd {
 }
 
 func (m alertsModel) Update(msg tea.Msg) (alertsModel, tea.Cmd) {
-	if d, ok := msg.(alertsDataMsg); ok {
-		m.items = []db.NotificationRecord(d)
+	switch msg := msg.(type) {
+	case alertsDataMsg:
+		m.items = []db.NotificationRecord(msg)
+		m.loading = false
+		m.vp.SetContent(m.buildContent())
+		return m, nil
+
+	case tea.WindowSizeMsg:
+		contentH := msg.Height - 5
+		if contentH < 1 {
+			contentH = 1
+		}
+		m.vp = viewport.New(msg.Width, contentH)
+		m.vp.SetContent(m.buildContent())
+		return m, nil
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	default:
+		var cmd tea.Cmd
+		m.vp, cmd = m.vp.Update(msg)
+		return m, cmd
 	}
-	return m, nil
 }
 
-func (m alertsModel) View() string {
+func (m alertsModel) sourceBadge(source string) string {
+	switch source {
+	case "github":
+		return StyleBadge(ColorAccent).Render(" " + source + " ")
+	case "azure":
+		return StyleBadge(ColorInfo).Render(" " + source + " ")
+	case "jira":
+		return StyleBadge(ColorWarning).Render(" " + source + " ")
+	default:
+		return StyleBadge(ColorMuted).Render(" " + source + " ")
+	}
+}
+
+func (m alertsModel) buildContent() string {
 	if len(m.items) == 0 {
 		return "\n  No notifications yet.\n  The ticket alerter will populate this as alerts arrive."
 	}
 
-	githubStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("255"))
-	azureStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("33"))
-	jiraStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("226"))
-	muted := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	unread := lipgloss.NewStyle().Bold(true)
-
 	var sb strings.Builder
 	sb.WriteString("\n")
 	for _, r := range m.items {
-		srcStyle := muted
-		switch r.Source {
-		case "github":
-			srcStyle = githubStyle
-		case "azure":
-			srcStyle = azureStyle
-		case "jira":
-			srcStyle = jiraStyle
-		}
-
-		dot := muted.Render("○")
-		titleStyle := muted
+		// Unread/read dot.
+		var dot string
+		var titleStyle lipgloss.Style
 		if !r.Read {
-			dot = lipgloss.NewStyle().Foreground(lipgloss.Color("82")).Render("●")
-			titleStyle = unread
+			dot = lipgloss.NewStyle().Foreground(ColorSuccess).Render("●")
+			titleStyle = lipgloss.NewStyle().Bold(true)
+		} else {
+			dot = StyleMuted.Render("○")
+			titleStyle = StyleMuted
 		}
 
-		ts := r.CreatedAt.Format("01/02 15:04")
+		ts := StyleMuted.Render(r.CreatedAt.Format("01/02 15:04"))
+		badge := m.sourceBadge(r.Source)
+		eventType := StyleMuted.Render(fmt.Sprintf("%-14s", r.EventType))
+
 		title := r.Title
 		if len(title) > 55 {
 			title = title[:52] + "…"
 		}
 
-		sb.WriteString(fmt.Sprintf("  %s %s  %-8s %-18s %s\n",
-			dot,
-			muted.Render(ts),
-			srcStyle.Render(r.Source),
-			muted.Render(r.EventType),
-			titleStyle.Render(title),
-		))
+		sb.WriteString(fmt.Sprintf("  %s  %s  %s  %s  %s\n",
+			dot, ts, badge, eventType, titleStyle.Render(title)))
 	}
 	return sb.String()
+}
+
+func (m alertsModel) View() string {
+	if m.loading {
+		return "\n  " + m.spinner.View() + " Loading alerts…"
+	}
+	return m.vp.View()
 }

--- a/devtrack_client/internal/tui/tui_overview.go
+++ b/devtrack_client/internal/tui/tui_overview.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -26,13 +27,20 @@ type overviewDataMsg struct {
 }
 
 type overviewModel struct {
-	db     *db.Database
-	data   overviewDataMsg
-	width  int
-	height int
+	db      *db.Database
+	data    overviewDataMsg
+	spinner spinner.Model
+	loading bool
+	width   int
+	height  int
 }
 
-func newOverviewModel(db *db.Database) overviewModel { return overviewModel{db: db} }
+func newOverviewModel(database *db.Database) overviewModel {
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	sp.Style = lipgloss.NewStyle().Foreground(ColorAccent)
+	return overviewModel{db: database, spinner: sp, loading: true}
+}
 
 func (m overviewModel) load() tea.Cmd {
 	return func() tea.Msg {
@@ -41,7 +49,7 @@ func (m overviewModel) load() tea.Cmd {
 			mode:      string(config.GetServerMode()),
 		}
 
-		// Daemon status — stat the PID file
+		// Daemon status — stat the PID file.
 		if fi, err := os.Stat(config.GetPIDFilePath()); err == nil {
 			msg.daemonRunning = true
 			uptime := time.Since(fi.ModTime())
@@ -55,18 +63,18 @@ func (m overviewModel) load() tea.Cmd {
 			}
 		}
 
-		// Server health ping
+		// Server health ping.
 		client := trigger.NewHTTPTriggerClient()
 		start := time.Now()
 		msg.serverUp = client.Ping()
 		msg.serverLatency = time.Since(start).Milliseconds()
 
-		// Trigger counts today
+		// Trigger counts today.
 		if m.db != nil {
 			msg.commits, msg.timers = m.db.CountTriggersToday()
 		}
 
-		// Workspace count
+		// Workspace count.
 		if cfg, err := config.LoadWorkspacesConfig(); err == nil && cfg != nil {
 			msg.workspaces = len(cfg.GetEnabledWorkspaces())
 		}
@@ -76,41 +84,64 @@ func (m overviewModel) load() tea.Cmd {
 }
 
 func (m overviewModel) Update(msg tea.Msg) (overviewModel, tea.Cmd) {
-	if d, ok := msg.(overviewDataMsg); ok {
-		m.data = d
+	switch msg := msg.(type) {
+	case overviewDataMsg:
+		m.data = msg
+		m.loading = false
+		return m, nil
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
 	}
 	return m, nil
 }
 
 func (m overviewModel) View() string {
+	if m.loading {
+		return "\n  " + m.spinner.View() + " Loading…"
+	}
+
 	d := m.data
-	bold := lipgloss.NewStyle().Bold(true)
-	green := lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
-	red := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
-	muted := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	cardW := (m.width - 6) / 2
 
-	daemonStatus := red.Render("● stopped")
+	// Daemon card.
+	var daemonStatus string
 	if d.daemonRunning {
-		extra := ""
+		dot := lipgloss.NewStyle().Foreground(ColorSuccess).Render("●")
+		uptime := ""
 		if d.daemonUptime != "" {
-			extra = muted.Render(" (" + d.daemonUptime + ")")
+			uptime = StyleMuted.Render("  uptime: " + d.daemonUptime)
 		}
-		daemonStatus = green.Render("● running") + extra
+		daemonStatus = dot + lipgloss.NewStyle().Foreground(ColorSuccess).Render(" running") + uptime
+	} else {
+		daemonStatus = lipgloss.NewStyle().Foreground(ColorDanger).Render("● stopped")
 	}
+	daemonCard := StyleCard.Width(cardW).Render(
+		StyleSection.Render("DAEMON") + "\n" + daemonStatus,
+	)
 
-	serverStatus := red.Render("✗ unreachable")
+	// Server card.
+	var serverStatus string
 	if d.serverUp {
-		serverStatus = green.Render(fmt.Sprintf("✓ up (%dms)", d.serverLatency))
+		check := lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓")
+		serverStatus = check + lipgloss.NewStyle().Foreground(ColorSuccess).Render(" up") +
+			StyleMuted.Render(fmt.Sprintf("  %dms  %s", d.serverLatency, d.mode)) +
+			"\n" + StyleMuted.Render(d.serverURL)
+	} else {
+		serverStatus = lipgloss.NewStyle().Foreground(ColorDanger).Render("✗ unreachable")
 	}
+	serverCard := StyleCard.Width(cardW).Render(
+		StyleSection.Render("AI SERVER") + "\n" + serverStatus,
+	)
 
-	out := "\n"
-	out += "  " + bold.Render("DevTrack Dashboard") + "\n\n"
-	out += fmt.Sprintf("  %-22s %s\n", "Go daemon:", daemonStatus)
-	out += fmt.Sprintf("  %-22s %s\n", "Python server:", serverStatus)
-	out += fmt.Sprintf("  %-22s %s\n", "Server URL:", muted.Render(d.serverURL))
-	out += fmt.Sprintf("  %-22s %s\n", "Mode:", d.mode)
-	out += "\n"
-	out += fmt.Sprintf("  %-22s %d commits, %d timers\n", "Triggers today:", d.commits, d.timers)
-	out += fmt.Sprintf("  %-22s %d active\n", "Workspaces:", d.workspaces)
-	return out
+	// Side-by-side layout.
+	cards := lipgloss.JoinHorizontal(lipgloss.Top, daemonCard, " ", serverCard)
+
+	// Metrics strip — full-width card.
+	metricsContent := fmt.Sprintf("  %d commits   │   %d timers   │   %d workspaces",
+		d.commits, d.timers, d.workspaces)
+	metricsCard := StyleCard.Width(m.width - 4).Render(metricsContent)
+
+	return "\n" + cards + "\n\n" + metricsCard
 }

--- a/devtrack_client/internal/tui/tui_queue.go
+++ b/devtrack_client/internal/tui/tui_queue.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -16,16 +17,22 @@ type queueDataMsg []db.PendingAction
 
 // queueModel holds the state for the Queue tab.
 type queueModel struct {
-	db       *db.Database
-	items    []db.PendingAction
-	cursor   int
-	width    int
-	height   int
-	lastLoad time.Time
+	db         *db.Database
+	items      []db.PendingAction
+	cursor     int
+	width      int
+	height     int
+	lastLoad   time.Time
+	spinner    spinner.Model
+	loading    bool
+	pulseState bool
 }
 
 func newQueueModel(database *db.Database) queueModel {
-	return queueModel{db: database}
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	sp.Style = lipgloss.NewStyle().Foreground(ColorAccent)
+	return queueModel{db: database, spinner: sp, loading: true}
 }
 
 // load fetches the last 24 hours of pending actions from the DB in a goroutine.
@@ -45,10 +52,21 @@ func (m queueModel) Update(msg tea.Msg) (queueModel, tea.Cmd) {
 	case queueDataMsg:
 		m.items = []db.PendingAction(msg)
 		m.lastLoad = time.Now()
+		m.loading = false
 		// Clamp cursor to valid range after reload.
 		if m.cursor >= len(m.items) && len(m.items) > 0 {
 			m.cursor = len(m.items) - 1
 		}
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case tuiTickMsg:
+		// Toggle pulse state on every tick for urgency animation.
+		m.pulseState = !m.pulseState
+		return m, m.load()
 
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -80,16 +98,30 @@ func (m queueModel) Update(msg tea.Msg) (queueModel, tea.Cmd) {
 			// Edit not implemented yet — placeholder for Phase 1 completion.
 			return m, nil
 		}
-
-	case tuiTickMsg:
-		return m, m.load()
 	}
 
 	return m, nil
 }
 
-// confidence_bar renders a 5-character block bar for a confidence score in [0.0, 1.0].
-// Example: 0.80 → "████░"
+// queueStatusBadge returns a background-colored status badge.
+func queueStatusBadge(status string) string {
+	switch status {
+	case "pending":
+		return StyleBadge(ColorWarning).Render(" pending ")
+	case "approved":
+		return StyleBadge(ColorSuccess).Render(" approved")
+	case "rejected":
+		return StyleBadge(ColorDanger).Render(" rejected")
+	case "posted":
+		return StyleBadge(ColorMuted).Render(" posted  ")
+	case "failed":
+		return StyleBadge(ColorDanger).Bold(true).Render(" FAILED  ")
+	default:
+		return StyleBadge(ColorMuted).Render(" " + status + " ")
+	}
+}
+
+// confidenceBar renders a 5-character block bar colored by threshold.
 func confidenceBar(c float64) string {
 	if c < 0 {
 		c = 0
@@ -97,71 +129,82 @@ func confidenceBar(c float64) string {
 	if c > 1 {
 		c = 1
 	}
+	var barColor lipgloss.TerminalColor
+	switch {
+	case c > 0.90:
+		barColor = ColorSuccess
+	case c >= 0.70:
+		barColor = ColorWarning
+	default:
+		barColor = ColorDanger
+	}
 	filled := int(c*5 + 0.5)
-	return strings.Repeat("█", filled) + strings.Repeat("░", 5-filled)
+	bar := strings.Repeat("█", filled) + strings.Repeat("░", 5-filled)
+	return lipgloss.NewStyle().Foreground(barColor).Render(bar)
 }
 
-// expiresCountdown returns a human-readable countdown for the ExpiresAt field.
-func expiresCountdown(t time.Time) string {
+// expiresCountdown returns a human-readable countdown, with pulsing color when < 30s.
+func expiresCountdown(t time.Time, pulse bool) string {
 	remaining := time.Until(t)
 	if remaining <= 0 {
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render("expired")
+		return lipgloss.NewStyle().Foreground(ColorDanger).Render("expired")
 	}
 	remaining = remaining.Round(time.Second)
+	var text string
 	if remaining >= time.Minute {
-		return fmt.Sprintf("in %dm", int(remaining.Minutes()))
+		text = fmt.Sprintf("in %dm", int(remaining.Minutes()))
+	} else {
+		text = fmt.Sprintf("in %ds", int(remaining.Seconds()))
 	}
-	return fmt.Sprintf("in %ds", int(remaining.Seconds()))
+	if remaining < 30*time.Second {
+		color := lipgloss.TerminalColor(ColorDanger)
+		if pulse {
+			color = ColorWarning
+		}
+		return lipgloss.NewStyle().Foreground(color).Render(text)
+	}
+	return lipgloss.NewStyle().Foreground(ColorWarning).Render(text)
+}
+
+// queueFooter renders the key-hint bar with Accent-colored brackets.
+func queueFooter(lastLoad time.Time) string {
+	bracket := lipgloss.NewStyle().Foreground(ColorAccent)
+	key := func(k, label string) string {
+		return bracket.Render("[") + k + bracket.Render("]") + label
+	}
+	ts := "--:--:--"
+	if !lastLoad.IsZero() {
+		ts = lastLoad.Format("15:04:05")
+	}
+	return StyleMuted.Render(fmt.Sprintf("  %s  %s  %s   last: %s",
+		key("a", "pprove"), key("r", "eject"), key("e", "dit"), ts))
 }
 
 // View renders the Queue tab.
 func (m queueModel) View() string {
+	if m.loading {
+		return "\n  " + m.spinner.View() + " Loading queue…"
+	}
+
 	if len(m.items) == 0 {
 		footer := queueFooter(m.lastLoad)
 		return "\n  No pending actions in the last 24 hours.\n\n" + footer
 	}
 
-	// Status badge styles.
-	pendingStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("226")).Bold(true)  // yellow
-	approvedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("82")).Bold(true)  // green
-	rejectedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))            // red
-	postedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))              // dim
-	failedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)   // bright red
-	muted := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	cursorStyle := lipgloss.NewStyle().Reverse(true)
+	muted := StyleMuted
 
 	var sb strings.Builder
 	sb.WriteString("\n")
 
-	header := fmt.Sprintf("  %-7s  %-5s  %-10s  %-18s  %-20s\n",
+	header := fmt.Sprintf("  %-9s  %-5s  %-10s  %-18s  %-20s\n",
 		"STATUS", "CONF", "EXPIRES", "TYPE", "TARGET")
 	sb.WriteString(muted.Render(header))
 
 	for i, item := range m.items {
-		// Status badge.
-		var badge string
-		switch item.Status {
-		case "pending":
-			badge = pendingStyle.Render(fmt.Sprintf("%-8s", "pending"))
-		case "approved":
-			badge = approvedStyle.Render(fmt.Sprintf("%-8s", "approved"))
-		case "rejected":
-			badge = rejectedStyle.Render(fmt.Sprintf("%-8s", "rejected"))
-		case "posted":
-			badge = postedStyle.Render(fmt.Sprintf("%-8s", "posted"))
-		case "failed":
-			badge = failedStyle.Render(fmt.Sprintf("%-8s", "failed"))
-		default:
-			badge = fmt.Sprintf("%-8s", item.Status)
-		}
-
-		// Confidence bar.
+		badge := queueStatusBadge(item.Status)
 		bar := confidenceBar(item.Confidence)
+		expiry := expiresCountdown(item.ExpiresAt, m.pulseState)
 
-		// Expiry countdown.
-		expiry := expiresCountdown(item.ExpiresAt)
-
-		// Truncate long strings.
 		actionType := item.ActionType
 		if len(actionType) > 18 {
 			actionType = actionType[:15] + "..."
@@ -175,23 +218,15 @@ func (m queueModel) View() string {
 			badge, bar, expiry, actionType, target)
 
 		if i == m.cursor {
-			sb.WriteString(cursorStyle.Render(row) + "\n")
-		} else {
-			sb.WriteString(row + "\n")
+			row = lipgloss.NewStyle().
+				Background(ColorAccent).
+				Foreground(lipgloss.Color("#FFFFFF")).
+				Render(row)
 		}
+		sb.WriteString(row + "\n")
 	}
 
 	sb.WriteString("\n")
 	sb.WriteString(queueFooter(m.lastLoad))
 	return sb.String()
-}
-
-func queueFooter(lastLoad time.Time) string {
-	ts := "--:--:--"
-	if !lastLoad.IsZero() {
-		ts = lastLoad.Format("15:04:05")
-	}
-	return lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
-		Render(fmt.Sprintf("  [a]pprove  [r]eject  [e]dit  (auto-refresh 10s)  last: %s", ts))
 }

--- a/devtrack_client/internal/tui/tui_workspaces.go
+++ b/devtrack_client/internal/tui/tui_workspaces.go
@@ -1,9 +1,9 @@
 package tui
 
 import (
-	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -13,12 +13,19 @@ import (
 type workspacesDataMsg []config.WorkspaceConfig
 
 type workspacesModel struct {
-	items  []config.WorkspaceConfig
-	width  int
-	height int
+	items   []config.WorkspaceConfig
+	spinner spinner.Model
+	loading bool
+	width   int
+	height  int
 }
 
-func newWorkspacesModel() workspacesModel { return workspacesModel{} }
+func newWorkspacesModel() workspacesModel {
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	sp.Style = lipgloss.NewStyle().Foreground(ColorAccent)
+	return workspacesModel{spinner: sp, loading: true}
+}
 
 func (m workspacesModel) load() tea.Cmd {
 	return func() tea.Msg {
@@ -31,47 +38,76 @@ func (m workspacesModel) load() tea.Cmd {
 }
 
 func (m workspacesModel) Update(msg tea.Msg) (workspacesModel, tea.Cmd) {
-	if d, ok := msg.(workspacesDataMsg); ok {
-		m.items = []config.WorkspaceConfig(d)
+	switch msg := msg.(type) {
+	case workspacesDataMsg:
+		m.items = []config.WorkspaceConfig(msg)
+		m.loading = false
+		return m, nil
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
 	}
 	return m, nil
 }
 
 func (m workspacesModel) View() string {
+	if m.loading {
+		return "\n  " + m.spinner.View() + " Loading workspaces…"
+	}
 	if len(m.items) == 0 {
 		return "\n  No workspaces configured. Add entries to workspaces.yaml."
 	}
 
-	green := lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
-	red := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
-	bold := lipgloss.NewStyle().Bold(true)
-	muted := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	cardW := m.width - 4
+	if cardW < 20 {
+		cardW = 20
+	}
+	// cardInnerWidth accounts for the card border+padding (2 chars each side = 4 total).
+	cardInnerWidth := cardW - 4
 
 	var sb strings.Builder
 	sb.WriteString("\n")
-	sb.WriteString(fmt.Sprintf("  %-24s %-12s %-12s %s\n",
-		bold.Render("Name"),
-		bold.Render("Platform"),
-		bold.Render("Status"),
-		bold.Render("Path"),
-	))
-	sb.WriteString("  " + strings.Repeat("─", 72) + "\n")
-
 	for _, ws := range m.items {
-		status := green.Render("● enabled ")
-		if !ws.Enabled {
-			status = red.Render("○ disabled")
-		}
+		// Platform badge.
 		platform := ws.PMPlatform
 		if platform == "" {
-			platform = muted.Render("none")
+			platform = "none"
 		}
+		platBadge := StyleBadge(ColorInfo).Render(" " + platform + " ")
+
+		// Status badge.
+		var statusBadge string
+		if ws.Enabled {
+			statusBadge = StyleBadge(ColorSuccess).Render("● enabled")
+		} else {
+			statusBadge = StyleBadge(ColorDanger).Render("○ disabled")
+		}
+
+		// Header line: workspace name left + platform badge right.
+		nameStr := lipgloss.NewStyle().Bold(true).Render(ws.Name)
+		// Calculate spacer between name and badge.
+		nameW := lipgloss.Width(nameStr)
+		badgeW := lipgloss.Width(platBadge)
+		spacer := cardInnerWidth - nameW - badgeW
+		if spacer < 1 {
+			spacer = 1
+		}
+		headerLine := nameStr + strings.Repeat(" ", spacer) + platBadge
+
+		// Path line (truncated).
 		path := ws.Path
-		if len(path) > 34 {
-			path = "…" + path[len(path)-33:]
+		if len(path) > cardInnerWidth-2 {
+			path = "…" + path[len(path)-(cardInnerWidth-3):]
 		}
-		sb.WriteString(fmt.Sprintf("  %-24s %-12s %-12s %s\n",
-			ws.Name, platform, status, muted.Render(path)))
+		pathLine := StyleMuted.Render(path)
+
+		// Status line.
+		statusLine := statusBadge
+
+		cardContent := headerLine + "\n" + pathLine + "\n" + statusLine
+		card := StyleCard.Width(cardW).Render(cardContent)
+		sb.WriteString(card + "\n")
 	}
 	return sb.String()
 }


### PR DESCRIPTION
## Summary

- `styles.go` (NEW): adaptive color palette (Accent/Success/Warning/Danger/Info/Muted/Subtle/Flash), `StyleCard` (rounded borders), `StyleBadge()` factory, `StyleHeader`, `StyleMuted`, `StyleSection`
- `tui.go`: header bar with `◆ DevTrack` branding + mode/version; pill-style tab bar with Accent bg on active; 150ms flash animation on tab switch; global refresh spinner in footer when `r` pressed; Queue (tab 5) fully wired
- `tui_overview.go`: side-by-side bordered cards (Daemon + AI Server) via `lipgloss.JoinHorizontal`; full-width metrics strip card; `bubbles/spinner` during load
- `tui_activity.go`: `bubbles/viewport` for scrolling; background-colored commit/timer badges (Info/Warning); spinner during load
- `tui_alerts.go`: `bubbles/viewport`; source badges with colored backgrounds (github=Accent, azure=Info, jira=Warning); unread dot in Success green; spinner during load
- `tui_workspaces.go`: per-workspace rounded-border cards with platform badge right-aligned; status badge (Success/Danger); spinner during load
- `tui_queue.go`: `StyleBadge` background status badges; threshold-colored confidence bar (>0.90 Success, ≥0.70 Warning, else Danger); Accent bg on selected row; 30s expiry pulse (Danger↔Warning); Accent-bracket footer key hints; spinner during load
- `db/pending_actions.go` + migration 006: ported from feat/TASK-060 (dependency not yet merged to main)
- `go get github.com/charmbracelet/bubbles v1.0.0` added

## Test plan

- [x] `go build ./...` passes clean from `devtrack_client/`
- [x] `go vet ./...` passes clean
- [ ] Run `devtrack tui` to verify header, tab bar, spinner, and card layout visually
- [ ] Switch tabs with 1-5 keys and verify 150ms flash
- [ ] Press `r` and verify footer shows spinner until data arrives
- [ ] Confirm `ticket_picker.go` and `pm_browser.go` unchanged

Closes TASK-066 on project board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)