### PR TITLE
TASK-068: Branch-name ticket extraction on every commit trigger

### DIFF
--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -1310,3 +1310,36 @@ Pre-existing test failure (test_find_related_projects) confirmed unchanged.
 - One thing that still feels rough: Two remaining violations (webhook_server.py L359/365/374/856-858, git_sage/agent.py L31) are out of scope for this sprint. Worth a TASK-007 to clean them up.
 
 **Pre-existing test failure noted**: `test_find_related_projects` in test_project_manager.py fails before and after all changes — confirmed pre-existing, not introduced by this work.
+
+---
+
+### [2026-06-16 20:30] TASK-068 — feat(db): Add ticket ID extraction column and methods
+
+**Original message**: "feat(ticket): wire branch-name ticket extraction into commit trigger flow (TASK-068)"
+**DevTrack enhanced it to**: "feat(db): Add ticket ID extraction column and methods — Adds `ticket_id` support across the database layer for tracking extracted Jira/project tickets. This includes: 1. Schema updates to add `ticket_id` to the `triggers` table. 2. Updates to `InsertTrigger`, `GetTriggerByID`, and `GetRecentTriggers` to handle this new column. 3. Introduction of `GetLastTicketID` to retrieve the most recently seen ticket ID, supporting advanced trigger logic fallback strategies (e.g., active-ticket)."
+**Ticket auto-linked**: NO — no PM platform configured on the active workspace (`mogrov.com`, platform: none)
+**PM system updated**: YES — project_board.md TASK-068 marked COMPLETE in a follow-up commit; all 7 criteria ticked
+**Time**: ~25 minutes
+**Friction**: LOW — spec referenced exact files/line numbers from a prior verification pass, all of which matched the live code. Only deviation: enhancement title emphasized the `db` package changes and didn't mention `infra`/`trigger` package wiring, but the body and diff are accurate — accepted as-is per "reject only if nonsense" rule.
+**Notes**:
+- Migration `007-add-ticket-id-to-triggers` appended to `allMigrations` in `migrations.go` (next available slot after `006-create-pending-actions`, confirmed by reading the file first) — uses `pragma_table_info('triggers')` check before `ALTER TABLE` for idempotency.
+- Also added `ticket_id` directly to the `CREATE TABLE IF NOT EXISTS triggers` schema in `database.go`'s `initSchema()` plus the existing additive-ALTER loop, so a brand-new database has the column without waiting on `RunPendingMigrations()` — migration 007 is then a no-op safety net for upgrades of existing DBs.
+- `TriggerRecord.TicketID` added; `InsertTrigger`, `GetTriggerByID`, `GetRecentTriggers` updated to write/read it (`COALESCE(ticket_id,'')` on the SELECTs for safety against any stale pre-migration rows).
+- Added `Database.GetLastTicketID(repoPath)` ahead of TASK-069 — it's the exact query TASK-069's active-ticket fallback needs; fully implemented and tested now even though nothing calls it yet (no dead/stub code, just unused-by-this-task).
+- `WorkspaceMonitor.ticketPattern` field added; set from `ws.TicketPattern` in both `NewIntegratedMonitor()` (multi-workspace branch) and `ReloadWorkspaces()`.
+- `handleCommitForWorkspace()`: calls `ticket.NewExtractor(ws.ticketPattern)` then `.Extract(commit.Branch)`, threads result into `TriggerEvent.TicketID` (new field on the existing struct in `scheduler.go`).
+- `handleTrigger()`: commit case sets `triggerRecord.TicketID = event.TicketID` and `cd.TicketID = event.TicketID` (`trigger.CommitTriggerData`); logs `trigger commit: hash=%s ticket_id=%q branch=%q` on match or `trigger commit: hash=%s ticket_id=unlinked branch=%q` on no match — exact format from the spec since TASK-069/070 will grep these lines.
+- `CommitTriggerData.TicketID string \`json:"ticket_id,omitempty"\`` — omitempty means unlinked commits drop the field from the JSON payload entirely rather than sending `"ticket_id":""`; verified both states with `httptest` mock-server tests.
+- Tests added: `internal/db/migration_007_test.go` (idempotent column-add + uniqueness of migration IDs in `allMigrations`), `internal/db/trigger_ticket_test.go` (insert/round-trip, unlinked commit, `GetRecentTriggers` includes ticket_id, `GetLastTicketID` happy/empty/cross-repo-isolation cases), `internal/infra/ticket_extraction_test.go` (default pattern extraction, unlinked no-match, custom pattern override, `TriggerEvent.TicketID` field), and two additions to `internal/trigger/http_trigger_test.go` (ticket_id present in JSON payload when populated, omitted when empty).
+- `go build ./...`, `go vet ./...`, and `go test ./...` all pass clean from `devtrack_client/` (full suite, not just new tests).
+- Daemon was stopped at session start (`devtrack status` showed `● Stopped`); started with `devtrack start`, confirmed `● Running` before committing.
+
+## Task Summary — TASK-068: Branch-name ticket extraction on every commit trigger — 2026-06-16
+
+- Total commits: 2 (319ec53 implementation, 45a18c8 board update)
+- Acceptance criteria met: 7/7
+- Tickets auto-updated: 0 (no PM platform on active workspace — extraction wiring itself has no PM-sync side effect, that's TASK-070's job)
+- Estimated daily time saved: N/A (foundational wiring — the payoff is TASK-069/070 building on a TicketID that's now always populated or explicitly unlinked)
+- Blockers encountered: none
+- One thing that still feels rough: the AI commit-message enhancement summarized only the `db` package half of the diff; for a 3-package change spanning db/infra/trigger, a one-line title understandably can't cover everything, but it's worth knowing the enhancer weights "what changed most" by file count/lines rather than "what's most architecturally significant."
+- Ready for PM review: YES

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -858,6 +858,7 @@ In `devtrack_client/internal/infra/` (wherever `TriggerEvent` is defined), add `
 **Blockers**: none — TASK-067 merged to dev (PR #174)
 
 **COMPLETE** — ready for PM review — 2026-06-16 20:35
+**PR**: https://github.com/sraj0501/Devtrack_/pull/175
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1,6 +1,6 @@
 # DevTrack Project Board
 
-_Last updated: 2026-06-16 by PM (Phase 2 decomposed — TASK-067 dispatched)_
+_Last updated: 2026-06-16 by PM (TASK-068 dispatched — branch on dev, tip 8fc3ef4)_
 _Next DevTrack task ID: TASK-071_
 _Active branch: `dev`_
 _Shipped: v3.0.10 (2026-06-14) — significant Windows fixes + gitsage improvements._
@@ -783,9 +783,11 @@ clear the field (set to `""`). Never return an error — workspace still loads.
 ---
 
 ### TASK-068 — Branch-name ticket extraction on every commit trigger
+**Assigned to**: engineer
 **Priority**: HIGH
 **Phase**: Phase 2
-**Depends on**: TASK-067
+**Started**: 2026-06-16
+**Depends on**: TASK-067 (merged — PR #174, commit df78a8f)
 **Branch**: `feat/TASK-068-branch-ticket-extraction`
 
 **Spec**:
@@ -844,16 +846,18 @@ Log the result:
 In `devtrack_client/internal/infra/` (wherever `TriggerEvent` is defined), add `TicketID string`.
 
 **Acceptance criteria**:
-- [ ] Migration 007 present; `go build ./...` passes; new column added on first run
-- [ ] `TriggerRecord.TicketID` populated for every commit trigger
-- [ ] `WorkspaceMonitor.ticketPattern` set from `ws.TicketPattern`
-- [ ] Branch `feat/PROJ-123-add-login` on a workspace with default pattern → `ticket_id=PROJ-123` in log
-- [ ] Branch `main` or `chore/update-readme` → `ticket_id=unlinked` in log (no blocking, no error)
-- [ ] `CommitTriggerData.TicketID` included in the JSON payload POSTed to Python server
-- [ ] `go build ./...` and `go vet ./...` pass clean from `devtrack_client/`
+- [x] Migration 007 present; `go build ./...` passes; new column added on first run
+- [x] `TriggerRecord.TicketID` populated for every commit trigger
+- [x] `WorkspaceMonitor.ticketPattern` set from `ws.TicketPattern`
+- [x] Branch `feat/PROJ-123-add-login` on a workspace with default pattern → `ticket_id=PROJ-123` in log
+- [x] Branch `main` or `chore/update-readme` → `ticket_id=unlinked` in log (no blocking, no error)
+- [x] `CommitTriggerData.TicketID` included in the JSON payload POSTed to Python server
+- [x] `go build ./...` and `go vet ./...` pass clean from `devtrack_client/`
 
-**Engineer status**: not started
-**Blockers**: TASK-067 must be merged to dev first
+**Engineer status**: 7/7 criteria done — last commit: 319ec53 "feat(db): Add ticket ID extraction column and methods" — 2026-06-16 20:30
+**Blockers**: none — TASK-067 merged to dev (PR #174)
+
+**COMPLETE** — ready for PM review — 2026-06-16 20:35
 
 ---
 

--- a/devtrack_client/internal/db/database.go
+++ b/devtrack_client/internal/db/database.go
@@ -30,6 +30,7 @@ type TriggerRecord struct {
 	Author        string
 	Data          string // JSON data
 	Processed     bool
+	TicketID      string // extracted ticket ID (branch/message/active-ticket); "" = unlinked
 }
 
 // ResponseRecord represents a user response in the database
@@ -222,6 +223,7 @@ func (d *Database) initSchema() error {
 		author TEXT,
 		data TEXT,
 		processed BOOLEAN DEFAULT 0,
+		ticket_id TEXT DEFAULT '',
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	);
 
@@ -450,6 +452,7 @@ func (d *Database) initSchema() error {
 	for _, alter := range []string{
 		`ALTER TABLE deferred_commits ADD COLUMN base_sha TEXT`,
 		`ALTER TABLE deferred_commits ADD COLUMN snapshot_sha TEXT`,
+		`ALTER TABLE triggers ADD COLUMN ticket_id TEXT DEFAULT ''`,
 	} {
 		if _, err := d.db.Exec(alter); err != nil && !strings.Contains(err.Error(), "duplicate column") {
 			return fmt.Errorf("migration failed (%s): %w", alter, err)
@@ -461,8 +464,8 @@ func (d *Database) initSchema() error {
 // InsertTrigger inserts a trigger record into the database
 func (d *Database) InsertTrigger(record TriggerRecord) (int64, error) {
 	query := `
-		INSERT INTO triggers (trigger_type, timestamp, source, repo_path, commit_hash, commit_message, author, data, processed)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO triggers (trigger_type, timestamp, source, repo_path, commit_hash, commit_message, author, data, processed, ticket_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
 	result, err := d.db.Exec(query,
@@ -475,6 +478,7 @@ func (d *Database) InsertTrigger(record TriggerRecord) (int64, error) {
 		record.Author,
 		record.Data,
 		record.Processed,
+		record.TicketID,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("failed to insert trigger: %w", err)
@@ -572,7 +576,7 @@ func (d *Database) InsertLog(record LogRecord) error {
 // GetTriggerByID retrieves a trigger by ID
 func (d *Database) GetTriggerByID(id int64) (*TriggerRecord, error) {
 	query := `
-		SELECT id, trigger_type, timestamp, source, repo_path, commit_hash, commit_message, author, data, processed
+		SELECT id, trigger_type, timestamp, source, repo_path, commit_hash, commit_message, author, data, processed, COALESCE(ticket_id,'')
 		FROM triggers
 		WHERE id = ?
 	`
@@ -589,6 +593,7 @@ func (d *Database) GetTriggerByID(id int64) (*TriggerRecord, error) {
 		&record.Author,
 		&record.Data,
 		&record.Processed,
+		&record.TicketID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get trigger: %w", err)
@@ -600,7 +605,7 @@ func (d *Database) GetTriggerByID(id int64) (*TriggerRecord, error) {
 // GetRecentTriggers retrieves recent triggers
 func (d *Database) GetRecentTriggers(limit int) ([]TriggerRecord, error) {
 	query := `
-		SELECT id, trigger_type, timestamp, source, repo_path, commit_hash, commit_message, author, data, processed
+		SELECT id, trigger_type, timestamp, source, repo_path, commit_hash, commit_message, author, data, processed, COALESCE(ticket_id,'')
 		FROM triggers
 		ORDER BY timestamp DESC
 		LIMIT ?
@@ -626,6 +631,7 @@ func (d *Database) GetRecentTriggers(limit int) ([]TriggerRecord, error) {
 			&record.Author,
 			&record.Data,
 			&record.Processed,
+			&record.TicketID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan trigger: %w", err)
@@ -634,6 +640,29 @@ func (d *Database) GetRecentTriggers(limit int) ([]TriggerRecord, error) {
 	}
 
 	return triggers, nil
+}
+
+// GetLastTicketID returns the most recently extracted (non-empty) ticket ID
+// for commit triggers in the given repo. Used by the active-ticket fallback
+// strategy (TASK-069) when branch and commit-message extraction both fail.
+// Returns "" with no error when no prior matched commit exists.
+func (d *Database) GetLastTicketID(repoPath string) (string, error) {
+	var ticketID string
+	err := d.db.QueryRow(`
+		SELECT ticket_id FROM triggers
+		WHERE trigger_type='commit'
+		  AND repo_path=?
+		  AND ticket_id != ''
+		  AND ticket_id != 'unlinked'
+		ORDER BY timestamp DESC LIMIT 1
+	`, repoPath).Scan(&ticketID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to get last ticket id: %w", err)
+	}
+	return ticketID, nil
 }
 
 // GetUnsyncedTaskUpdates retrieves task updates that haven't been synced

--- a/devtrack_client/internal/db/migration_007_test.go
+++ b/devtrack_client/internal/db/migration_007_test.go
@@ -1,0 +1,83 @@
+package db
+
+import "testing"
+
+// TestMigration007_TicketIDColumnIdempotent verifies the core safety property
+// of migration 007 (add ticket_id to triggers): checking pragma_table_info
+// before ALTER means running the add-column step twice never errors, and the
+// column is usable for read/write either way.
+//
+// The migration's Apply func opens its own NewDatabase() (env-dependent), so
+// this test exercises the same idempotent-ALTER logic against a temp DB
+// instead of calling Apply directly — newTestDB's initSchema already creates
+// the column (TASK-068 added it to the base schema), so a fresh database
+// already satisfies the migration's postcondition without needing the ALTER.
+func TestMigration007_TicketIDColumnIdempotent(t *testing.T) {
+	database := newTestDB(t)
+
+	hasColumn := func() int {
+		var count int
+		if err := database.db.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('triggers') WHERE name='ticket_id'`,
+		).Scan(&count); err != nil {
+			t.Fatalf("pragma_table_info check: %v", err)
+		}
+		return count
+	}
+
+	if got := hasColumn(); got != 1 {
+		t.Fatalf("expected exactly 1 ticket_id column after initSchema, got %d", got)
+	}
+
+	// Simulate running the migration's guarded ALTER a second time — must be a no-op.
+	var count int
+	if err := database.db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('triggers') WHERE name='ticket_id'`,
+	).Scan(&count); err != nil {
+		t.Fatalf("pragma_table_info check: %v", err)
+	}
+	if count == 0 {
+		if _, err := database.db.Exec(`ALTER TABLE triggers ADD COLUMN ticket_id TEXT DEFAULT ''`); err != nil {
+			t.Fatalf("ALTER TABLE should not run (column already present) but errored: %v", err)
+		}
+	}
+
+	if got := hasColumn(); got != 1 {
+		t.Fatalf("expected exactly 1 ticket_id column after idempotent re-check, got %d", got)
+	}
+
+	// Column must be usable for read/write.
+	if _, err := database.db.Exec(
+		`INSERT INTO triggers (trigger_type, timestamp, source, ticket_id) VALUES ('commit', datetime('now'), 'git', 'PROJ-9')`,
+	); err != nil {
+		t.Fatalf("insert using ticket_id column: %v", err)
+	}
+	var ticketID string
+	if err := database.db.QueryRow(`SELECT ticket_id FROM triggers WHERE ticket_id='PROJ-9'`).Scan(&ticketID); err != nil {
+		t.Fatalf("select ticket_id: %v", err)
+	}
+	if ticketID != "PROJ-9" {
+		t.Errorf("ticket_id = %q, want %q", ticketID, "PROJ-9")
+	}
+}
+
+// TestAllMigrations_007Present confirms migration 007 is registered exactly
+// once in allMigrations with the expected ID, and that migration IDs are
+// unique and append-only (never reordered/removed — a basic regression guard
+// for the project's "append-only" migration rule).
+func TestAllMigrations_007Present(t *testing.T) {
+	seen := make(map[string]bool)
+	found007 := false
+	for _, m := range allMigrations {
+		if seen[m.ID] {
+			t.Errorf("duplicate migration ID: %s", m.ID)
+		}
+		seen[m.ID] = true
+		if m.ID == "007-add-ticket-id-to-triggers" {
+			found007 = true
+		}
+	}
+	if !found007 {
+		t.Error("expected migration 007-add-ticket-id-to-triggers to be registered in allMigrations")
+	}
+}

--- a/devtrack_client/internal/db/migrations.go
+++ b/devtrack_client/internal/db/migrations.go
@@ -125,6 +125,30 @@ var allMigrations = []Migration{
 			return err
 		},
 	},
+	{
+		ID:          "007-add-ticket-id-to-triggers",
+		Description: "Add ticket_id column to triggers table for Phase 2 ticket extraction",
+		Apply: func() error {
+			database, err := NewDatabase()
+			if err != nil {
+				return fmt.Errorf("open db: %w", err)
+			}
+			defer database.Close()
+
+			var count int
+			if err := database.db.QueryRow(
+				`SELECT COUNT(*) FROM pragma_table_info('triggers') WHERE name='ticket_id'`,
+			).Scan(&count); err != nil {
+				return fmt.Errorf("check ticket_id column: %w", err)
+			}
+			if count > 0 {
+				return nil // already present — idempotent no-op
+			}
+
+			_, err = database.db.Exec(`ALTER TABLE triggers ADD COLUMN ticket_id TEXT DEFAULT ''`)
+			return err
+		},
+	},
 }
 
 // RunPendingMigrations applies any migrations that have not yet been recorded

--- a/devtrack_client/internal/db/trigger_ticket_test.go
+++ b/devtrack_client/internal/db/trigger_ticket_test.go
@@ -1,0 +1,137 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+// TestInsertTrigger_TicketIDRoundTrip confirms TASK-068 acceptance criterion:
+// TriggerRecord.TicketID is persisted and read back for every commit trigger.
+func TestInsertTrigger_TicketIDRoundTrip(t *testing.T) {
+	database := newTestDB(t)
+
+	id, err := database.InsertTrigger(TriggerRecord{
+		TriggerType:   "commit",
+		Timestamp:     time.Now(),
+		Source:        "git",
+		RepoPath:      "/repo/devtrack",
+		CommitHash:    "abc1234",
+		CommitMessage: "feat: add login",
+		Author:        "dev",
+		TicketID:      "PROJ-123",
+	})
+	if err != nil {
+		t.Fatalf("InsertTrigger: %v", err)
+	}
+
+	got, err := database.GetTriggerByID(id)
+	if err != nil {
+		t.Fatalf("GetTriggerByID: %v", err)
+	}
+	if got.TicketID != "PROJ-123" {
+		t.Errorf("TicketID = %q, want %q", got.TicketID, "PROJ-123")
+	}
+}
+
+// TestInsertTrigger_UnlinkedTicketID confirms a commit with no extractable
+// ticket ID stores an empty string ("unlinked") without error.
+func TestInsertTrigger_UnlinkedTicketID(t *testing.T) {
+	database := newTestDB(t)
+
+	id, err := database.InsertTrigger(TriggerRecord{
+		TriggerType:   "commit",
+		Timestamp:     time.Now(),
+		Source:        "git",
+		RepoPath:      "/repo/devtrack",
+		CommitHash:    "def5678",
+		CommitMessage: "chore: update readme",
+		Author:        "dev",
+		TicketID:      "",
+	})
+	if err != nil {
+		t.Fatalf("InsertTrigger: %v", err)
+	}
+
+	got, err := database.GetTriggerByID(id)
+	if err != nil {
+		t.Fatalf("GetTriggerByID: %v", err)
+	}
+	if got.TicketID != "" {
+		t.Errorf("TicketID = %q, want empty string for unlinked commit", got.TicketID)
+	}
+}
+
+// TestGetRecentTriggers_IncludesTicketID confirms the list query also surfaces
+// the ticket_id column (not just the single-row lookup).
+func TestGetRecentTriggers_IncludesTicketID(t *testing.T) {
+	database := newTestDB(t)
+
+	if _, err := database.InsertTrigger(TriggerRecord{
+		TriggerType: "commit",
+		Timestamp:   time.Now(),
+		Source:      "git",
+		RepoPath:    "/repo/devtrack",
+		CommitHash:  "111aaaa",
+		TicketID:    "AB-7",
+	}); err != nil {
+		t.Fatalf("InsertTrigger: %v", err)
+	}
+
+	triggers, err := database.GetRecentTriggers(10)
+	if err != nil {
+		t.Fatalf("GetRecentTriggers: %v", err)
+	}
+	if len(triggers) != 1 {
+		t.Fatalf("expected 1 trigger, got %d", len(triggers))
+	}
+	if triggers[0].TicketID != "AB-7" {
+		t.Errorf("TicketID = %q, want %q", triggers[0].TicketID, "AB-7")
+	}
+}
+
+// TestGetLastTicketID confirms the active-ticket fallback query (used by
+// TASK-069) returns the most recently matched ticket for a repo, ignoring
+// unlinked (empty) commits, and "" when no prior matched commit exists.
+func TestGetLastTicketID(t *testing.T) {
+	database := newTestDB(t)
+
+	repoPath := "/repo/devtrack"
+
+	// No commits yet — should return "" with no error.
+	last, err := database.GetLastTicketID(repoPath)
+	if err != nil {
+		t.Fatalf("GetLastTicketID (empty): %v", err)
+	}
+	if last != "" {
+		t.Errorf("GetLastTicketID with no prior commits = %q, want empty", last)
+	}
+
+	base := time.Now().Add(-1 * time.Hour)
+	inserts := []TriggerRecord{
+		{TriggerType: "commit", Timestamp: base, Source: "git", RepoPath: repoPath, CommitHash: "h1", TicketID: "PROJ-1"},
+		{TriggerType: "commit", Timestamp: base.Add(10 * time.Minute), Source: "git", RepoPath: repoPath, CommitHash: "h2", TicketID: ""},
+		{TriggerType: "commit", Timestamp: base.Add(20 * time.Minute), Source: "git", RepoPath: repoPath, CommitHash: "h3", TicketID: "PROJ-2"},
+	}
+	for _, r := range inserts {
+		if _, err := database.InsertTrigger(r); err != nil {
+			t.Fatalf("InsertTrigger: %v", err)
+		}
+	}
+
+	last, err = database.GetLastTicketID(repoPath)
+	if err != nil {
+		t.Fatalf("GetLastTicketID: %v", err)
+	}
+	if last != "PROJ-2" {
+		t.Errorf("GetLastTicketID = %q, want %q (most recent matched commit, skipping unlinked h2)", last, "PROJ-2")
+	}
+
+	// A different repo path must not see this repo's tickets.
+	other, err := database.GetLastTicketID("/repo/other")
+	if err != nil {
+		t.Fatalf("GetLastTicketID (other repo): %v", err)
+	}
+	if other != "" {
+		t.Errorf("GetLastTicketID for unrelated repo = %q, want empty", other)
+	}
+}

--- a/devtrack_client/internal/infra/integrated.go
+++ b/devtrack_client/internal/infra/integrated.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sraj0501/Devtrack_/devtrack_client/internal/config"
 	"github.com/sraj0501/Devtrack_/devtrack_client/internal/db"
+	"github.com/sraj0501/Devtrack_/devtrack_client/internal/ticket"
 	"github.com/sraj0501/Devtrack_/devtrack_client/internal/trigger"
 )
 
@@ -30,6 +31,9 @@ type WorkspaceMonitor struct {
 	pmMilestone     int
 	// Filtering
 	ignoreBranches  []string // commits on these branches are silently skipped
+	// ticketPattern is a custom regex used to extract ticket IDs from branch
+	// names/commit messages for this workspace; empty = use default patterns.
+	ticketPattern string
 }
 
 // IntegratedMonitor combines Git monitoring and time-based scheduling
@@ -89,6 +93,7 @@ func NewIntegratedMonitor(repoPath string) (*IntegratedMonitor, error) {
 				pmAreaPath:      ws.PMAreaPath,
 				pmMilestone:     ws.PMMilestone,
 				ignoreBranches:  ws.IgnoreBranches,
+				ticketPattern:   ws.TicketPattern,
 			})
 			log.Printf("  ✓ Workspace %q → %s (platform: %q)", ws.Name, ws.Path, ws.PMPlatform)
 		}
@@ -281,6 +286,7 @@ func (im *IntegratedMonitor) ReloadWorkspaces() {
 			pmAreaPath:      ws.PMAreaPath,
 			pmMilestone:     ws.PMMilestone,
 			ignoreBranches:  ws.IgnoreBranches,
+			ticketPattern:   ws.TicketPattern,
 		}
 		wmCopy := wm
 		if err := wmCopy.gitMonitor.Start(func(commit CommitInfo) {
@@ -332,6 +338,12 @@ func (im *IntegratedMonitor) handleCommitForWorkspace(commit CommitInfo, ws *Wor
 	im.lastActiveWorkspace = ws
 	im.lastActiveWorkspaceMu.Unlock()
 
+	// Phase 2 ticket extraction: attempt to map this commit to a ticket ID via
+	// the branch name. ext.Extract returns "" (unlinked) on no match — never
+	// blocks or errors the trigger.
+	ext, _ := ticket.NewExtractor(ws.ticketPattern) // falls back to defaults on ""
+	ticketID := ext.Extract(commit.Branch)
+
 	event := TriggerEvent{
 		Type:            TriggerTypeCommit,
 		Timestamp:       commit.Timestamp,
@@ -345,6 +357,7 @@ func (im *IntegratedMonitor) handleCommitForWorkspace(commit CommitInfo, ws *Wor
 		PMIterationPath: ws.pmIterationPath,
 		PMAreaPath:      ws.pmAreaPath,
 		PMMilestone:     ws.pmMilestone,
+		TicketID:        ticketID,
 	}
 	im.handleTrigger(event)
 }
@@ -366,6 +379,11 @@ func (im *IntegratedMonitor) handleTrigger(event TriggerEvent) {
 			if event.WorkspaceName != "" {
 				workspace = event.WorkspaceName
 			}
+			if event.TicketID != "" {
+				log.Printf("trigger commit: hash=%s ticket_id=%q branch=%q", commit.Hash[:12], event.TicketID, commit.Branch)
+			} else {
+				log.Printf("trigger commit: hash=%s ticket_id=unlinked branch=%q", commit.Hash[:12], commit.Branch)
+			}
 			log.Printf("trigger commit: hash=%s author=%q files=%d workspace=%q message=%q",
 				commit.Hash[:12], commit.Author, len(commit.Files), workspace, commit.Message)
 
@@ -377,6 +395,7 @@ func (im *IntegratedMonitor) handleTrigger(event TriggerEvent) {
 				Timestamp:       commit.Timestamp.Format(time.RFC3339),
 				FilesChanged:    commit.Files,
 				Branch:          commit.Branch,
+				TicketID:        event.TicketID,
 				WorkspaceName:   event.WorkspaceName,
 				PMPlatform:      event.PMPlatform,
 				PMProject:       event.PMProject,
@@ -396,6 +415,7 @@ func (im *IntegratedMonitor) handleTrigger(event TriggerEvent) {
 				CommitMessage: commit.Message,
 				Author:        commit.Author,
 				Processed:     false,
+				TicketID:      event.TicketID,
 			}
 		}
 

--- a/devtrack_client/internal/infra/scheduler.go
+++ b/devtrack_client/internal/infra/scheduler.go
@@ -34,6 +34,7 @@ type TriggerEvent struct {
 	// Workspace context (populated for commit triggers in multi-repo mode)
 	RepoPath        string
 	WorkspaceName   string
+	TicketID        string // extracted from branch name (or "" if unlinked)
 	PMPlatform      string
 	PMProject       string
 	// Per-workspace PM settings (override global .env defaults)

--- a/devtrack_client/internal/infra/ticket_extraction_test.go
+++ b/devtrack_client/internal/infra/ticket_extraction_test.go
@@ -1,0 +1,80 @@
+package infra
+
+import (
+	"testing"
+
+	"github.com/sraj0501/Devtrack_/devtrack_client/internal/ticket"
+)
+
+// TestWorkspaceMonitor_TicketPattern_DefaultExtraction mirrors the extraction
+// call in handleCommitForWorkspace (TASK-068): a WorkspaceMonitor with no
+// custom ticketPattern falls back to the default patterns, so a branch named
+// after a Jira/ADO-style ticket produces a populated TicketID on the event.
+func TestWorkspaceMonitor_TicketPattern_DefaultExtraction(t *testing.T) {
+	ws := &WorkspaceMonitor{workspaceName: "default-pattern-ws", ticketPattern: ""}
+
+	ext, err := ticket.NewExtractor(ws.ticketPattern)
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+
+	got := ext.Extract("feat/PROJ-123-add-login")
+	if got != "PROJ-123" {
+		t.Errorf("Extract(branch) = %q, want %q", got, "PROJ-123")
+	}
+}
+
+// TestWorkspaceMonitor_TicketPattern_NoMatchIsUnlinked confirms a branch with
+// no extractable ticket (e.g. "main", "chore/update-readme") yields an empty
+// TicketID — the "unlinked" case — without error or panic.
+func TestWorkspaceMonitor_TicketPattern_NoMatchIsUnlinked(t *testing.T) {
+	ws := &WorkspaceMonitor{workspaceName: "default-pattern-ws", ticketPattern: ""}
+
+	ext, err := ticket.NewExtractor(ws.ticketPattern)
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+
+	cases := []string{"main", "chore/update-readme"}
+	for _, branch := range cases {
+		if got := ext.Extract(branch); got != "" {
+			t.Errorf("Extract(%q) = %q, want empty (unlinked)", branch, got)
+		}
+	}
+}
+
+// TestWorkspaceMonitor_TicketPattern_CustomOverridesDefault confirms a
+// workspace-level custom ticketPattern (from workspaces.yaml's ticket_pattern
+// field) is honoured instead of the default multi-pattern extractor.
+func TestWorkspaceMonitor_TicketPattern_CustomOverridesDefault(t *testing.T) {
+	ws := &WorkspaceMonitor{workspaceName: "custom-pattern-ws", ticketPattern: `(?P<ticket>DT-\d+)`}
+
+	ext, err := ticket.NewExtractor(ws.ticketPattern)
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+
+	// Matches the custom pattern.
+	if got := ext.Extract("feat/DT-999-thing"); got != "DT-999" {
+		t.Errorf("Extract with custom pattern = %q, want %q", got, "DT-999")
+	}
+
+	// A default-pattern-style ticket ID (Jira PROJ-123) must NOT match once a
+	// custom pattern is set — custom patterns are exclusive, not additive.
+	if got := ext.Extract("feat/PROJ-123-add-login"); got != "" {
+		t.Errorf("Extract with custom pattern matched default-style ticket: got %q, want empty", got)
+	}
+}
+
+// TestTriggerEvent_CarriesTicketID confirms the TriggerEvent struct (the
+// payload handed from handleCommitForWorkspace to handleTrigger) has the
+// TicketID field threaded through, per TASK-068 step 6.
+func TestTriggerEvent_CarriesTicketID(t *testing.T) {
+	event := TriggerEvent{
+		Type:     TriggerTypeCommit,
+		TicketID: "PROJ-123",
+	}
+	if event.TicketID != "PROJ-123" {
+		t.Errorf("TriggerEvent.TicketID = %q, want %q", event.TicketID, "PROJ-123")
+	}
+}

--- a/devtrack_client/internal/trigger/http_trigger_test.go
+++ b/devtrack_client/internal/trigger/http_trigger_test.go
@@ -175,6 +175,54 @@ func TestHTTPTriggerClient_SendCommitTrigger_PayloadJSON(t *testing.T) {
 	}
 }
 
+// TestHTTPTriggerClient_SendCommitTrigger_TicketIDInPayload confirms TASK-068
+// wiring: a populated TicketID on CommitTriggerData reaches the JSON body
+// POSTed to the Python server.
+func TestHTTPTriggerClient_SendCommitTrigger_TicketIDInPayload(t *testing.T) {
+	var body map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := clientFor(t, srv.URL, "")
+	_ = c.SendCommitTrigger(CommitTriggerData{
+		CommitHash: "abc123",
+		Branch:     "feat/PROJ-123-add-login",
+		TicketID:   "PROJ-123",
+	})
+
+	if body["ticket_id"] != "PROJ-123" {
+		t.Errorf("payload ticket_id mismatch: %v", body["ticket_id"])
+	}
+}
+
+// TestHTTPTriggerClient_SendCommitTrigger_UnlinkedTicketIDOmitted confirms the
+// omitempty tag drops ticket_id from the JSON payload entirely when the
+// extractor found no match (unlinked commit) — never blocks the trigger.
+func TestHTTPTriggerClient_SendCommitTrigger_UnlinkedTicketIDOmitted(t *testing.T) {
+	var body map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := clientFor(t, srv.URL, "")
+	_ = c.SendCommitTrigger(CommitTriggerData{
+		CommitHash: "abc123",
+		Branch:     "main",
+		TicketID:   "",
+	})
+
+	if _, present := body["ticket_id"]; present {
+		t.Errorf("expected ticket_id to be omitted from payload when unlinked, got %v", body["ticket_id"])
+	}
+}
+
 // ---------------------------------------------------------------------------
 // SendTimerTrigger
 // ---------------------------------------------------------------------------

--- a/devtrack_client/internal/trigger/types.go
+++ b/devtrack_client/internal/trigger/types.go
@@ -13,6 +13,7 @@ type CommitTriggerData struct {
 	Timestamp     string   `json:"timestamp"`
 	FilesChanged  []string `json:"files_changed"`
 	Branch        string   `json:"branch"`
+	TicketID      string   `json:"ticket_id,omitempty"`
 	// Workspace routing fields (omitempty — zero value = fall back to priority chain)
 	WorkspaceName string `json:"workspace_name,omitempty"`
 	PMPlatform    string `json:"pm_platform,omitempty"`


### PR DESCRIPTION
## Summary

- Wires the `internal/ticket` extractor (TASK-067) into the commit trigger flow: every commit attempt now extracts a ticket ID from the branch name, or logs/stores it as unlinked. No commit is ever blocked.
- Adds migration `007-add-ticket-id-to-triggers` (idempotent via `pragma_table_info`) plus the column directly in `initSchema()` so fresh installs get it without waiting on the migration runner.
- Threads `TicketID` through `TriggerEvent` → `TriggerRecord` (SQLite) → `CommitTriggerData` (JSON payload to the Python server, `omitempty` so unlinked commits drop the field).
- `WorkspaceMonitor.ticketPattern` is now set from `ws.TicketPattern` in both `NewIntegratedMonitor()` and `ReloadWorkspaces()`, so per-workspace custom patterns (configured in TASK-067) take effect.
- Added `Database.GetLastTicketID(repoPath)` ahead of schedule — it's the exact query TASK-069's active-ticket fallback strategy needs.

Closes TASK-068 on the project board.

## Test plan

- [x] `go build ./...` clean from `devtrack_client/`
- [x] `go vet ./...` clean from `devtrack_client/`
- [x] `go test ./...` — full suite passes, including new tests:
  - `internal/db/migration_007_test.go` — idempotent column-add, migration ID uniqueness
  - `internal/db/trigger_ticket_test.go` — TicketID round-trip, unlinked commit, `GetRecentTriggers` includes ticket_id, `GetLastTicketID` happy/empty/cross-repo cases
  - `internal/infra/ticket_extraction_test.go` — default pattern extraction, no-match unlinked, custom pattern override, `TriggerEvent.TicketID` field
  - `internal/trigger/http_trigger_test.go` — ticket_id present in JSON payload when populated, omitted (`omitempty`) when unlinked
- [x] Manual verification: branch `feat/PROJ-123-add-login` → `ticket_id="PROJ-123"`; branch `main`/`chore/update-readme` → unlinked, no error, trigger still processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)