### PR TITLE
TASK-071: Wire Phase 2 ticket_id into process_commit

### DIFF
--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -1435,3 +1435,31 @@ Pre-existing test failure (test_find_related_projects) confirmed unchanged.
 - Blockers encountered: none
 - One thing that still feels rough: three pre-existing unit tests in `test_http_triggers.py` were silently relying on the absence of a `ticket_id` field rather than asserting it explicitly — easy to miss when changing the meaning of an implicit default. Worth a convention going forward: test payload constants should make implicit-default fields explicit when a future change could shift their meaning.
 - Ready for PM review: YES
+
+---
+
+### [2026-06-16 22:18] TASK-071 (fix-up) — fix(server): PM sync must not skip when NLP task_data is None but ticket_id resolved
+
+**Original message**: "fix(server): PM sync must not skip when NLP task_data is None but ticket_id resolved"
+**DevTrack enhanced it to**: "feat(server): Ensure PM sync on ticket ID when NLP enrichment fails — The process commit action for PM synchronization should not skip simply because the Natural Language Processing (NLP) stage failed or returned no data. When a Phase-2 resolved ticket ID is available, `task_data` should be treated as optional enrichment; therefore, we now ensure that the system stages the comment even if NLP is unavailable, falling back to the raw commit message for descriptions and comments."
+**Ticket auto-linked**: NO (no PM platform on active workspace)
+**PM system updated**: YES — project_board.md TASK-071 fix-up note added under the existing COMPLETE block; commit hash + summary posted
+**Time**: ~12 minutes
+**Friction**: LOW — bug and required fix were both fully specified by the PM with exact line numbers and before/after code; the only judgment call was how to handle the one pre-existing test (`test_skips_pm_sync_when_nlp_returns_none`) that had encoded the buggy behavior as its expected assertion.
+**Notes**:
+- Root cause: the "PM sync" stage was gated `elif task_data and self.workspace_router:` — so a resolved `resolved_ticket_id` plus a live `workspace_router` were not enough to stage an action if `task_data` was `None` (NLP parser absent, e.g. spaCy not installed, or `nlp_parser.parse()` raised inside the try/except in the "NLP parse" stage immediately above). This silently broke Phase 3's "commit -> ticket commented... dev did nothing" exit criterion on any setup with degraded NLP — a state CLAUDE.md explicitly documents as supported graceful degradation, not an error case.
+- Fix: condition changed to `elif self.workspace_router:`. Inside the branch, `description = task_data.get("description", commit_msg) if task_data else commit_msg` and `status = task_data.get("status", "") if task_data else ""` — both feed `pm_payload["description"]` and `pm_payload["comment"]` (previously both called `task_data.get(...)` directly, which would have raised `AttributeError` on `None` the moment this gate was loosened, so the guard was necessary, not optional).
+- Updated `test_skips_pm_sync_when_nlp_returns_none` -> renamed `test_stages_pm_sync_when_nlp_returns_none_but_ticket_id_resolved`, now asserts `_queue_gateway.stage()` IS called with `target="GH-1"` and description falling back to the raw commit message.
+- Added two new regression tests in `TestProcessCommitQueueStaging`: `test_stages_when_task_data_is_none_but_ticket_id_resolved` (parser absent entirely) and `test_stages_when_nlp_parse_raises_but_ticket_id_resolved` (parser present but `.parse()` raises) — both assert staging happens with the commit message as the description fallback.
+- `uv run pytest backend/tests/ -q` -> 625 passed, 1 pre-existing documented failure (`test_ollama_host_returns_string`, `OLLAMA_HOST` env leak — unrelated to this change). No other regressions.
+- Pushed to the existing branch `feat/TASK-071-wire-ticket-id-into-process-commit`; PR #178 updated automatically via the push, no new PR opened.
+
+## Task Summary — TASK-071 (fix-up): PM sync NLP-degraded regression fix — 2026-06-16
+
+- Total commits: 1 (dddaf55), 2 total across the full TASK-071 lifecycle (dffd32c, dddaf55)
+- Acceptance criteria met: 8/8 (original) + bug fix verified with 2 new regression tests + 1 updated test
+- Tickets auto-updated: 0 (no PM platform on active workspace)
+- Estimated daily time saved: N/A — correctness fix; its value is making Phase 3 ticket commenting actually work on NLP-degraded setups instead of silently no-opping
+- Blockers encountered: none
+- One thing that still feels rough: `test_skips_pm_sync_when_nlp_returns_none` had quietly encoded the bug as the expected behavior — a reminder that test names asserting a negative ("skips X") deserve extra scrutiny when the surrounding logic changes, since a passing test gave false confidence the old gate was intentional.
+- Ready for PM review: YES

--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -1403,3 +1403,35 @@ Pre-existing test failure (test_find_related_projects) confirmed unchanged.
 - Ready for PM review: YES
 - Phase 2 exit criterion status: **MET** — verified live against the real trigger pipeline, not just unit tests. `devtrack status` now shows PASS/BELOW TARGET objectively.
 - Ready for PM review: YES
+
+---
+
+### [2026-06-16 21:52] TASK-071 — feat(server): Wire ticket_id into process_commit and drop fallback commit_hash
+
+**Original message**: "fix(server): wire Phase 2 ticket_id into process_commit, drop commit_hash fallback"
+**DevTrack enhanced it to**: "feat(server): Wire ticket_id into process_commit and drop fallback commit_hash — Refactors the trigger processing logic to use `ticket_id` from the payload as the single authoritative target for queuing. This change eliminates reliance on the old, less reliable `commit_hash[:12]` fallback mechanism for determining the queue target, aligning with Phase 2 resolution strategies. This updates core testing and webhook handling logic accordingly."
+**Ticket auto-linked**: NO (no PM platform on active workspace)
+**PM system updated**: YES — project_board.md TASK-071 marked COMPLETE; all 8 criteria ticked; PR URL posted
+**Time**: ~25 minutes
+**Friction**: LOW — spec gave exact before/after code snippets and line ranges; the only judgment call was how to update the three pre-existing tests in `test_http_triggers.py` that implicitly relied on the old behavior (no `ticket_id` key in `COMMIT_PAYLOAD` meant the legacy NLP-guess path always ran) — fixed by adding an explicit `ticket_id` to the payload where the test's intent was "router gets called," and adding new tests for the now-meaningful absent/empty cases.
+**Notes**:
+- `process_commit` now reads `resolved_ticket_id = data.get("ticket_id", "")` immediately after the other field reads (Phase 2 Go-resolved signal).
+- The "PM sync" `_stage` block is now gated `if not resolved_ticket_id: <skip, log, no exception>  elif task_data and self.workspace_router: <build payload>`. This guarantees the staging/legacy-fallback code path is only ever reached with a non-empty, Go-resolved ticket ID.
+- Deleted `ticket_id = task_data.get("ticket_id", "") or commit_hash[:12]` entirely — replaced with `ticket_id = resolved_ticket_id`. The bogus truncated-hash PM target can no longer be produced.
+- Confidence is now a flat `0.85` constant (was `0.80/0.70` conditioned on NLP's own guess) — confidence reflects Phase 2's verified ~100% hit rate for the Go-resolved ID, not whether NLP separately guessed a ticket.
+- `pm_payload["ticket_id"]` now also sources from `resolved_ticket_id`.
+- Updated 3 existing tests in `test_http_triggers.py` (`test_calls_workspace_router_when_nlp_parses`, `test_skips_pm_sync_when_nlp_returns_none`, `test_skips_pm_sync_when_no_workspace_router`) to pass an explicit `ticket_id` on the payload where the test needs the router to actually run.
+- Added 5 new tests: `test_skips_pm_sync_when_ticket_id_absent`, `test_skips_pm_sync_when_ticket_id_empty_string`, `test_no_commit_hash_truncation_fallback_target` (in `TestTriggerProcessorCommit`), plus a new `TestProcessCommitQueueStaging` class with `test_stages_with_resolved_ticket_id_as_target`, `test_confidence_independent_of_nlp_ticket_guess`, `test_does_not_stage_when_ticket_id_absent` — these exercise the actual `_queue_gateway.stage()` call with a mock gateway (the pre-existing tests in this file never set `_queue_gateway`, so they only ever touched the legacy direct-post fallback).
+- `uv run pytest backend/tests/test_http_triggers.py -q` → 34/34 passed.
+- `uv run pytest backend/tests/ -q` → 623 passed, 1 pre-existing documented failure (`test_ollama_host_returns_string`), no regressions.
+- Hardcoded-values scan on diff: clean — the one `localhost:11434` hit in `webhook_server.py` is pre-existing code outside this diff (confirmed via `git diff dev -- webhook_server.py`).
+
+## Task Summary — TASK-071: Wire Phase 2 ticket_id into process_commit; graceful skip when unlinked — 2026-06-16
+
+- Total commits: 1 (dffd32c)
+- Acceptance criteria met: 8/8
+- Tickets auto-updated: 0 (no PM platform on active workspace)
+- Estimated daily time saved: N/A — this is a correctness fix removing a bogus PM-target bug (`commit_hash[:12]`), not a new time-saving feature; its value is unblocking every later Phase 3 task by making the queue action's target trustworthy.
+- Blockers encountered: none
+- One thing that still feels rough: three pre-existing unit tests in `test_http_triggers.py` were silently relying on the absence of a `ticket_id` field rather than asserting it explicitly — easy to miss when changing the meaning of an implicit default. Worth a convention going forward: test payload constants should make implicit-default fields explicit when a future change could shift their meaning.
+- Ready for PM review: YES

--- a/Data/agent_logs/feature_tracker.md
+++ b/Data/agent_logs/feature_tracker.md
@@ -1,6 +1,6 @@
 # DevTrack Feature Tracker
 
-_Last updated: 2026-06-16 by PM (TASK-070 complete, PR #177 open against dev — Phase 2 CLOSED)_
+_Last updated: 2026-06-16 by PM (TASK-071 complete + PM-verified, PR #178 open against dev)_
 
 ---
 
@@ -18,7 +18,7 @@ _Last updated: 2026-06-16 by PM (TASK-070 complete, PR #177 open against dev —
 | 0 | Foundation reset (silent daemon) | DONE | Daemon runs a full day with no prompts shown |
 | 1 | Pending actions queue | DONE | A week of outbound actions all staged; nothing unexpected posts |
 | 2 | Opinionated ticket extractor | DONE | >80% commits mapped to tickets, no config beyond branch naming — verified 100% (10/10) live |
-| 3 | Silent commit handler | ACTIVE — next up | Commit → ticket commented + state-transitioned; dev did nothing |
+| 3 | Silent commit handler | ACTIVE — TASK-071 in progress | Commit → ticket commented + state-transitioned; dev did nothing |
 | 4 | EOD pipeline | QUEUED | Accurate EOD email every evening, in the dev's voice |
 | 5 | Voice training (low friction) | QUEUED | Generated text passes "did I write this?" after 1 week |
 | 6 | Dialectic self-improvement | QUEUED | 30-day correction rate down; ≥3 autonomous skills emerged |
@@ -37,6 +37,79 @@ decoupling Phases 1–2. Detail in Task History below.
 ---
 
 ## Task History
+
+## 2026-06-16 — TASK-071: Wire Phase 2 ticket_id into process_commit; graceful skip when unlinked
+**Phase**: Phase 3 — Silent commit handler
+**Status**: DONE (PR #178 open against dev, not yet merged)
+**Files**:
+- `devtrack_server/backend/webhook_server.py` — `TriggerProcessor.process_commit()`: reads
+  `data.get("ticket_id", "")` as `resolved_ticket_id` (the Go-resolved, Phase-2-verified
+  signal); PM-sync stage now gated on `resolved_ticket_id` truthiness first (skip + log,
+  no exception, no queue row, when absent/unlinked), then on `self.workspace_router` alone
+  (not `task_data and self.workspace_router`); every `task_data.get(...)` read inside the
+  branch falls back to `commit_msg`/`""` when `task_data` is `None`; deleted the
+  `task_data.get("ticket_id", "") or commit_hash[:12]` fallback target entirely; confidence
+  for the staged `post_comment` action changed from conditional `0.80/0.70` to flat `0.85`.
+- `devtrack_server/backend/tests/test_http_triggers.py` — 9 tests added/rewritten: ticket_id
+  present/absent/empty-string, NLP-guess independence, no-fallback-hash-target, and (from the
+  PM-review fix-up) `task_data is None` and `nlp_parser.parse()` raises — both must still
+  stage successfully when `resolved_ticket_id` is present.
+
+**Vision check**: PASS — Non-Negotiable #2 (everything outbound staged via the pending
+queue, never bypassed) and #8 (never block on failure: unlinked commits skip silently with
+no error; NLP-degraded commits — a documented graceful-degradation state per CLAUDE.md —
+still stage successfully now) both upheld.
+
+**Hardcoded scan**: CLEAN — no `os.getenv` outside `config.py` in changed files, no hardcoded
+hosts/ports/secrets.
+
+**PM review caught a real bug before merge**: the original implementation gated PM-sync
+staging on `task_data and self.workspace_router` — meaning a perfectly good, Phase-2-resolved
+`ticket_id` would be silently dropped (no queue action staged at all) whenever the NLP parser
+was unavailable or raised. This would have broken the Phase 3 exit criterion on any NLP-
+degraded setup. Engineer fixed in a follow-up commit on the same PR: condition changed to
+`elif self.workspace_router:`, with `task_data` treated as optional enrichment only. Two new
+regression tests cover the exact failure mode (NLP parser absent, NLP parse raises).
+
+**PM independently verified**: re-diffed the branch, re-ran the test file standalone
+(36/36 passed), re-ran the hardcoded scan — all clean. Full suite (`uv run pytest backend/tests/ -q`)
+625 passed, 1 pre-existing documented failure (`test_ollama_host_returns_string`), no
+regressions.
+
+**Engineer notes**: Commits `dffd32c` (initial implementation + tests), `dddaf55` (PM-review
+fix-up + regression tests), `e9c52d1`/`770170b` (board/log updates). PR #178 → `dev`. Unblocks
+TASK-072 (voice-aware ticket comment generation) and TASK-073 (state-transition queue action),
+both dependent on this task's ticket-targeting fix.
+
+---
+
+## 2026-06-16 — Phase 3 breakdown: TASK-071 through TASK-074
+**Phase**: Phase 3 — Silent commit handler (opened)
+**Status**: PLANNED — TASK-071 dispatched to engineer, TASK-072/073/074 queued
+**Breakdown rationale**: Investigation during planning found `TriggerProcessor.process_commit()`
+(`devtrack_server/backend/webhook_server.py`) still derives its `post_comment` queue target
+from the NLP task-matcher's own ticket guess, not from the `ticket_id` field Go's Phase 2
+extractor already sends in the commit-trigger JSON payload (`ticket_id,omitempty` on
+`CommitTriggerData`, ~100% hit-rate verified in TASK-070). TASK-071 closes that gap first —
+every other Phase 3 task depends on the queue action being keyed off the trustworthy
+Go-resolved ID. TASK-072 (voice-aware ticket comment via existing `commit_message_enhancer.py`
+pipeline, not a new LLM path) and TASK-073 (state transition as an independent queue action
+type, with per-platform state-vocabulary mapping) both build on TASK-071 but are independent
+of each other. TASK-074 closes the phase with a live runtime verification, mirroring the
+TASK-070/Phase-2 closure pattern — checking actual PM-platform side effects, not just queue
+status flips.
+**Files (planned, not yet touched)**: `devtrack_server/backend/webhook_server.py`
+(`process_commit`, `_execute_pm_action`), `devtrack_server/backend/commit_message_enhancer.py`
+(new `generate_ticket_comment`), new `devtrack_server/backend/ticket_state_mapper.py`,
+`devtrack_client/internal/db/database.go` (`CountTicketCommits`), `devtrack_client/internal/trigger/types.go`
+(`IsFirstCommitForTicket`), `devtrack_client/internal/infra/integrated.go`.
+**Vision check**: PASS — both new queue actions route through Phase 1's pending_actions
+table (Non-Negotiable #2, never bypassed); unresolved tickets skip gracefully, never block
+(Non-Negotiable #8); no new cloud dependency; no TUI/CLI gating (CLI parity already covers
+queue approve/reject via TASK-064).
+**Board**: `Data/agent_logs/project_board.md` — Phase 3 section with TASK-071..074 specs.
+
+---
 
 ## 2026-06-16 — TASK-070: Unlinked commit logging + hit-rate metrics in `devtrack status` — PHASE 2 COMPLETE
 **Phase**: Phase 2 — Opinionated ticket extractor (closes the phase)

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1,7 +1,7 @@
 # DevTrack Project Board
 
-_Last updated: 2026-06-16 by PM (TASK-070 complete — Phase 2 closed; PR #177 open against dev)_
-_Next DevTrack task ID: TASK-071_
+_Last updated: 2026-06-16 by PM (Phase 3 broken down — TASK-071 dispatched)_
+_Next DevTrack task ID: TASK-075_
 _Active branch: `dev`_
 _Shipped: v3.0.10 (2026-06-14) — significant Windows fixes + gitsage improvements._
 _Direction: **PRODUCT_BIBLE.md** (pivot 2026-06-10) — `../../PRODUCT_BIBLE.md`_
@@ -1194,6 +1194,445 @@ in each tab's `Init()`. Forward `spinner.TickMsg` in each `Update()` so the dot 
 **PR**: https://github.com/sraj0501/Devtrack_/pull/173
 
 **COMPLETE** — ready for PM review — 2026-06-15 23:30
+
+---
+
+## ACTIVE — Phase 3: Silent commit handler
+
+**Goal**: On every commit with a resolved ticket ID: draft a ticket comment in the
+developer's voice, stage it in the pending queue; decide whether the ticket should be
+state-transitioned (e.g. To Do → In Progress on first linked commit) and stage that as
+its own queue action. Both ride on Phase 1's confidence/auto-approve mechanism — neither
+ever posts directly. Commits with no resolved ticket ID (logged `[UNLINKED]` by Phase 2)
+are skipped gracefully — no error, no queue entry, no block.
+
+**Exit criterion** (PRODUCT_BIBLE.md): Developer commits normally. Ticket is commented
+and state-transitioned within the auto-approve window. Developer did nothing except commit.
+
+**Why this order**: TASK-071 fixes a real integration gap discovered during breakdown —
+`process_commit` currently builds its `post_comment` action from the NLP task-matcher's
+own (weaker) ticket guess, not from the `ticket_id` the Go client now reliably resolves
+and sends in the commit trigger payload (Phase 2, ~100% hit rate verified). Every later
+task in this phase depends on the queue action being keyed off the trustworthy ticket ID,
+so this must land first. TASK-072 and TASK-073 are independent of each other once
+TASK-071 lands (different queue action types) and can in principle run in parallel, but
+are sequenced for one engineer. TASK-074 closes the phase with a live verification run,
+matching the pattern used for TASK-070 / Phase 2.
+
+---
+
+### TASK-071 — Wire Phase 2 ticket_id into process_commit; graceful skip when unlinked
+**Assigned to**: engineer
+**Status**: ✅ COMPLETE — ready for PM review
+**Priority**: HIGH
+**Phase**: Phase 3
+**Started**: 2026-06-16
+**Depends on**: none (Phase 2 merged — dev tip a9b6bf0)
+**Branch**: `feat/TASK-071-wire-ticket-id-into-process-commit`
+
+**Spec**:
+
+`devtrack_client` already sends a reliable `ticket_id` field in the commit-trigger JSON
+payload (`devtrack_client/internal/trigger/types.go:47` — `TicketID string \`json:"ticket_id"\``
+on `CommitTriggerData`; omitted entirely from the top-level trigger envelope when unlinked,
+per `types.go:16`). Today, `TriggerProcessor.process_commit()` in
+`devtrack_server/backend/webhook_server.py` (around line 396-522) ignores this field — it
+derives its own ticket guess from `self.nlp_parser.parse()` / `task_data.get("ticket_id")`,
+which is weaker than Phase 2's branch/message/active-ticket fallback chain. This task makes
+`process_commit` trust the Go-resolved ticket ID as the primary signal, with NLP's guess only
+as an additional descriptive enhancement (not an alternate ticket source).
+
+**Step 1 — Read `ticket_id` from the inbound payload**
+
+In `process_commit(self, data: dict)`, near the existing field reads (commit_hash, commit_msg,
+repo_path, etc. around line 410-420), add:
+
+```python
+resolved_ticket_id = data.get("ticket_id", "")  # Phase 2 — Go-resolved, empty/absent = unlinked
+```
+
+**Step 2 — Skip ticket-targeted staging gracefully when unresolved**
+
+Where the method currently builds `pm_payload` and calls `self._queue_gateway.stage(...)`
+(around line 449-496), gate the whole "PM sync" stage block on `resolved_ticket_id` being
+non-empty:
+
+```python
+with _stage("PM sync"):
+    if not resolved_ticket_id:
+        logger.info(
+            "PM sync skipped: commit %s has no resolved ticket_id (Phase 2 unlinked) — "
+            "no queue action staged", commit_hash[:12] if commit_hash else "?"
+        )
+    elif self.workspace_router:
+        ...
+```
+
+No exception, no error log, no queue row. This is the Non-Negotiable #8 "never block on
+failure" behavior applied to the new signal — unresolved tickets must not regress to the
+old NLP-guess fallback either; if Go says unlinked, Python treats it as unlinked.
+
+**Step 3 — Use `resolved_ticket_id` as the queue target, not `task_data.get("ticket_id")`**
+
+Replace the existing line:
+```python
+ticket_id  = task_data.get("ticket_id", "") or commit_hash[:12]
+```
+with:
+```python
+ticket_id = resolved_ticket_id
+```
+Remove the `commit_hash[:12]` fallback entirely — Step 2 already guarantees we only reach
+this code when `resolved_ticket_id` is non-empty, so the old "no ticket, use truncated hash
+as the target" behavior (which created bogus PM targets) is dead code and must be deleted.
+
+**Step 4 — Confidence reflects ticket-resolution source, not just NLP match**
+
+The current confidence heuristic (`0.80 if task_data.get("ticket_id") else 0.70`) was built
+around NLP's own guess. Since the ticket ID is now Go-resolved (already ~100% hit-rate
+verified in Phase 2), raise the baseline and stop conditioning confidence on whether NLP
+*also* found a ticket id — NLP's role from here on is describing the commit, not locating
+the ticket:
+
+```python
+# Phase 3: ticket_id resolution confidence now comes from Go's extraction strategy,
+# not NLP's own (weaker) guess. NLP match only affects descriptive quality, not target
+# confidence. Baseline reflects Phase 2's verified ~100% hit rate for resolved IDs.
+confidence = 0.85
+```//
+
+(Use the literal value as a constant if there is a clear existing place for tunables in this
+file; otherwise an inline literal with the comment above is acceptable — do not invent a new
+config var for this in this task, that's a follow-up if a future task needs to tune it.)
+
+**Step 5 — pm_payload still carries `ticket_id` from the resolved field**
+
+In `pm_payload` construction, set `"ticket_id": resolved_ticket_id` (was
+`task_data.get("ticket_id", "")`). Leave `"description"` / `"comment"` driven by
+`task_data.get("description", commit_msg)` unchanged — NLP/description enhancement quality
+is untouched by this task; only ticket *targeting* changes.
+
+**Step 6 — Tests**
+
+Add to `devtrack_server/backend/tests/` (new file `test_process_commit_ticket_id.py` or
+extend an existing trigger-processor test file if one already covers `process_commit`):
+
+- `data["ticket_id"] = "PROJ-123"` present → `queue_gateway.stage()` called with
+  `target="PROJ-123"`, confidence `0.85`.
+- `data` has no `"ticket_id"` key (simulates Go's `omitempty` drop) → `queue_gateway.stage()`
+  is NOT called; `process_commit` returns without raising; `actions` list does not contain
+  any `queued:post_comment:*` entry.
+- `data["ticket_id"] = ""` (explicit empty string) → same as above, treated identically to
+  absent.
+- Existing tests in whatever file currently exercises `process_commit`'s queue staging must
+  still pass — update any fixture that relied on the old `commit_hash[:12]` fallback target.
+
+Run `uv run pytest backend/tests/ -q` — no regressions beyond the one pre-existing documented
+failure (`test_ollama_host_returns_string`).
+
+**Acceptance criteria**:
+- [x] `process_commit` reads `data.get("ticket_id", "")` and treats it as the authoritative
+      ticket-resolution signal.
+- [x] When `ticket_id` is absent or empty: no `_queue_gateway.stage()` call, no exception,
+      `logger.info` line confirms the skip, method returns normally.
+- [x] When `ticket_id` is present: `_queue_gateway.stage()` is called with
+      `target=<ticket_id>` (not the old `commit_hash[:12]` fallback).
+- [x] The `commit_hash[:12]` fallback target is removed from the code path entirely.
+- [x] Confidence for the staged `post_comment` action is `0.85` (or the documented constant)
+      when ticket_id is resolved — independent of whether NLP separately found a ticket guess.
+- [x] New/updated tests pass: ticket_id present, ticket_id absent, ticket_id empty string.
+- [x] `uv run pytest backend/tests/ -q` — no regressions beyond the documented pre-existing failure.
+- [x] No `os.getenv` introduced; no hardcoded host/port/timeout literals.
+
+**Engineer status**: 8/8 criteria done — last commit: dffd32c "feat(server): Wire ticket_id into process_commit and drop fallback commit_hash" — 2026-06-16 21:52
+**PR**: https://github.com/sraj0501/Devtrack_/pull/178
+**Blockers**: none
+
+**COMPLETE** — ready for PM review — 2026-06-16 21:52
+
+---
+
+### TASK-072 — Voice-aware ticket comment generation (reuse commit_message_enhancer style)
+**Priority**: HIGH
+**Phase**: Phase 3
+**Depends on**: TASK-071
+
+**Spec**:
+
+Today the `post_comment` payload's `"description"` / `"comment"` field is whatever the NLP
+parser extracted (`task_data.get("description", commit_msg)`) — effectively a cleaned-up
+restatement of the commit message, not a ticket comment written in the developer's voice.
+This task generates an actual ticket comment using the same AI-enhancement approach already
+proven for commit messages in `devtrack_server/backend/commit_message_enhancer.py`
+(`enhance_message_with_ai(original_message, diff, files, repo_path)`), redirected at ticket-
+comment phrasing instead of commit-message phrasing. Do not build a new LLM pipeline from
+scratch — adapt the existing one.
+
+**Step 1 — New function in `commit_message_enhancer.py` (or a thin new module if cleaner):
+`generate_ticket_comment`**
+
+Add a function (same file, alongside `enhance_message_with_ai`, reusing its Ollama
+client setup / prompt-building helpers — do not duplicate the LLM call plumbing):
+
+```python
+def generate_ticket_comment(commit_message: str, diff: str, files: list[str],
+                             ticket_id: str, repo_path: str = None) -> str:
+    """Generate a ticket comment in the developer's voice describing this commit's
+    contribution to the named ticket. Reuses the same Ollama enhancement pipeline as
+    commit message refinement, with a ticket-comment-shaped prompt instead of a
+    commit-message-shaped one. Falls back to a templated comment
+    (e.g. f"Commit {short_hash}: {commit_message}") if the LLM is unavailable —
+    Non-Negotiable #8, never block on failure."
+    """
+```
+
+Prompt should ask for a short, professional update suitable for posting as a ticket
+comment (1-3 sentences, references what changed and why if discernible from the diff),
+not a restatement of the raw commit message. Apply `backend.personalization.inject_style()`
+the same way other generated text in this codebase does (see CLAUDE.md "Personalization" —
+`context_type="comment"` is one of the five existing injection points; use it).
+
+**Step 2 — Wire into `process_commit`**
+
+Where `pm_payload["description"]` / `pm_payload["comment"]` are currently set from
+`task_data.get("description", commit_msg)`, call `generate_ticket_comment(...)` instead,
+passing the resolved `ticket_id` from TASK-071. Keep `task_data`'s description as a fallback
+input/context but the final posted text comes from this new function.
+
+**Step 3 — Diff and file list**
+
+`process_commit`'s inbound `data` dict may not currently carry diff/file-list — check
+what's available (likely from `git_diff_analyzer.py`, already used elsewhere per CLAUDE.md).
+If the trigger payload doesn't include a diff, call the existing diff-fetch path used by
+`commit_message_enhancer.py`'s CLI entrypoint (reads from local git via `repo_path` +
+`commit_hash`) rather than inventing a new one.
+
+**Step 4 — Tests**
+
+`devtrack_server/backend/tests/test_ticket_comment_generation.py`:
+- LLM available (mocked Ollama client) → returns a non-empty string, distinct from the raw
+  commit message, includes ticket_id context implicitly via the prompt (assert the function
+  was called with ticket_id in the prompt construction, not that the output literally
+  contains the string).
+- LLM unavailable / raises → falls back to templated comment, no exception propagates.
+- `inject_style()` is called with `context_type="comment"` (mock/spy assertion).
+
+Run `uv run pytest backend/tests/ -q` — no regressions.
+
+**Acceptance criteria**:
+- [ ] `generate_ticket_comment()` exists, reuses `commit_message_enhancer.py`'s existing
+      Ollama client/prompt plumbing (no duplicate LLM client setup).
+- [ ] Falls back to a templated comment string when the LLM call fails — never raises out
+      of `process_commit`.
+- [ ] `inject_style()` applied with `context_type="comment"`.
+- [ ] `process_commit`'s staged `post_comment` payload description/comment field is sourced
+      from `generate_ticket_comment()`, not the raw NLP description.
+- [ ] New tests pass (LLM available / unavailable / style injection called).
+- [ ] `uv run pytest backend/tests/ -q` — no regressions.
+- [ ] No `os.getenv` introduced; no hardcoded model name, host, or timeout literals
+      (reuse existing config accessors).
+
+**Engineer status**: not started
+**Blockers**: TASK-071 must merge first (payload/target wiring this depends on)
+
+---
+
+### TASK-073 — State-transition decision + per-connector status mapping, staged as its own queue action
+**Priority**: HIGH
+**Phase**: Phase 3
+**Depends on**: TASK-071
+
+**Spec**:
+
+Add a second, independent queue action type — `state_transition` — staged alongside (not
+merged into) the `post_comment` action from TASK-071/072. Each gets its own confidence score
+and its own auto-approve timeout, per PRODUCT_BIBLE.md Layer 2 ("each queued action" is a
+distinct row). The decision this task encodes: **on the first commit linked to a given
+ticket in a workspace, transition that ticket from its "not started" state to "in progress"**
+— per PRODUCT_BIBLE.md Phase 3 spec ("To Do → In Progress").
+
+**Step 1 — "First commit for this ticket" detection**
+
+Add a DB helper (Go side, since `triggers` table with `ticket_id` already lives there per
+Phase 2 — TASK-068/069):
+`devtrack_client/internal/db/database.go`:
+```go
+// CountTicketCommits returns how many prior commit triggers reference this ticket_id
+// for this repo_path, excluding the current trigger row (caller passes count BEFORE insert,
+// or pass excludeTriggerID to exclude the just-inserted row).
+func (d *Database) CountTicketCommits(repoPath, ticketID string) (int, error)
+```
+This is queried from Go and sent to Python as a new field on `CommitTriggerData`:
+`IsFirstCommitForTicket bool \`json:"is_first_commit_for_ticket"\`` — computed in
+`handleCommitForWorkspace`/`handleTrigger` (`devtrack_client/internal/infra/integrated.go`)
+right after `ticketID` is resolved (TASK-068/069 code), as `CountTicketCommits(...) == 0`
+BEFORE this trigger's own row is inserted (check ordering against existing `InsertTrigger`
+call — must count prior rows only).
+
+**Step 2 — Per-connector status mapping**
+
+PM platforms use different state vocabularies. Add a mapping table/function — Python side,
+since `_execute_pm_action` / `workspace_router.route()` already accepts a `status` string
+per platform (`devtrack_server/backend/workspace_router.py:39` parameter, consumed at
+lines 119, 149, 172 for azure/gitlab/github respectively):
+
+New small module `devtrack_server/backend/ticket_state_mapper.py`:
+```python
+# Maps DevTrack's logical "in_progress" intent to each platform's actual state vocabulary.
+# Existing auto-transition code (workspace_router.py:298,372,445) only recognizes
+# "done"/"completed"/"closed" as transition targets — that logic is unrelated/unchanged.
+# This module adds the "starting work" transition the existing code doesn't cover.
+PLATFORM_IN_PROGRESS_STATE = {
+    "azure":  "Active",       # Azure DevOps default process states: New -> Active -> Resolved -> Closed
+    "github": "in_progress",  # GitHub Issues has no native state beyond open/closed — this maps to
+                               # a label-based convention; check existing github/client.py for any
+                               # existing label-state handling before inventing a new one
+    "gitlab": "doing",        # GitLab issue board label convention; check gitlab/client.py similarly
+    "jira":   "In Progress",  # Jira default workflow
+}
+
+def in_progress_state_for(platform: str) -> str:
+    """Returns the platform-specific state string DevTrack should request when
+    transitioning a ticket to 'in progress' on first linked commit. Returns ''
+    for an unrecognized platform — caller must skip the transition, never guess."""
+```
+
+Before hardcoding the GitHub/GitLab label conventions, check `backend/github/client.py` and
+`backend/gitlab/client.py` for any existing label-as-state handling (search for `label` near
+`state`/`status`) — if a convention already exists in this codebase, reuse it instead of
+inventing a parallel one. Document whichever you land on in the module docstring.
+
+**Step 3 — Stage the `state_transition` action**
+
+In `process_commit` (after TASK-071/072 land), when `resolved_ticket_id` is non-empty AND
+`data.get("is_first_commit_for_ticket")` is true AND `in_progress_state_for(platform)`
+returns non-empty:
+
+```python
+state_action_id = self._queue_gateway.stage(
+    action_type="state_transition",
+    target=resolved_ticket_id,
+    platform=pm_platform or "auto",
+    workspace=data.get("workspace_name", ""),
+    payload={
+        "ticket_id": resolved_ticket_id,
+        "new_state": in_progress_state_for(pm_platform),
+        "commit_info": {...},  # same shape as post_comment's commit_info
+    },
+    confidence=0.90,  # first-commit-for-ticket signal is unambiguous — high confidence
+)
+```//
+Use a `confidence` constant with an inline comment, same convention as TASK-071. This is a
+*separate* `stage()` call from the `post_comment` one — two rows, two independent timeouts,
+exactly as PRODUCT_BIBLE.md Layer 2 specifies ("each queued action").
+
+**Step 4 — `_execute_pm_action` handles `action_type == "state_transition"`**
+
+`_execute_pm_action()` (`webhook_server.py:334`) currently builds its `workspace_router.route()`
+call uniformly regardless of `action_type` — it always passes `description`/`comment` from
+the payload. Branch on `action_type`:
+- `"post_comment"` → existing behavior unchanged.
+- `"state_transition"` → call `workspace_router.route()` with `status=payload["new_state"]`
+  and an empty/minimal `description` (no comment text being posted by this action — the
+  comment, if any, was already staged and executed separately by the `post_comment` action).
+  Confirm `workspace_router.route()` tolerates an empty `description` when only a status
+  change is intended; if it does not, this is the place to add that tolerance (do not change
+  `route()`'s signature, only its internal handling of an empty description with non-empty
+  status).
+
+**Step 5 — Tests**
+
+- Go: `CountTicketCommits` unit test (table-driven: 0 prior commits, N prior commits, wrong
+  repo_path excluded).
+- Go: `IsFirstCommitForTicket` populated correctly on `CommitTriggerData` JSON payload
+  (mirror the pattern of TASK-068's `TestHTTPTriggerClient_SendCommitTrigger_TicketIDInPayload`).
+- Python: `ticket_state_mapper.py` unit tests — known platform returns expected state,
+  unknown platform returns `""`.
+- Python: `process_commit` stages a `state_transition` action when first-commit + known
+  platform; does NOT stage one when not first-commit, or platform unmapped, or ticket
+  unresolved.
+- Python: `_execute_pm_action` routes `state_transition` actions to `workspace_router.route()`
+  with the mapped status and does not require/duplicate comment text.
+
+Run `go build ./...`, `go vet ./...`, `go test ./...` from `devtrack_client/`; run
+`uv run pytest backend/tests/ -q` from `devtrack_server/`.
+
+**Acceptance criteria**:
+- [ ] `Database.CountTicketCommits(repoPath, ticketID)` exists with passing table-driven tests.
+- [ ] `CommitTriggerData.IsFirstCommitForTicket` populated and present in the JSON payload
+      sent to Python (mirrors TASK-068's payload test pattern).
+- [ ] `ticket_state_mapper.py` exists; reuses any pre-existing label-as-state convention found
+      in `github/client.py` / `gitlab/client.py` rather than inventing a parallel one (or
+      documents why none existed).
+- [ ] `state_transition` is staged as an independent queue row from `post_comment` — distinct
+      `action_id`, distinct confidence, distinct expiry.
+- [ ] `state_transition` is only staged when: ticket resolved AND first commit for that ticket
+      AND platform has a known in-progress state mapping.
+- [ ] `_execute_pm_action` branches on `action_type` and routes `state_transition` actions
+      correctly without requiring comment text.
+- [ ] All new Go and Python tests pass; `go build`, `go vet`, `go test ./...`,
+      `uv run pytest backend/tests/ -q` all clean (no regressions beyond the one documented
+      pre-existing failure).
+- [ ] No hardcoded host/port/timeout values; platform state strings live in the mapping
+      module, not scattered inline.
+
+**Engineer status**: not started
+**Blockers**: TASK-071 must merge first (this task's Python staging code sits right next to it)
+
+---
+
+### TASK-074 — Phase 3 exit criterion verification + phase closure
+**Priority**: MEDIUM
+**Phase**: Phase 3
+**Depends on**: TASK-071, TASK-072, TASK-073
+
+**Spec**:
+
+Closes Phase 3 the same way TASK-070 closed Phase 2 — a live runtime verification run
+against the real pipeline, not just unit tests, plus the board/feature-tracker updates.
+
+**Steps**:
+
+1. Build the Go client (`go build -o devtrack .` from `devtrack_client/`) and confirm the
+   Python server starts cleanly in managed mode.
+2. Register a disposable scratch repo as a temporary workspace (same pattern TASK-070 used —
+   remove it afterward and restart the daemon back to original config).
+3. Make a commit on a branch whose name resolves a ticket ID via Phase 2's extractor
+   (e.g. `feat/PROJ-1-test`), against a platform that has PM credentials configured in this
+   dev environment (whichever of GitHub/Azure/GitLab/Jira is already set up — check
+   `workspaces.yaml` / `.env` for what's live; do not fabricate credentials for platforms
+   not already configured).
+4. Confirm via `devtrack queue list` (TASK-064 CLI) that two pending actions appear:
+   one `post_comment`, one `state_transition`, both targeting the same ticket ID, with
+   independent confidence scores and countdowns.
+5. Either wait for the auto-approve window to expire, or approve both manually via
+   `devtrack queue approve <id>` — confirm both actually post to the PM platform (check the
+   ticket on the live platform: comment present, state changed to the mapped in-progress
+   value).
+6. Make a second commit on the same branch — confirm only a `post_comment` action is staged
+   this time (not a second `state_transition` — first-commit detection must not re-fire).
+7. Make a commit on `main` or an unlinked branch — confirm `[UNLINKED]` log line, zero queue
+   actions staged, no error, no block (Non-Negotiable #8 spot-check).
+8. Run the full hardcoded-values scan across all files touched in TASK-071/072/073.
+9. Update `Data/agent_logs/feature_tracker.md` with the Phase 3 completion entry (mirror the
+   TASK-070 entry's structure and level of detail).
+10. Open a PR targeting `dev` with title "Phase 3: silent commit handler — exit criterion
+    verified".
+
+**Acceptance criteria**:
+- [ ] Live test: first linked commit on a fresh ticket produces both a `post_comment` and a
+      `state_transition` pending action, independently confidence-scored.
+- [ ] Both actions, once approved (auto or manual), actually post to the live PM platform —
+      verified by checking the ticket directly, not just queue status flipping to "posted".
+- [ ] Second commit on the same ticket does not re-trigger `state_transition`.
+- [ ] Unlinked commit produces zero queue actions and no error.
+- [ ] Hardcoded-values scan clean across all Phase 3 diffs.
+- [ ] `devtrack status` / `devtrack queue status` reflect the test run plausibly.
+- [ ] Feature tracker updated with Phase 3 completion entry; PR opened against `dev`.
+- [ ] Scratch workspace removed and daemon restored to original config after verification.
+
+**Engineer status**: not started
+**Blockers**: TASK-071, TASK-072, TASK-073 must all merge first
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1,6 +1,6 @@
 # DevTrack Project Board
 
-_Last updated: 2026-06-16 by PM (Phase 3 broken down — TASK-071 dispatched)_
+_Last updated: 2026-06-16 by PM (TASK-071 complete and PM-verified, PR #178 open against dev — TASK-072/073 unblocked)_
 _Next DevTrack task ID: TASK-075_
 _Active branch: `dev`_
 _Shipped: v3.0.10 (2026-06-14) — significant Windows fixes + gitsage improvements._
@@ -1364,6 +1364,17 @@ NLP enrichment fails" — 2026-06-16 22:18. Pushed to the same branch; PR #178 u
 automatically (no new PR).
 
 **COMPLETE** — ready for PM review — 2026-06-16 22:18
+
+**PM verification (independent)**: re-diffed `dev..feat/TASK-071-wire-ticket-id-into-process-commit`
+on `devtrack_server/backend/webhook_server.py` — confirmed no remaining unguarded
+`task_data.get(...)` calls inside the PM-sync branch, confirmed `commit_hash[:12]` fallback
+target fully removed, confirmed `confidence = 0.85` is unconditional on ticket_id alone.
+Re-ran `uv run pytest backend/tests/test_http_triggers.py -q` independently: 36/36 passed.
+Hardcoded scan (`os.getenv` in changed files): clean. Vision check: PASS — Non-Negotiable #2
+(staged via queue, never bypassed) and #8 (never block on failure — unlinked commits skip
+silently, NLP-degraded commits still stage) both upheld.
+
+**PM SIGN-OFF**: APPROVED — 2026-06-16. Unblocks TASK-072 and TASK-073.
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1348,7 +1348,22 @@ failure (`test_ollama_host_returns_string`).
 **PR**: https://github.com/sraj0501/Devtrack_/pull/178
 **Blockers**: none
 
-**COMPLETE** — ready for PM review — 2026-06-16 21:52
+**Fix-up (PM review)**: PM review found the `elif task_data and self.workspace_router:` gate
+silently skipped PM sync whenever `task_data` was `None` (NLP parser unavailable, e.g. spaCy
+missing, or `nlp_parser.parse()` raised) — even with a perfectly good Phase-2-resolved
+`resolved_ticket_id` and a live `workspace_router`. This directly broke the Phase 3 exit
+criterion on any setup with degraded NLP, a state CLAUDE.md documents as supported graceful
+degradation. Fixed: condition changed to `elif self.workspace_router:`, and every
+`task_data.get(...)` read inside the branch (`description`, `status`) now falls back to
+`commit_msg` / `""` when `task_data` is `None`. Also updated
+`test_skips_pm_sync_when_nlp_returns_none` (renamed
+`test_stages_pm_sync_when_nlp_returns_none_but_ticket_id_resolved`) which had encoded the old
+buggy behavior as expected, and added two new regression tests covering NLP-parser-absent and
+NLP-parse-raises cases. Last commit: dddaf55 "feat(server): Ensure PM sync on ticket ID when
+NLP enrichment fails" — 2026-06-16 22:18. Pushed to the same branch; PR #178 updated
+automatically (no new PR).
+
+**COMPLETE** — ready for PM review — 2026-06-16 22:18
 
 ---
 

--- a/devtrack_server/backend/tests/test_http_triggers.py
+++ b/devtrack_server/backend/tests/test_http_triggers.py
@@ -311,7 +311,10 @@ class TestTriggerProcessorCommit:
         mock_router = MagicMock()
         proc.workspace_router = mock_router
 
-        proc.process_commit(COMMIT_PAYLOAD)
+        # Phase 3: the queue target now comes from the Go-resolved ticket_id
+        # field on the payload, not from the NLP parser's own guess.
+        payload = {**COMMIT_PAYLOAD, "ticket_id": "GH-1"}
+        proc.process_commit(payload)
 
         mock_router.route.assert_called_once()
 
@@ -323,7 +326,8 @@ class TestTriggerProcessorCommit:
         mock_router = MagicMock()
         proc.workspace_router = mock_router
 
-        result = proc.process_commit(COMMIT_PAYLOAD)
+        payload = {**COMMIT_PAYLOAD, "ticket_id": "GH-1"}
+        result = proc.process_commit(payload)
 
         mock_router.route.assert_not_called()
         assert not any("pm_sync" in a for a in result["actions"])
@@ -335,8 +339,125 @@ class TestTriggerProcessorCommit:
         proc.nlp_parser = mock_parser
         # workspace_router stays None
 
-        result = proc.process_commit(COMMIT_PAYLOAD)
+        payload = {**COMMIT_PAYLOAD, "ticket_id": "X-1"}
+        result = proc.process_commit(payload)
         assert not any("pm_sync" in a for a in result["actions"])
+
+    def test_skips_pm_sync_when_ticket_id_absent(self):
+        """Phase 3: no 'ticket_id' key at all (Go's omitempty dropped it) means
+        unlinked — no queue action staged, no exception, method returns normally."""
+        proc = _bare_processor()
+        mock_parser = MagicMock()
+        mock_parser.parse.return_value = {
+            "description": "fix login",
+            "ticket_id": "GH-1",  # NLP's own guess must NOT be used as a fallback target
+            "status": "done",
+        }
+        proc.nlp_parser = mock_parser
+        mock_router = MagicMock()
+        proc.workspace_router = mock_router
+
+        result = proc.process_commit(COMMIT_PAYLOAD)  # no "ticket_id" key
+
+        mock_router.route.assert_not_called()
+        assert not any("pm_sync" in a for a in result["actions"])
+        assert not any("queued:post_comment" in a for a in result["actions"])
+
+    def test_skips_pm_sync_when_ticket_id_empty_string(self):
+        """Phase 3: explicit empty string ticket_id is treated identically to absent."""
+        proc = _bare_processor()
+        mock_parser = MagicMock()
+        mock_parser.parse.return_value = {
+            "description": "fix login",
+            "ticket_id": "GH-1",
+            "status": "done",
+        }
+        proc.nlp_parser = mock_parser
+        mock_router = MagicMock()
+        proc.workspace_router = mock_router
+
+        payload = {**COMMIT_PAYLOAD, "ticket_id": ""}
+        result = proc.process_commit(payload)
+
+        mock_router.route.assert_not_called()
+        assert not any("pm_sync" in a for a in result["actions"])
+        assert not any("queued:post_comment" in a for a in result["actions"])
+
+    def test_no_commit_hash_truncation_fallback_target(self):
+        """Phase 3: the old commit_hash[:12] fallback target is dead — confirm a
+        commit with no ticket_id never reaches workspace_router with a hash-based
+        target, even when commit_hash is present and NLP found nothing useful."""
+        proc = _bare_processor()
+        mock_parser = MagicMock()
+        mock_parser.parse.return_value = {"description": "misc work", "status": ""}
+        proc.nlp_parser = mock_parser
+        mock_router = MagicMock()
+        proc.workspace_router = mock_router
+
+        result = proc.process_commit(COMMIT_PAYLOAD)  # commit_hash="abc123def456", no ticket_id
+
+        mock_router.route.assert_not_called()
+        assert not any("pm_sync" in a for a in result["actions"])
+
+
+# ---------------------------------------------------------------------------
+# TriggerProcessor.process_commit — queue staging with resolved ticket_id
+# (TASK-071: Phase 2 ticket_id is the authoritative target/confidence signal)
+# ---------------------------------------------------------------------------
+
+class TestProcessCommitQueueStaging:
+    def test_stages_with_resolved_ticket_id_as_target(self):
+        proc = _bare_processor()
+        mock_parser = MagicMock()
+        mock_parser.parse.return_value = {"description": "fix login", "status": "done"}
+        proc.nlp_parser = mock_parser
+        proc.workspace_router = MagicMock()
+        mock_gateway = MagicMock()
+        mock_gateway.stage.return_value = 7
+        proc._queue_gateway = mock_gateway
+
+        payload = {**COMMIT_PAYLOAD, "ticket_id": "PROJ-123"}
+        result = proc.process_commit(payload)
+
+        mock_gateway.stage.assert_called_once()
+        _, kwargs = mock_gateway.stage.call_args
+        assert kwargs["target"] == "PROJ-123"
+        assert kwargs["confidence"] == 0.85
+        assert kwargs["action_type"] == "post_comment"
+        assert "queued:post_comment:7" in result["actions"]
+
+    def test_confidence_independent_of_nlp_ticket_guess(self):
+        """Confidence is 0.85 whether or not NLP separately found a ticket id —
+        NLP's role is descriptive only, never the ticket-targeting signal."""
+        proc = _bare_processor()
+        mock_parser = MagicMock()
+        mock_parser.parse.return_value = {"description": "fix login", "status": "done"}  # no ticket_id from NLP
+        proc.nlp_parser = mock_parser
+        proc.workspace_router = MagicMock()
+        mock_gateway = MagicMock()
+        mock_gateway.stage.return_value = 9
+        proc._queue_gateway = mock_gateway
+
+        payload = {**COMMIT_PAYLOAD, "ticket_id": "PROJ-999"}
+        proc.process_commit(payload)
+
+        _, kwargs = mock_gateway.stage.call_args
+        assert kwargs["confidence"] == 0.85
+        assert kwargs["target"] == "PROJ-999"
+
+    def test_does_not_stage_when_ticket_id_absent(self):
+        proc = _bare_processor()
+        mock_parser = MagicMock()
+        mock_parser.parse.return_value = {"description": "fix login", "ticket_id": "GH-1", "status": "done"}
+        proc.nlp_parser = mock_parser
+        proc.workspace_router = MagicMock()
+        mock_gateway = MagicMock()
+        proc._queue_gateway = mock_gateway
+
+        result = proc.process_commit(COMMIT_PAYLOAD)  # no ticket_id key
+
+        mock_gateway.stage.assert_not_called()
+        assert not any("queued:post_comment" in a for a in result["actions"])
 
 
 # ---------------------------------------------------------------------------

--- a/devtrack_server/backend/tests/test_http_triggers.py
+++ b/devtrack_server/backend/tests/test_http_triggers.py
@@ -318,19 +318,29 @@ class TestTriggerProcessorCommit:
 
         mock_router.route.assert_called_once()
 
-    def test_skips_pm_sync_when_nlp_returns_none(self):
+    def test_stages_pm_sync_when_nlp_returns_none_but_ticket_id_resolved(self):
+        """Regression guard (PR #178 PM review fix): task_data being None
+        (NLP parser returned None, e.g. degraded/unavailable spaCy) must NOT
+        skip PM sync when a Phase-2-resolved ticket_id and workspace_router
+        are both present — task_data is optional enrichment, not a gate on
+        whether the ticket gets a queued comment at all."""
         proc = _bare_processor()
         mock_parser = MagicMock()
         mock_parser.parse.return_value = None
         proc.nlp_parser = mock_parser
-        mock_router = MagicMock()
-        proc.workspace_router = mock_router
+        proc.workspace_router = MagicMock()
+        mock_gateway = MagicMock()
+        mock_gateway.stage.return_value = 13
+        proc._queue_gateway = mock_gateway
 
         payload = {**COMMIT_PAYLOAD, "ticket_id": "GH-1"}
         result = proc.process_commit(payload)
 
-        mock_router.route.assert_not_called()
-        assert not any("pm_sync" in a for a in result["actions"])
+        mock_gateway.stage.assert_called_once()
+        _, kwargs = mock_gateway.stage.call_args
+        assert kwargs["target"] == "GH-1"
+        assert kwargs["payload"]["description"] == COMMIT_PAYLOAD["commit_message"]
+        assert "queued:post_comment:13" in result["actions"]
 
     def test_skips_pm_sync_when_no_workspace_router(self):
         proc = _bare_processor()
@@ -458,6 +468,58 @@ class TestProcessCommitQueueStaging:
 
         mock_gateway.stage.assert_not_called()
         assert not any("queued:post_comment" in a for a in result["actions"])
+
+    def test_stages_when_task_data_is_none_but_ticket_id_resolved(self):
+        """Regression (PM review on PR #178): when the NLP parser is
+        unavailable (e.g. spaCy not installed) or parse() raises, task_data
+        is None — but a Phase-2-resolved ticket_id plus a workspace_router
+        is everything process_commit needs to stage a PM sync action.
+        Previously the `elif task_data and self.workspace_router:` gate
+        skipped staging entirely in this case, silently breaking Phase 3
+        ticket commenting on any setup with degraded NLP. task_data must be
+        treated as optional enrichment, falling back to the raw commit
+        message for the description/comment text."""
+        proc = _bare_processor()
+        proc.nlp_parser = None  # simulates spaCy unavailable
+        proc.workspace_router = MagicMock()
+        mock_gateway = MagicMock()
+        mock_gateway.stage.return_value = 11
+        proc._queue_gateway = mock_gateway
+
+        payload = {**COMMIT_PAYLOAD, "ticket_id": "PROJ-555"}
+        result = proc.process_commit(payload)
+
+        mock_gateway.stage.assert_called_once()
+        _, kwargs = mock_gateway.stage.call_args
+        assert kwargs["target"] == "PROJ-555"
+        assert kwargs["confidence"] == 0.85
+        assert kwargs["action_type"] == "post_comment"
+        # description falls back to the raw commit message when task_data is None
+        assert kwargs["payload"]["description"] == COMMIT_PAYLOAD["commit_message"]
+        assert kwargs["payload"]["status"] == ""
+        assert "queued:post_comment:11" in result["actions"]
+
+    def test_stages_when_nlp_parse_raises_but_ticket_id_resolved(self):
+        """Same regression, but task_data is None because nlp_parser.parse()
+        raised (caught by the 'NLP parse' stage) rather than the parser being
+        absent entirely."""
+        proc = _bare_processor()
+        mock_parser = MagicMock()
+        mock_parser.parse.side_effect = RuntimeError("spaCy model load failed")
+        proc.nlp_parser = mock_parser
+        proc.workspace_router = MagicMock()
+        mock_gateway = MagicMock()
+        mock_gateway.stage.return_value = 12
+        proc._queue_gateway = mock_gateway
+
+        payload = {**COMMIT_PAYLOAD, "ticket_id": "PROJ-556"}
+        result = proc.process_commit(payload)
+
+        mock_gateway.stage.assert_called_once()
+        _, kwargs = mock_gateway.stage.call_args
+        assert kwargs["target"] == "PROJ-556"
+        assert kwargs["payload"]["description"] == COMMIT_PAYLOAD["commit_message"]
+        assert "queued:post_comment:12" in result["actions"]
 
 
 # ---------------------------------------------------------------------------

--- a/devtrack_server/backend/webhook_server.py
+++ b/devtrack_server/backend/webhook_server.py
@@ -418,6 +418,13 @@ class TriggerProcessor:
         pm_iteration_path = data.get("pm_iteration_path", "")
         pm_area_path      = data.get("pm_area_path", "")
         pm_milestone      = data.get("pm_milestone", "")
+        # Phase 2 — Go-resolved ticket ID (branch/message/active-ticket fallback
+        # chain, ~100% hit-rate verified). Absent or empty means Go's extractor
+        # found no ticket for this commit (logged [UNLINKED] on the client side).
+        # This is the authoritative ticket-resolution signal — NLP's own guess
+        # (task_data.get("ticket_id")) is no longer used to locate the ticket,
+        # only to enrich the description/comment text.
+        resolved_ticket_id = data.get("ticket_id", "")
 
         logger.info(f"[HTTP commit] {commit_hash[:12]} — {commit_msg[:60]}")
 
@@ -448,11 +455,23 @@ class TriggerProcessor:
 
         # PM sync — stage via queue (Phase 1) or fall back to direct post
         with _stage("PM sync"):
-            if task_data and self.workspace_router:
+            if not resolved_ticket_id:
+                # Phase 2 found no ticket for this commit (branch/message/
+                # active-ticket fallback chain all came up empty — logged
+                # [UNLINKED] on the Go side). Non-Negotiable #8: never block,
+                # never error. We do not fall back to the old NLP-guess or
+                # truncated-commit-hash target — if Go says unlinked, treat
+                # it as unlinked here too.
+                logger.info(
+                    "PM sync skipped: commit %s has no resolved ticket_id "
+                    "(Phase 2 unlinked) — no queue action staged",
+                    commit_hash[:12] if commit_hash else "?",
+                )
+            elif task_data and self.workspace_router:
                 # Build the payload that _execute_pm_action expects
                 pm_payload = {
                     "description": task_data.get("description", commit_msg),
-                    "ticket_id":   task_data.get("ticket_id", ""),
+                    "ticket_id":   resolved_ticket_id,
                     "status":      task_data.get("status", ""),
                     "pm_project":  pm_project,
                     "pm_assignee": pm_assignee,
@@ -467,10 +486,13 @@ class TriggerProcessor:
                         "branch":  branch,
                     },
                 }
-                ticket_id  = task_data.get("ticket_id", "") or commit_hash[:12]
-                # Confidence heuristic: NLP-matched commits get 0.75; if the
-                # parser also found a ticket_id it gets a small boost.
-                confidence = 0.80 if task_data.get("ticket_id") else 0.70
+                ticket_id = resolved_ticket_id
+                # Phase 3: ticket_id resolution confidence now comes from Go's
+                # extraction strategy, not NLP's own (weaker) guess. NLP match
+                # only affects descriptive quality, not target confidence.
+                # Baseline reflects Phase 2's verified ~100% hit rate for
+                # resolved IDs.
+                confidence = 0.85
 
                 if getattr(self, "_queue_gateway", None):
                     try:

--- a/devtrack_server/backend/webhook_server.py
+++ b/devtrack_server/backend/webhook_server.py
@@ -467,18 +467,27 @@ class TriggerProcessor:
                     "(Phase 2 unlinked) — no queue action staged",
                     commit_hash[:12] if commit_hash else "?",
                 )
-            elif task_data and self.workspace_router:
+            elif self.workspace_router:
+                # task_data may legitimately be None here (NLP parser
+                # unavailable, e.g. spaCy not installed, or parse() raised —
+                # see "NLP parse" stage above). resolved_ticket_id is the
+                # authoritative signal for *targeting*; task_data is only
+                # optional descriptive enrichment, so every read of it below
+                # must fall back to commit_msg / "" without raising.
+                description = task_data.get("description", commit_msg) if task_data else commit_msg
+                status      = task_data.get("status", "") if task_data else ""
+
                 # Build the payload that _execute_pm_action expects
                 pm_payload = {
-                    "description": task_data.get("description", commit_msg),
+                    "description": description,
                     "ticket_id":   resolved_ticket_id,
-                    "status":      task_data.get("status", ""),
+                    "status":      status,
                     "pm_project":  pm_project,
                     "pm_assignee": pm_assignee,
                     "pm_iteration_path": pm_iteration_path,
                     "pm_area_path":      pm_area_path,
                     "pm_milestone":      pm_milestone,
-                    "comment":     task_data.get("description", commit_msg),
+                    "comment":     description,
                     "commit_info": {
                         "hash":    commit_hash,
                         "message": commit_msg,


### PR DESCRIPTION
## Summary
- `process_commit` now trusts the Go-resolved `ticket_id` field (Phase 2 branch/message/active-ticket fallback chain, ~100% hit-rate verified) as the authoritative ticket-targeting signal instead of the NLP task-matcher's own weaker guess.
- When `ticket_id` is absent or empty (Phase 2 unlinked), PM sync is skipped gracefully — no queue entry, no exception, just a `logger.info` line. No fallback to NLP's guess or to the old `commit_hash[:12]` target.
- Deleted the buggy `commit_hash[:12]` fallback target entirely (dead code now that unresolved tickets never reach the staging branch).
- Confidence for staged `post_comment` actions is now a flat `0.85` baseline reflecting Phase 2's verified hit rate, independent of whether NLP separately found a ticket guess.

## Test plan
- [x] `uv run pytest backend/tests/test_http_triggers.py -q` — 34/34 passed (added 6 new tests covering: ticket_id present stages with correct target/confidence, ticket_id absent skips, ticket_id empty string skips, NLP-guess-independent confidence, no commit_hash fallback target)
- [x] `uv run pytest backend/tests/ -q` — 623 passed, 1 pre-existing documented failure (`test_ollama_host_returns_string`), no regressions
- [x] Hardcoded-values scan on diff — clean (no `os.getenv`, no hardcoded hosts/ports introduced)

Closes TASK-071 on project board.