### PR TITLE
TASK-072: Voice-aware ticket comment generation

### DIFF
--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -2,6 +2,39 @@
 
 ---
 
+### [2026-06-17 17:18] TASK-072 — Voice-aware ticket comment generation
+
+**Branch**: feat/TASK-072-ticket-comment-generation
+**Status**: COMPLETE
+**Commit**: 87e4915 — feat(comment): add generate_ticket_comment(); wire into process_commit (TASK-072)
+**PR**: https://github.com/sraj0501/Devtrack_/pull/179 (base: dev)
+**Original message**: "feat(comment): add generate_ticket_comment(); wire into process_commit (TASK-072)"
+**DevTrack enhanced it to**: (AI provider unreachable — Ollama not running at http://127.0.0.1:11434 — committed with original message as-is)
+**Ticket auto-linked**: NO
+**PM system updated**: YES — project_board.md TASK-072 marked COMPLETE; all 7 criteria ticked; PR URL posted
+**Tests**: uv run pytest backend/tests/ -q — 633 passed, 0 regressions (1 pre-existing failure: test_ollama_host_returns_string, documented since TASK-058)
+**Friction**: LOW
+**Notes**:
+- `generate_ticket_comment()` added to `commit_message_enhancer.py` alongside `enhance_message_with_ai()`. Reuses `CommitMessageEnhancer._get_provider()` (lazy-init LLM chain), same config accessors (`http_timeout()`, `commit_llm_temperature()`, `commit_llm_max_tokens()`), same module-level `_inject_style` binding. No new LLM client or dependency.
+- Prompt explicitly embeds `ticket_id` twice (in the header and in the instruction) so the test assertion on prompt content is unambiguous.
+- Diff fetched via `git_diff_analyzer.GitDiffAnalyzer.get_commit_diff(repo_path, "HEAD")` when the trigger payload does not carry a `"diff"` key (standard case today).
+- Fallback: on any exception, derives `short_id` from `git rev-parse --short=12 HEAD` in `repo_path`, falling back to the first 12 chars of the commit message. Returns `f"Commit {short_id}: {commit_message}"`.
+- `_inject_style` patching in tests: uses `wraps=lambda ...` to stay transparent while recording calls — needed to avoid breaking the actual inject_style mock while also recording it.
+- 3 existing tests in `test_http_triggers.py` updated to patch `generate_ticket_comment` (the description field is no longer the raw NLP output — these tests guard PM sync behavior, not comment content).
+- `process_commit` wiring: both `pm_payload["description"]` and `pm_payload["comment"]` fields now set from `generate_ticket_comment()`. Belt-and-suspenders try/except in `process_commit` catches any uncaught exception from `generate_ticket_comment()` and falls back to NLP/commit_msg.
+
+## Task Summary — TASK-072: Voice-aware ticket comment generation — 2026-06-17
+
+- Total commits: 1
+- Acceptance criteria met: 7/7
+- Tickets auto-updated: 0 (platform not configured in test env)
+- Estimated daily time saved: ~3 min per commit-linked ticket (no manual ticket comment writing)
+- Blockers encountered: none
+- One thing that still feels rough: "config accessors being imported inside the function body (not at module level) requires patching backend.config.* instead of the module-level name — this is consistent with how other functions work here but means test patches need to know this detail"
+- Ready for PM review: YES
+
+---
+
 ### [2026-06-16] SESSION START — Phase 2: Opinionated ticket extractor
 
 **PM dispatch**: Phase 2 decomposed into TASK-067 through TASK-070. TASK-067 dispatched.

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1458,8 +1458,8 @@ Run `uv run pytest backend/tests/ -q` — no regressions.
 - [ ] No `os.getenv` introduced; no hardcoded model name, host, or timeout literals
       (reuse existing config accessors).
 
-**Engineer status**: not started
-**Blockers**: TASK-071 must merge first (payload/target wiring this depends on)
+**Engineer status**: started — add generate_ticket_comment() to commit_message_enhancer.py reusing existing LLM plumbing; wire into process_commit; 3 tests (LLM available, LLM unavailable, inject_style called)
+**Blockers**: none (TASK-071 merged as PR #178)
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1446,20 +1446,23 @@ If the trigger payload doesn't include a diff, call the existing diff-fetch path
 Run `uv run pytest backend/tests/ -q` — no regressions.
 
 **Acceptance criteria**:
-- [ ] `generate_ticket_comment()` exists, reuses `commit_message_enhancer.py`'s existing
+- [x] `generate_ticket_comment()` exists, reuses `commit_message_enhancer.py`'s existing
       Ollama client/prompt plumbing (no duplicate LLM client setup).
-- [ ] Falls back to a templated comment string when the LLM call fails — never raises out
+- [x] Falls back to a templated comment string when the LLM call fails — never raises out
       of `process_commit`.
-- [ ] `inject_style()` applied with `context_type="comment"`.
-- [ ] `process_commit`'s staged `post_comment` payload description/comment field is sourced
+- [x] `inject_style()` applied with `context_type="comment"`.
+- [x] `process_commit`'s staged `post_comment` payload description/comment field is sourced
       from `generate_ticket_comment()`, not the raw NLP description.
-- [ ] New tests pass (LLM available / unavailable / style injection called).
-- [ ] `uv run pytest backend/tests/ -q` — no regressions.
-- [ ] No `os.getenv` introduced; no hardcoded model name, host, or timeout literals
+- [x] New tests pass (LLM available / unavailable / style injection called).
+- [x] `uv run pytest backend/tests/ -q` — no regressions (633 passed, 1 pre-existing failure).
+- [x] No `os.getenv` introduced; no hardcoded model name, host, or timeout literals
       (reuse existing config accessors).
 
-**Engineer status**: started — add generate_ticket_comment() to commit_message_enhancer.py reusing existing LLM plumbing; wire into process_commit; 3 tests (LLM available, LLM unavailable, inject_style called)
-**Blockers**: none (TASK-071 merged as PR #178)
+**Engineer status**: 7/7 criteria done — last commit: 87e4915 "feat(comment): add generate_ticket_comment(); wire into process_commit (TASK-072)" — 2026-06-17 17:18
+**PR**: https://github.com/sraj0501/Devtrack_/pull/179
+**Blockers**: none
+
+**COMPLETE** — ready for PM review — 2026-06-17 17:25
 
 ---
 

--- a/devtrack_server/backend/commit_message_enhancer.py
+++ b/devtrack_server/backend/commit_message_enhancer.py
@@ -473,6 +473,133 @@ class CommitMessageEnhancer:
             return False
 
 
+def generate_ticket_comment(
+    commit_message: str,
+    diff: str,
+    files: list,
+    ticket_id: str,
+    repo_path: str = None,
+) -> str:
+    """Generate a ticket comment in the developer's voice describing this commit's
+    contribution to the named ticket.
+
+    Reuses the same Ollama/LLM pipeline as ``enhance_message_with_ai`` — same
+    provider, same config accessors, no duplicate client setup.  Falls back to a
+    templated comment (``"Commit <hash>: <message>"``) if the LLM call raises for
+    any reason (Non-Negotiable #8: never block commit processing on failure).
+
+    Args:
+        commit_message: The raw commit message string.
+        diff:           The diff text for context (may be empty string).
+        files:          List of changed file paths.
+        ticket_id:      The resolved ticket ID (e.g. "PROJ-123", "AB-7").
+        repo_path:      Path to the git repository (used to fetch diff via git
+                        when ``diff`` is empty).
+
+    Returns:
+        A short, professional ticket comment (1–3 sentences) or a templated
+        fallback string — never raises.
+    """
+    # ── fallback template ──────────────────────────────────────────────────────
+    # Derive a short hash from whatever is available.
+    short_id: str = ""
+    if repo_path:
+        try:
+            from backend.config import http_timeout_short
+            import subprocess as _sp
+            r = _sp.run(
+                ["git", "rev-parse", "--short=12", "HEAD"],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                timeout=http_timeout_short(),
+            )
+            if r.returncode == 0:
+                short_id = r.stdout.strip()
+        except Exception:
+            pass
+    if not short_id:
+        # last resort: first 12 chars of the commit message (unique enough for fallback)
+        short_id = (commit_message or "")[:12].strip() or "unknown"
+
+    fallback = f"Commit {short_id}: {commit_message}"
+
+    try:
+        # ── if no diff provided, try to fetch it from git ──────────────────────
+        resolved_diff = diff or ""
+        if not resolved_diff and repo_path:
+            try:
+                from backend.git_diff_analyzer import GitDiffAnalyzer
+                _analyzer = GitDiffAnalyzer()
+                fetched = _analyzer.get_commit_diff(repo_path, "HEAD")
+                if fetched:
+                    resolved_diff = fetched
+            except Exception as _e:
+                logger.debug("generate_ticket_comment: diff fetch failed (non-fatal): %s", _e)
+
+        # ── build file list summary ────────────────────────────────────────────
+        files_summary = ""
+        if files:
+            listed = files[:8]
+            files_summary = "Files changed: " + ", ".join(listed)
+            if len(files) > 8:
+                files_summary += f" … and {len(files) - 8} more"
+
+        # ── build ticket-comment prompt ────────────────────────────────────────
+        # ticket_id appears explicitly so the prompt is keyed to this ticket;
+        # the test suite asserts the prompt construction path, not the output text.
+        diff_excerpt = ""
+        if resolved_diff:
+            diff_lines = resolved_diff.splitlines()
+            if len(diff_lines) > 80:
+                diff_lines = diff_lines[:80]
+                diff_lines.append("... (diff truncated)")
+            diff_excerpt = "\n".join(diff_lines)
+
+        prompt = f"""You are writing a brief ticket update comment for ticket {ticket_id}.
+
+A developer just committed the following change. Write a short, professional comment
+(1–3 sentences) suitable for posting directly on ticket {ticket_id}. The comment should
+describe what was changed and why — from the commit diff and message — in the developer's
+own voice. Do NOT restate the raw commit message verbatim. Do NOT include meta-commentary,
+options lists, or preamble. Output ONLY the comment text.
+
+Commit message: {commit_message}
+{files_summary}
+{"Diff (excerpt):" + chr(10) + diff_excerpt if diff_excerpt else ""}
+""".strip()
+
+        # ── apply personalization style injection ──────────────────────────────
+        prompt = _inject_style(prompt, context_type="comment", query_text=commit_message)
+
+        # ── call LLM (reuse the module-level enhancer's provider chain) ────────
+        from backend.llm.base import LLMOptions
+        from backend.config import http_timeout, commit_llm_temperature, commit_llm_max_tokens
+
+        _enhancer = CommitMessageEnhancer()
+        generated = _enhancer._get_provider().generate(
+            prompt=prompt,
+            options=LLMOptions(
+                temperature=commit_llm_temperature(),
+                max_tokens=commit_llm_max_tokens(),
+            ),
+            timeout=http_timeout(),
+        )
+
+        if not generated or len(generated.strip()) < 5:
+            return fallback
+
+        # Strip markdown fences if the model wrapped the output
+        result = generated.replace("```", "").strip()
+        if not result:
+            return fallback
+        return result
+
+    except Exception as e:
+        logger.warning("generate_ticket_comment: LLM call failed (using fallback): %s", e)
+        return fallback
+
+
 def main():
     """CLI entry point for git hook"""
     if len(sys.argv) < 2:

--- a/devtrack_server/backend/tests/test_http_triggers.py
+++ b/devtrack_server/backend/tests/test_http_triggers.py
@@ -334,7 +334,14 @@ class TestTriggerProcessorCommit:
         proc._queue_gateway = mock_gateway
 
         payload = {**COMMIT_PAYLOAD, "ticket_id": "GH-1"}
-        result = proc.process_commit(payload)
+        # TASK-072: generate_ticket_comment() is now called for the description.
+        # Patch it to return the raw commit message so this regression guard
+        # continues to verify PM sync staging behaviour, not LLM output.
+        with patch(
+            "backend.commit_message_enhancer.generate_ticket_comment",
+            return_value=COMMIT_PAYLOAD["commit_message"],
+        ):
+            result = proc.process_commit(payload)
 
         mock_gateway.stage.assert_called_once()
         _, kwargs = mock_gateway.stage.call_args
@@ -487,14 +494,20 @@ class TestProcessCommitQueueStaging:
         proc._queue_gateway = mock_gateway
 
         payload = {**COMMIT_PAYLOAD, "ticket_id": "PROJ-555"}
-        result = proc.process_commit(payload)
+        # TASK-072: generate_ticket_comment() is now the source of description.
+        # Patch it so this regression test stays focused on PM sync staging.
+        with patch(
+            "backend.commit_message_enhancer.generate_ticket_comment",
+            return_value=COMMIT_PAYLOAD["commit_message"],
+        ):
+            result = proc.process_commit(payload)
 
         mock_gateway.stage.assert_called_once()
         _, kwargs = mock_gateway.stage.call_args
         assert kwargs["target"] == "PROJ-555"
         assert kwargs["confidence"] == 0.85
         assert kwargs["action_type"] == "post_comment"
-        # description falls back to the raw commit message when task_data is None
+        # description comes from generate_ticket_comment (patched to raw commit msg here)
         assert kwargs["payload"]["description"] == COMMIT_PAYLOAD["commit_message"]
         assert kwargs["payload"]["status"] == ""
         assert "queued:post_comment:11" in result["actions"]
@@ -513,7 +526,13 @@ class TestProcessCommitQueueStaging:
         proc._queue_gateway = mock_gateway
 
         payload = {**COMMIT_PAYLOAD, "ticket_id": "PROJ-556"}
-        result = proc.process_commit(payload)
+        # TASK-072: generate_ticket_comment() is now the source of description.
+        # Patch it so this regression test stays focused on PM sync staging.
+        with patch(
+            "backend.commit_message_enhancer.generate_ticket_comment",
+            return_value=COMMIT_PAYLOAD["commit_message"],
+        ):
+            result = proc.process_commit(payload)
 
         mock_gateway.stage.assert_called_once()
         _, kwargs = mock_gateway.stage.call_args

--- a/devtrack_server/backend/tests/test_ticket_comment_generation.py
+++ b/devtrack_server/backend/tests/test_ticket_comment_generation.py
@@ -1,0 +1,268 @@
+"""
+Tests for generate_ticket_comment() in commit_message_enhancer.py.
+
+Three tests as specified by TASK-072:
+  1. LLM available  — returns a non-empty string distinct from raw commit message;
+                      ticket_id appears in the prompt sent to the LLM.
+  2. LLM unavailable — falls back to a templated string; no exception propagates.
+  3. inject_style called — assert inject_style was invoked with context_type="comment".
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure project root on sys.path
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+COMMIT_MSG = "fix: auth bug"
+DIFF_TEXT   = "--- a/auth.py\n+++ b/auth.py\n@@ -1 +1 @@\n-old\n+new"
+FILES       = ["auth.py"]
+TICKET_ID   = "PROJ-42"
+
+
+def _make_provider_mock(return_value: str) -> MagicMock:
+    """Build a mock LLM provider whose .generate() returns *return_value*."""
+    provider = MagicMock()
+    provider.generate.return_value = return_value
+    return provider
+
+
+def _llm_patches(mock_provider: MagicMock):
+    """Return a context manager that patches the LLM provider and all config
+    accessors used inside generate_ticket_comment(), so tests don't require
+    real environment variables.
+
+    The config functions (http_timeout etc.) are imported inside the function
+    body at call time, so we patch them on their source module (backend.config).
+    """
+    from contextlib import ExitStack
+    stack = ExitStack()
+    stack.enter_context(patch(
+        "backend.commit_message_enhancer.CommitMessageEnhancer._get_provider",
+        return_value=mock_provider,
+    ))
+    # Patch config accessors at source — generate_ticket_comment imports them
+    # fresh from backend.config on each call.
+    stack.enter_context(patch("backend.config.http_timeout", return_value=30))
+    stack.enter_context(patch("backend.config.commit_llm_temperature", return_value=0.3))
+    stack.enter_context(patch("backend.config.commit_llm_max_tokens", return_value=256))
+    return stack
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — LLM available
+# ---------------------------------------------------------------------------
+
+class TestGenerateTicketCommentLLMAvailable:
+    """When the LLM is reachable, generate_ticket_comment() should:
+    - return a non-empty string
+    - NOT return the raw commit message verbatim (i.e. the LLM response was used)
+    - have called the LLM with a prompt that contains the ticket_id
+    """
+
+    def test_returns_nonempty_string(self):
+        mock_provider = _make_provider_mock("Fixed the authentication issue in this commit.")
+
+        with _llm_patches(mock_provider):
+            from backend.commit_message_enhancer import generate_ticket_comment
+            result = generate_ticket_comment(
+                commit_message=COMMIT_MSG,
+                diff=DIFF_TEXT,
+                files=FILES,
+                ticket_id=TICKET_ID,
+                repo_path=None,
+            )
+
+        assert result, "Result must be a non-empty string"
+        assert isinstance(result, str)
+
+    def test_result_distinct_from_raw_commit_message(self):
+        mock_provider = _make_provider_mock("Fixed the authentication issue in this commit.")
+
+        with _llm_patches(mock_provider):
+            from backend.commit_message_enhancer import generate_ticket_comment
+            result = generate_ticket_comment(
+                commit_message=COMMIT_MSG,
+                diff=DIFF_TEXT,
+                files=FILES,
+                ticket_id=TICKET_ID,
+                repo_path=None,
+            )
+
+        assert result != COMMIT_MSG, (
+            "LLM was called and returned a custom response — result must differ from raw msg"
+        )
+
+    def test_ticket_id_present_in_prompt_sent_to_llm(self):
+        """The prompt construction path must embed the ticket_id so the LLM
+        knows which ticket the comment is for.  We assert this by inspecting
+        the prompt passed to provider.generate()."""
+        mock_provider = _make_provider_mock("Resolved auth timeout on PROJ-42.")
+
+        with _llm_patches(mock_provider):
+            from backend.commit_message_enhancer import generate_ticket_comment
+            generate_ticket_comment(
+                commit_message=COMMIT_MSG,
+                diff=DIFF_TEXT,
+                files=FILES,
+                ticket_id=TICKET_ID,
+                repo_path=None,
+            )
+
+        assert mock_provider.generate.called, "provider.generate must have been called"
+        call_kwargs = mock_provider.generate.call_args
+        # The prompt is passed as the first positional arg or as keyword 'prompt'
+        prompt_arg: str = (
+            call_kwargs.kwargs.get("prompt")
+            or (call_kwargs.args[0] if call_kwargs.args else "")
+        )
+        assert TICKET_ID in prompt_arg, (
+            f"ticket_id '{TICKET_ID}' must appear in the prompt sent to the LLM; "
+            f"got prompt: {prompt_arg[:300]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — LLM unavailable
+# ---------------------------------------------------------------------------
+
+class TestGenerateTicketCommentLLMUnavailable:
+    """When the LLM raises any exception, generate_ticket_comment() must:
+    - not propagate the exception
+    - return a non-empty fallback string
+    - fallback string must contain the original commit message
+    """
+
+    def test_no_exception_propagates(self):
+        mock_provider = MagicMock()
+        mock_provider.generate.side_effect = ConnectionError("Ollama unreachable")
+
+        with patch(
+            "backend.commit_message_enhancer.CommitMessageEnhancer._get_provider",
+            return_value=mock_provider,
+        ):
+            from backend.commit_message_enhancer import generate_ticket_comment
+            # Must not raise
+            result = generate_ticket_comment(
+                commit_message=COMMIT_MSG,
+                diff=DIFF_TEXT,
+                files=FILES,
+                ticket_id=TICKET_ID,
+                repo_path=None,
+            )
+
+        assert result is not None
+
+    def test_returns_nonempty_fallback(self):
+        mock_provider = MagicMock()
+        mock_provider.generate.side_effect = RuntimeError("model not loaded")
+
+        with patch(
+            "backend.commit_message_enhancer.CommitMessageEnhancer._get_provider",
+            return_value=mock_provider,
+        ):
+            from backend.commit_message_enhancer import generate_ticket_comment
+            result = generate_ticket_comment(
+                commit_message=COMMIT_MSG,
+                diff=DIFF_TEXT,
+                files=FILES,
+                ticket_id=TICKET_ID,
+                repo_path=None,
+            )
+
+        assert isinstance(result, str) and result.strip(), "Fallback must be a non-empty string"
+
+    def test_fallback_contains_commit_message(self):
+        mock_provider = MagicMock()
+        mock_provider.generate.side_effect = OSError("connection refused")
+
+        with patch(
+            "backend.commit_message_enhancer.CommitMessageEnhancer._get_provider",
+            return_value=mock_provider,
+        ):
+            from backend.commit_message_enhancer import generate_ticket_comment
+            result = generate_ticket_comment(
+                commit_message=COMMIT_MSG,
+                diff=DIFF_TEXT,
+                files=FILES,
+                ticket_id=TICKET_ID,
+                repo_path=None,
+            )
+
+        assert COMMIT_MSG in result, (
+            f"Fallback must contain the original commit message; got: {result!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — inject_style called with context_type="comment"
+# ---------------------------------------------------------------------------
+
+class TestGenerateTicketCommentInjectStyle:
+    """inject_style() must be called with context_type='comment' so that
+    personalization is applied to the ticket comment prompt."""
+
+    def test_inject_style_called_with_comment_context(self):
+        mock_provider = _make_provider_mock("Auth fix applied to resolve ticket.")
+
+        # Patch inject_style at the location it is bound in the module
+        with (
+            _llm_patches(mock_provider),
+            patch(
+                "backend.commit_message_enhancer._inject_style",
+                wraps=lambda p, context_type="general", query_text=None: p,
+            ) as mock_inject,
+        ):
+            from backend.commit_message_enhancer import generate_ticket_comment
+            generate_ticket_comment(
+                commit_message=COMMIT_MSG,
+                diff=DIFF_TEXT,
+                files=FILES,
+                ticket_id=TICKET_ID,
+                repo_path=None,
+            )
+
+        assert mock_inject.called, "_inject_style must have been called"
+        _, inject_kwargs = mock_inject.call_args
+        assert inject_kwargs.get("context_type") == "comment", (
+            f"inject_style must be called with context_type='comment'; "
+            f"got: {inject_kwargs.get('context_type')!r}"
+        )
+
+    def test_inject_style_receives_commit_message_as_query_text(self):
+        """The query_text passed to inject_style should be the commit message,
+        so RAG retrieves examples of how the user wrote about similar work."""
+        mock_provider = _make_provider_mock("Auth fix applied.")
+
+        with (
+            _llm_patches(mock_provider),
+            patch(
+                "backend.commit_message_enhancer._inject_style",
+                wraps=lambda p, context_type="general", query_text=None: p,
+            ) as mock_inject,
+        ):
+            from backend.commit_message_enhancer import generate_ticket_comment
+            generate_ticket_comment(
+                commit_message=COMMIT_MSG,
+                diff=DIFF_TEXT,
+                files=FILES,
+                ticket_id=TICKET_ID,
+                repo_path=None,
+            )
+
+        _, inject_kwargs = mock_inject.call_args
+        assert inject_kwargs.get("query_text") == COMMIT_MSG, (
+            f"inject_style query_text should be the commit message; "
+            f"got: {inject_kwargs.get('query_text')!r}"
+        )

--- a/devtrack_server/backend/webhook_server.py
+++ b/devtrack_server/backend/webhook_server.py
@@ -474,12 +474,33 @@ class TriggerProcessor:
                 # authoritative signal for *targeting*; task_data is only
                 # optional descriptive enrichment, so every read of it below
                 # must fall back to commit_msg / "" without raising.
-                description = task_data.get("description", commit_msg) if task_data else commit_msg
-                status      = task_data.get("status", "") if task_data else ""
+                status = task_data.get("status", "") if task_data else ""
+
+                # Phase 3 (TASK-072): generate a voice-aware ticket comment via
+                # the LLM pipeline, not a raw NLP restatement. Falls back to a
+                # templated string on any LLM failure — never blocks processing.
+                try:
+                    from backend.commit_message_enhancer import generate_ticket_comment as _gtc
+                    ticket_comment = _gtc(
+                        commit_message=commit_msg,
+                        diff=data.get("diff", ""),
+                        files=data.get("files", []),
+                        ticket_id=resolved_ticket_id,
+                        repo_path=repo_path or None,
+                    )
+                except Exception as _gtc_exc:
+                    logger.warning(
+                        "generate_ticket_comment failed (belt-and-suspenders fallback): %s",
+                        _gtc_exc,
+                    )
+                    # task_data.get("description") NLP restatement as last resort
+                    ticket_comment = (
+                        task_data.get("description", commit_msg) if task_data else commit_msg
+                    )
 
                 # Build the payload that _execute_pm_action expects
                 pm_payload = {
-                    "description": description,
+                    "description": ticket_comment,
                     "ticket_id":   resolved_ticket_id,
                     "status":      status,
                     "pm_project":  pm_project,
@@ -487,7 +508,7 @@ class TriggerProcessor:
                     "pm_iteration_path": pm_iteration_path,
                     "pm_area_path":      pm_area_path,
                     "pm_milestone":      pm_milestone,
-                    "comment":     description,
+                    "comment":     ticket_comment,
                     "commit_info": {
                         "hash":    commit_hash,
                         "message": commit_msg,


### PR DESCRIPTION
## Summary
- Adds \`generate_ticket_comment()\` to \`commit_message_enhancer.py\`, reusing existing Ollama/LLM plumbing (same \`CommitMessageEnhancer._get_provider()\`, same config accessors — no duplicate LLM client setup)
- Applies \`inject_style(context_type=\"comment\")\` for voice-aware personalized output
- Falls back to templated comment (\`Commit <hash>: <message>\`) on LLM failure — never blocks \`process_commit\` (Non-Negotiable #8)
- Wires into \`process_commit\`'s \`post_comment\` payload: both \`description\` and \`comment\` fields now sourced from \`generate_ticket_comment()\`, not raw NLP description
- Fetches diff via \`git_diff_analyzer.GitDiffAnalyzer.get_commit_diff()\` when not present in the trigger payload
- 8 new tests: LLM available (3), LLM unavailable (3), inject_style assertion (2)
- Updates 3 existing regression tests in test_http_triggers.py to patch generate_ticket_comment()

## Test plan
- [x] \`uv run pytest backend/tests/ -q\` — 633 passed, 0 regressions (pre-existing \`test_ollama_host_returns_string\` failure unchanged)
- [x] Test LLM available: non-empty result, distinct from raw commit msg, ticket_id in prompt
- [x] Test LLM unavailable: fallback returned, no exception propagates
- [x] Test inject_style called with context_type="comment" and query_text=commit_message

Closes TASK-072 | Base: dev (NOT main)