### PR TITLE
TASK-069: Commit-message fallback + active-ticket fallback

### DIFF
--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -1343,3 +1343,31 @@ Pre-existing test failure (test_find_related_projects) confirmed unchanged.
 - Blockers encountered: none
 - One thing that still feels rough: the AI commit-message enhancement summarized only the `db` package half of the diff; for a 3-package change spanning db/infra/trigger, a one-line title understandably can't cover everything, but it's worth knowing the enhancer weights "what changed most" by file count/lines rather than "what's most architecturally significant."
 - Ready for PM review: YES
+
+---
+
+### [2026-06-16 20:50] TASK-069 — feat(infra): Implement staged commit-message and active-ticket fallback
+
+**Original message**: "feat(infra): commit-message and active-ticket fallback for ticket extraction (TASK-069)"
+**DevTrack enhanced it to**: "feat(infra): Implement staged commit-message and active-ticket fallback — Updates the ticket extraction logic in `handleCommitForWorkspace` to use a three-stage strategy when determining a linked task ID for a commit: 1. Branch Name (highest priority). 2. Commit Message Scan (if stage 1 fails). 3. Active-Ticket Fallback (if stages 1 and 2 fail, checks a persisted 'last active ticket' ID stored in the database for that repository path). Corresponding unit tests have been added to validate this new fallback chain logic."
+**Ticket auto-linked**: NO — no PM platform configured on the active workspace (`mogrov.com`, platform: none)
+**PM system updated**: YES — project_board.md TASK-069 marked COMPLETE; all 7 criteria ticked; PR URL posted
+**Time**: ~15 minutes
+**Friction**: LOW — discovered during pre-work investigation that `Database.GetLastTicketID(repoPath)` and its full test suite (`TestGetLastTicketID` in `trigger_ticket_test.go`) had already been implemented ahead of schedule during TASK-068, exactly as the PM's dispatch note warned ("verify its exact signature... since the task spec's SQL is illustrative, not necessarily the literal existing implementation"). Likewise the unlinked-logging requirement and two of the three spec'd unit tests (`Extract("feat/no-ticket-here")` and `Extract("fix bug in login AB-99")`) already existed in `internal/ticket/extractor_test.go`. Only the actual wiring into `handleCommitForWorkspace` (the two fallback `if` blocks) was missing.
+**Notes**:
+- `handleCommitForWorkspace()` in `devtrack_client/internal/infra/integrated.go`: after branch extraction (`ext.Extract(commit.Branch)`), added strategy 2 (`ext.Extract(commit.Message)` when branch result is empty, logged with `(from commit message)`) and strategy 3 (`im.database.GetLastTicketID(ws.gitMonitor.repoPath)` when both branch and message are empty, logged with `(active-ticket fallback)`), matching the spec's code blocks verbatim including the `commit.Hash[:8]` slice length (the pre-existing match/unlinked log lines a few steps later use `[:12]` — left as-is since that was out of scope and not flagged as inconsistent in the spec).
+- `CommitTriggerData.TicketID` / `TriggerRecord.TicketID` required no changes — both already read from `event.TicketID`/`ticketID` (TASK-068 wiring), and `ticketID` is fully resolved (all three strategies) before `TriggerEvent` is constructed, so the existing flow-through picks up whichever strategy won automatically.
+- Unlinked logging (`ticket_id=unlinked`) already existed in `handleTrigger()` from TASK-068 — verified present, did not duplicate it.
+- Added 3 new tests to `devtrack_client/internal/infra/ticket_extraction_test.go`: `TestFallbackChain_BranchMatchWinsOverMessage` (branch short-circuits before message is consulted), `TestFallbackChain_MessageScanRunsWhenBranchEmpty` (message scan fires and returns `AB-99` when branch is empty), `TestFallbackChain_AllStrategiesFailYieldsUnlinked` (branch=`main`, message=`chore: update docs` -> `""`, matching the acceptance-criterion fixture exactly). These follow the same lightweight pattern as TASK-068's existing tests in the same file (direct `ticket.NewExtractor` calls mirroring the production call sites) rather than spinning up a full `IntegratedMonitor`/DB/HTTP integration harness, since `handleTrigger` makes a live HTTP POST to the Python server with no mock seam — the DB-level `GetLastTicketID` behavior is already covered exhaustively by TASK-068's `TestGetLastTicketID`.
+- `go build ./...`, `go vet ./...`, and `go test ./...` all pass clean from `devtrack_client/` (full suite).
+- Daemon was already running (PID 34920) at session start — no restart needed.
+
+## Task Summary — TASK-069: Commit-message fallback + active-ticket fallback — 2026-06-16
+
+- Total commits: 1 (6fc4e64 implementation + tests; board/log updates to follow in a second commit)
+- Acceptance criteria met: 7/7
+- Tickets auto-updated: 0 (no PM platform on active workspace)
+- Estimated daily time saved: N/A (continues foundational wiring for Phase 2 — TASK-070 will surface hit-rate metrics built on this fallback chain)
+- Blockers encountered: none
+- One thing that still feels rough: a meaningful fraction of this task's spec'd deliverables (the DB method, its tests, the unlinked logging, two of three unit tests) had already been built one task early during TASK-068. Worth flagging to the PM that task boundaries in a tightly sequential phase like this one blur in practice — the engineer doing TASK-068 reasonably front-loaded TASK-069's DB dependency rather than leaving a stub, which was the right call, but it means TASK-069's actual diff is much smaller than the spec implies.
+- Ready for PM review: YES

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1,6 +1,6 @@
 # DevTrack Project Board
 
-_Last updated: 2026-06-16 by PM (TASK-068 dispatched — branch on dev, tip 8fc3ef4)_
+_Last updated: 2026-06-16 by PM (TASK-069 dispatched — dev tip 219768c)_
 _Next DevTrack task ID: TASK-071_
 _Active branch: `dev`_
 _Shipped: v3.0.10 (2026-06-14) — significant Windows fixes + gitsage improvements._
@@ -863,9 +863,11 @@ In `devtrack_client/internal/infra/` (wherever `TriggerEvent` is defined), add `
 ---
 
 ### TASK-069 — Commit-message fallback + active-ticket fallback
+**Assigned to**: engineer
 **Priority**: HIGH
 **Phase**: Phase 2
-**Depends on**: TASK-068
+**Started**: 2026-06-16
+**Depends on**: TASK-068 (MERGED — PR #175, tip 219768c on dev)
 **Branch**: `feat/TASK-069-commit-message-fallback`
 
 **Spec**:
@@ -925,16 +927,19 @@ processed normally — unlinked commits are never blocked.
 - Verify `GetLastTicketID` returns the ticket from the most recent matched commit
 
 **Acceptance criteria**:
-- [ ] Commit message scan runs when branch extraction returns `""`
-- [ ] Active-ticket fallback runs when both branch and message return `""`
-- [ ] `GetLastTicketID(repoPath)` method exists on `Database`; returns `""` when no prior matched commits
-- [ ] Log line distinguishes source: `(from commit message)` or `(active-ticket fallback)` or `unlinked`
-- [ ] `CommitTriggerData.TicketID` is populated from whichever strategy succeeded
-- [ ] A commit on branch `main` with message `"chore: update docs"` and no prior commits → `ticket_id=""` in DB, `unlinked` in log
-- [ ] `go build ./...` and `go vet ./...` pass clean
+- [x] Commit message scan runs when branch extraction returns `""`
+- [x] Active-ticket fallback runs when both branch and message return `""`
+- [x] `GetLastTicketID(repoPath)` method exists on `Database`; returns `""` when no prior matched commits
+- [x] Log line distinguishes source: `(from commit message)` or `(active-ticket fallback)` or `unlinked`
+- [x] `CommitTriggerData.TicketID` is populated from whichever strategy succeeded
+- [x] A commit on branch `main` with message `"chore: update docs"` and no prior commits → `ticket_id=""` in DB, `unlinked` in log
+- [x] `go build ./...` and `go vet ./...` pass clean
 
-**Engineer status**: not started
-**Blockers**: TASK-068 must be merged to dev first
+**Engineer status**: 7/7 criteria done — last commit: 6fc4e64 "feat(infra): Implement staged commit-message and active-ticket fallback" — 2026-06-16 20:50
+**PR**: https://github.com/sraj0501/Devtrack_/pull/176
+**Blockers**: none
+
+**COMPLETE** — ready for PM review — 2026-06-16 20:50
 
 ---
 

--- a/devtrack_client/internal/infra/integrated.go
+++ b/devtrack_client/internal/infra/integrated.go
@@ -338,11 +338,29 @@ func (im *IntegratedMonitor) handleCommitForWorkspace(commit CommitInfo, ws *Wor
 	im.lastActiveWorkspace = ws
 	im.lastActiveWorkspaceMu.Unlock()
 
-	// Phase 2 ticket extraction: attempt to map this commit to a ticket ID via
-	// the branch name. ext.Extract returns "" (unlinked) on no match — never
-	// blocks or errors the trigger.
+	// Phase 2 ticket extraction: attempt to map this commit to a ticket ID.
+	// Three strategies, in order — never blocks or errors the trigger:
+	//   1. Branch name (e.g. feat/PROJ-123-add-login)
+	//   2. Commit message scan (TASK-069 strategy 2)
+	//   3. Active-ticket fallback — last successfully matched ticket for this
+	//      repo (TASK-069 strategy 3)
+	// If all three fail, ticketID stays "" and the trigger is logged unlinked.
 	ext, _ := ticket.NewExtractor(ws.ticketPattern) // falls back to defaults on ""
 	ticketID := ext.Extract(commit.Branch)
+
+	if ticketID == "" {
+		ticketID = ext.Extract(commit.Message)
+		if ticketID != "" {
+			log.Printf("trigger commit: hash=%s ticket_id=%q (from commit message)", commit.Hash[:8], ticketID)
+		}
+	}
+
+	if ticketID == "" && im.database != nil {
+		if last, err := im.database.GetLastTicketID(ws.gitMonitor.repoPath); err == nil && last != "" {
+			ticketID = last
+			log.Printf("trigger commit: hash=%s ticket_id=%q (active-ticket fallback)", commit.Hash[:8], ticketID)
+		}
+	}
 
 	event := TriggerEvent{
 		Type:            TriggerTypeCommit,

--- a/devtrack_client/internal/infra/ticket_extraction_test.go
+++ b/devtrack_client/internal/infra/ticket_extraction_test.go
@@ -78,3 +78,81 @@ func TestTriggerEvent_CarriesTicketID(t *testing.T) {
 		t.Errorf("TriggerEvent.TicketID = %q, want %q", event.TicketID, "PROJ-123")
 	}
 }
+
+// --- TASK-069: commit-message fallback + active-ticket fallback ---------
+//
+// These tests mirror the three-strategy fallback chain implemented in
+// handleCommitForWorkspace: branch -> commit message -> active-ticket
+// (DB lookup). The DB-backed third strategy is covered separately by
+// TestGetLastTicketID in internal/db/trigger_ticket_test.go; here we
+// exercise strategies 1 and 2 exactly as handleCommitForWorkspace calls them.
+
+// TestFallbackChain_BranchMatchWinsOverMessage confirms strategy 1 (branch)
+// short-circuits the chain — when the branch already yields a ticket, the
+// commit message is never consulted.
+func TestFallbackChain_BranchMatchWinsOverMessage(t *testing.T) {
+	ext, err := ticket.NewExtractor("")
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+
+	branch := "feat/PROJ-123-add-login"
+	message := "fix bug in login AB-99"
+
+	ticketID := ext.Extract(branch)
+	if ticketID == "" {
+		ticketID = ext.Extract(message)
+	}
+
+	if ticketID != "PROJ-123" {
+		t.Errorf("ticketID = %q, want %q (branch match should win over message)", ticketID, "PROJ-123")
+	}
+}
+
+// TestFallbackChain_MessageScanRunsWhenBranchEmpty confirms strategy 2: when
+// branch extraction returns "", the commit message is scanned next and its
+// match is used as the ticket ID.
+func TestFallbackChain_MessageScanRunsWhenBranchEmpty(t *testing.T) {
+	ext, err := ticket.NewExtractor("")
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+
+	branch := "feat/no-ticket-here"
+	message := "fix bug in login AB-99"
+
+	ticketID := ext.Extract(branch)
+	if ticketID != "" {
+		t.Fatalf("branch extraction = %q, want empty for this test fixture", ticketID)
+	}
+	ticketID = ext.Extract(message)
+
+	if ticketID != "AB-99" {
+		t.Errorf("ticketID = %q, want %q (message-scan fallback)", ticketID, "AB-99")
+	}
+}
+
+// TestFallbackChain_AllStrategiesFailYieldsUnlinked confirms that when branch
+// and message extraction both fail (and there is no active-ticket fallback
+// available), the final ticketID is "" — the unlinked case. This matches the
+// acceptance criterion: a commit on branch "main" with message "chore:
+// update docs" and no prior commits produces ticket_id="".
+func TestFallbackChain_AllStrategiesFailYieldsUnlinked(t *testing.T) {
+	ext, err := ticket.NewExtractor("")
+	if err != nil {
+		t.Fatalf("NewExtractor: %v", err)
+	}
+
+	branch := "main"
+	message := "chore: update docs"
+
+	ticketID := ext.Extract(branch)
+	if ticketID == "" {
+		ticketID = ext.Extract(message)
+	}
+	// No active-ticket fallback simulated here (no prior matched commits).
+
+	if ticketID != "" {
+		t.Errorf("ticketID = %q, want empty (unlinked)", ticketID)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds strategy 2 (commit-message scan) and strategy 3 (active-ticket fallback via `Database.GetLastTicketID`) to the ticket-extraction chain in `handleCommitForWorkspace`, completing the three-tier fallback: branch -> commit message -> last matched ticket for the repo.
- `GetLastTicketID(repoPath string) (string, error)` already existed on `Database` (added ahead of schedule alongside TASK-068's migration 007); this PR wires it into the commit trigger flow rather than reimplementing it.
- Log lines now distinguish source: `(from commit message)`, `(active-ticket fallback)`, or `ticket_id=unlinked` (unlinked logging already existed from TASK-068).
- `CommitTriggerData.TicketID` / `TriggerRecord.TicketID` already flow from `event.TicketID` (TASK-068 wiring) — no change needed there since `ticketID` is resolved before `TriggerEvent` construction.
- Added unit tests in `devtrack_client/internal/infra/ticket_extraction_test.go` covering the fallback chain order (branch wins over message; message runs when branch is empty; all-fail yields unlinked). Pre-existing tests in `internal/ticket/extractor_test.go` and `internal/db/trigger_ticket_test.go` already covered `Extract("feat/no-ticket-here")`, `Extract("fix bug in login AB-99")`, and `GetLastTicketID` per the task spec.

Closes TASK-069 on the project board.

## Test plan
- [x] `go build ./...` clean from `devtrack_client/`
- [x] `go vet ./...` clean from `devtrack_client/`
- [x] `go test ./...` clean from `devtrack_client/` (all packages pass)
- [x] New fallback-chain tests pass: `TestFallbackChain_BranchMatchWinsOverMessage`, `TestFallbackChain_MessageScanRunsWhenBranchEmpty`, `TestFallbackChain_AllStrategiesFailYieldsUnlinked`
- [x] Existing `TestGetLastTicketID` (db) and extractor tests for `AB-99` / `no-ticket-here` confirmed passing