### PR TITLE
TASK-076: EOD report content — commit-grouped narrative with personalization

### DIFF
--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -2,6 +2,35 @@
 
 ---
 
+### [2026-06-17 19:40] TASK-076 — EOD report content: commit-grouped narrative with personalization
+
+**Original message**: "feat(server): add generate_eod_narrative() to DailyReportGenerator; update /reports/eod endpoint (TASK-076)"
+**DevTrack enhanced it to**: (AI provider unreachable — Ollama not running — committed with original message as-is)
+**Ticket auto-linked**: NO
+**PM system updated**: YES — project_board.md TASK-076 marked COMPLETE; all 8 criteria ticked; PR #183 posted
+**Time**: ~45 minutes
+**Friction**: LOW
+**Notes**:
+- Extended `DailyReportGenerator` in `devtrack_server/backend/daily_report_generator.py` with three new private methods + one public method: `generate_eod_narrative()`, `_query_commit_rows()`, `_generate_ticket_narrative()`.
+- `_query_commit_rows()` queries the `triggers` table WHERE `trigger_type='commit'` AND `date(timestamp) = target_date`. Uses `self.db_path` which is already set on the class via `backend.config.database_path()` or the injected `db_path` arg.
+- `_generate_ticket_narrative()` builds a 1-3 sentence prompt, passes it through `_inject_style(context_type="report", query_text=messages_joined)`, calls `self._get_provider().generate()` with typed config accessors. Falls back to bullet list on any exception — Non-Negotiable #8 upheld.
+- `generate_eod_narrative()` groups rows by ticket_id; empty/"unlinked" values go to the "Other commits" section. Returns "No commits recorded today." for an empty day, never raises.
+- `/reports/eod` endpoint rewritten: dropped the old `_EODGenerator` import (which came from `backend.work_tracker.eod_report_generator`, a legacy module). Now imports `DailyReportGenerator` and calls `generate_eod_narrative()` via `asyncio.to_thread`. Returns `{"output": narrative, "success": True, "narrative": narrative}` shape as specified in the task.
+- 16 tests written across 5 classes in `test_eod_narrative.py`. A temp SQLite DB is created per test with the relevant trigger rows so tests are fully isolated and do not require the real devtrack.db.
+- Zero `os.getenv` introduced. All config read through `backend.config` typed accessors.
+
+## Task Summary — TASK-076: EOD report content — commit-grouped narrative with personalization — 2026-06-17
+
+- Total commits: 1 (a25bc94)
+- Acceptance criteria met: 8/8
+- Tickets auto-updated: 0
+- Estimated daily time saved: ~10 min (eliminates manual EOD report writing for every commit-heavy day)
+- Blockers encountered: none
+- One thing that still feels rough: "The triggers table schema was inferred from prior tasks (TASK-068) — it would be cleaner if there were a central schema doc. The query works but required cross-referencing the Go migration SQL to confirm column names."
+- Ready for PM review: YES
+
+---
+
 ### [2026-06-17 18:50] TASK-074 — Phase 3 exit criterion verification
 
 **Branch**: feat/TASK-074-phase3-exit-verification

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1795,16 +1795,20 @@ return {"output": narrative, "success": True, "narrative": narrative}
 - Unlinked commits (ticket_id = "") → appear under "Other commits" section, not silently dropped.
 
 **Acceptance criteria**:
-- [ ] `DailyReportGenerator.generate_eod_narrative()` exists; queries `triggers` table; groups by `ticket_id`
-- [ ] LLM applied per ticket group via existing provider chain; falls back gracefully when absent
-- [ ] `inject_style(context_type="report")` applied to each ticket narrative
-- [ ] Unlinked commits appear under "Other commits" section (not silently dropped)
-- [ ] Empty-day returns a non-empty "No commits recorded" string, never raises
-- [ ] `/reports/eod` endpoint uses `DailyReportGenerator.generate_eod_narrative()` — not the old `_EODGenerator`
-- [ ] `uv run pytest backend/tests/ -q` — no regressions (1 pre-existing failure allowed)
-- [ ] No `os.getenv` introduced; all config via `backend.config` accessors
+- [x] `DailyReportGenerator.generate_eod_narrative()` exists; queries `triggers` table; groups by `ticket_id`
+- [x] LLM applied per ticket group via existing provider chain; falls back gracefully when absent
+- [x] `inject_style(context_type="report")` applied to each ticket narrative
+- [x] Unlinked commits appear under "Other commits" section (not silently dropped)
+- [x] Empty-day returns a non-empty "No commits recorded" string, never raises
+- [x] `/reports/eod` endpoint uses `DailyReportGenerator.generate_eod_narrative()` — not the old `_EODGenerator`
+- [x] `uv run pytest backend/tests/ -q` — no regressions (1 pre-existing failure allowed)
+- [x] No `os.getenv` introduced; all config via `backend.config` accessors
 
-**Engineer status**: started — add generate_eod_narrative() to DailyReportGenerator; query triggers table; group by ticket_id; LLM per-ticket narrative with inject_style; update /reports/eod endpoint; write test_eod_narrative.py
+**Engineer status**: 8/8 criteria done — last commit: a25bc94 "feat(server): add generate_eod_narrative() to DailyReportGenerator; update /reports/eod endpoint (TASK-076)" — 2026-06-17 19:40
+**PR**: https://github.com/sraj0501/Devtrack_/pull/183
+**Blockers**: none
+
+**COMPLETE** — ready for PM review — 2026-06-17 19:45
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1695,6 +1695,313 @@ against the real pipeline, not just unit tests, plus the board/feature-tracker u
 
 ---
 
+## ACTIVE — Phase 4: EOD Pipeline
+
+**Goal**: Cron fires at the configured time (`EOD_REPORT_HOUR` per workspace or global). Query
+today's commits from SQLite, group by ticket, LLM generates a per-ticket narrative in the
+developer's voice. All outbound actions (email send, Telegram delivery) are staged in
+`pending_actions`. Developer receives an accurate EOD report every evening without doing anything.
+
+**Exit criterion** (PRODUCT_BIBLE.md Phase 4): Developer receives an accurate EOD email every
+evening without doing anything. Report reads like they wrote it.
+
+---
+
+### TASK-075 — Fix EOD cron config: replace os.Getenv with typed accessors; per-workspace eod_time
+**Assigned to**: engineer
+**Priority**: HIGH
+**Phase**: Phase 4
+**Started**: 2026-06-17
+**Depends on**: none
+**Branch**: `feat/TASK-075-eod-cron-config`
+
+**Acceptance criteria**:
+- [x] `GetEODReportHour()`, `GetEODReportEmail()`, `GetEODReportMinute()`, `GetWorkSessionAutoStopMinutes()` exist in `config_env.go`
+- [x] `scheduleEODReport()` and `scheduleIdleSessionStop()` contain zero `os.Getenv` calls
+- [x] `WorkspaceConfig.EODTime string yaml:"eod_time,omitempty"` present in `config.go`
+- [x] `.env_sample` documents all four new keys
+- [x] `go build ./...` and `go vet ./...` pass clean from `devtrack_client/`
+- [x] `grep -n "os\.Getenv" devtrack_client/internal/infra/scheduler.go` returns zero matches
+
+**Engineer status**: 6/6 criteria done — last commit: 26b0d2e "fix(config): replace os.Getenv in scheduler.go with typed accessors; add EODTime to WorkspaceConfig (TASK-075)" — 2026-06-17 19:24
+**PR**: https://github.com/sraj0501/Devtrack_/pull/182
+**Blockers**: none
+
+**COMPLETE** — ready for PM review — 2026-06-17 19:25
+
+---
+
+### TASK-076 — EOD report content: commit-grouped narrative with personalization
+**Assigned to**: engineer
+**Priority**: HIGH
+**Phase**: Phase 4
+**Started**: 2026-06-17
+**Depends on**: TASK-075 (COMPLETE — PR #182)
+**Branch**: `feat/TASK-076-eod-narrative-content`
+
+**Spec**:
+
+Upgrade `devtrack_server/backend/daily_report_generator.py` and the `/reports/eod` endpoint in
+`webhook_server.py` to produce a commit-grouped, personalized narrative instead of the current
+session-duration summary. Do NOT rewrite `daily_report_generator.py` — extend it.
+
+The current `/reports/eod` handler calls `_EODGenerator().generate()` and formats duration/session
+counts. Phase 4 needs: (1) today's commits from `triggers` table grouped by `ticket_id`;
+(2) per-ticket LLM narrative in developer's voice; (3) `inject_style(context_type="report")` applied.
+
+**Step 1 — New method on `DailyReportGenerator`: `generate_eod_narrative(target_date: str) -> str`**
+
+In `devtrack_server/backend/daily_report_generator.py`, add:
+
+```python
+def generate_eod_narrative(self, target_date: Optional[str] = None) -> str:
+    """
+    Query today's commit triggers from SQLite, group by ticket_id, generate a
+    per-ticket narrative paragraph via LLM (reusing existing Ollama provider chain),
+    apply inject_style(context_type="report"), assemble into a complete EOD report string.
+    Falls back to a plain-text enumeration of commits if LLM is unavailable.
+    Never raises — always returns a string.
+    """
+```
+
+Implementation notes:
+- Query `triggers` table WHERE `trigger_type='commit'` AND `date(timestamp) = target_date`
+  (default: today in local time). Use `self.email_reporter.db_path` for the SQLite connection.
+- Group rows by `ticket_id`. Rows with empty or unlinked `ticket_id` go into "Other commits" section.
+- For each ticket group: build a prompt — "Summarize what was accomplished on ticket {ticket_id}
+  today based on these commit messages: {messages}. Write 1–3 sentences, first person, past tense."
+  Pass through `_inject_style(prompt, context_type="report")` before the LLM call.
+- Use the existing `self._provider` LLM chain (already initialized). If None or unavailable:
+  fall back to bullet-listing raw commit messages under each ticket section.
+- Assemble: `"EOD Report — {date}\n\n{per_ticket_sections}\n{unlinked_section}"`.
+
+**Step 2 — Update `/reports/eod` endpoint in `webhook_server.py`**
+
+Replace the current endpoint body with:
+
+```python
+from backend.daily_report_generator import DailyReportGenerator
+gen = DailyReportGenerator()
+narrative = gen.generate_eod_narrative(target_date=date_str)
+return {"output": narrative, "success": True, "narrative": narrative}
+```
+
+**Step 3 — Tests: `devtrack_server/backend/tests/test_eod_narrative.py`**
+
+- LLM available (mocked provider) → returns a multi-section string mentioning ticket IDs.
+- LLM unavailable → falls back to plain-text bullet list; no exception raised.
+- Empty commit history → returns "No commits recorded" string, never raises.
+- `inject_style` called with `context_type="report"` (mock/spy assertion).
+- Unlinked commits (ticket_id = "") → appear under "Other commits" section, not silently dropped.
+
+**Acceptance criteria**:
+- [ ] `DailyReportGenerator.generate_eod_narrative()` exists; queries `triggers` table; groups by `ticket_id`
+- [ ] LLM applied per ticket group via existing provider chain; falls back gracefully when absent
+- [ ] `inject_style(context_type="report")` applied to each ticket narrative
+- [ ] Unlinked commits appear under "Other commits" section (not silently dropped)
+- [ ] Empty-day returns a non-empty "No commits recorded" string, never raises
+- [ ] `/reports/eod` endpoint uses `DailyReportGenerator.generate_eod_narrative()` — not the old `_EODGenerator`
+- [ ] `uv run pytest backend/tests/ -q` — no regressions (1 pre-existing failure allowed)
+- [ ] No `os.getenv` introduced; all config via `backend.config` accessors
+
+**Engineer status**: started — add generate_eod_narrative() to DailyReportGenerator; query triggers table; group by ticket_id; LLM per-ticket narrative with inject_style; update /reports/eod endpoint; write test_eod_narrative.py
+
+---
+
+### TASK-077 — Queue the EOD report: `eod_report` action type through pending_actions
+**Priority**: HIGH
+**Phase**: Phase 4
+**Depends on**: TASK-075, TASK-076
+**Branch**: `feat/TASK-077-eod-queue-action`
+
+**Spec**:
+
+Every outbound action stages through `pending_actions` (Non-Negotiable #2). The EOD report
+must be queued like every other action, not sent directly.
+
+**Step 1 — Stage the EOD report as a queue action in `/reports/eod`**
+
+In `webhook_server.py` `/reports/eod` handler, after generating the narrative (TASK-076):
+
+```python
+action_id = _queue_gateway.stage(
+    action_type="eod_report",
+    target="developer",
+    platform="email",
+    workspace=data.get("workspace", "all"),
+    payload={
+        "narrative": narrative,
+        "email": email or "",
+        "date": date_str or str(date.today()),
+    },
+    confidence=get_eod_report_confidence(),
+    is_new_action_type=False,
+)
+return {"output": narrative, "success": True, "action_id": action_id}
+```
+
+Access `_queue_gateway` via the same app-level singleton used by `process_commit`
+(match TASK-061's established pattern exactly).
+
+**Step 2 — `_execute_pm_action` handles `action_type == "eod_report"`**
+
+In `webhook_server.py:_execute_pm_action()`, add a branch:
+
+```python
+elif action["action_type"] == "eod_report":
+    payload = action.get("payload", {})
+    narrative = payload.get("narrative", "")
+    email = payload.get("email", "")
+    if email:
+        reporter = EmailReporter()
+        reporter.send_text_report(narrative, email)
+    return {"status": "posted", "delivered_to": email or "none"}
+```
+
+If `EmailReporter` lacks `send_text_report(text, email)`, add it. It calls
+`reporter.graph_client.send_email(...)` when graph_client is initialized; otherwise
+logs and returns (never raises — Non-Negotiable #8).
+
+**Step 3 — `get_eod_report_confidence()` in `devtrack_server/backend/config.py`**
+
+```python
+def get_eod_report_confidence() -> float:
+    """Confidence for staged EOD report actions. EOD_REPORT_CONFIDENCE (default: 0.88)."""
+    return float(get("EOD_REPORT_CONFIDENCE", "0.88"))
+```
+
+**Step 4 — Tests: `devtrack_server/backend/tests/test_eod_queue_action.py`**
+
+- `/reports/eod` endpoint calls `_queue_gateway.stage()` with `action_type="eod_report"`.
+- `_execute_pm_action` with `eod_report` + non-empty email calls `EmailReporter.send_text_report`.
+- `_execute_pm_action` with empty email returns `{"status": "posted"}` without raising.
+- `get_eod_report_confidence()` returns `0.88` when `EOD_REPORT_CONFIDENCE` is unset.
+
+**Acceptance criteria**:
+- [ ] `/reports/eod` stages an `eod_report` queue row before returning
+- [ ] `_execute_pm_action` handles `action_type == "eod_report"`: delivers email when configured, skips gracefully otherwise
+- [ ] `get_eod_report_confidence()` accessor exists in `config.py`; no literal confidence in handler
+- [ ] No `os.getenv` introduced
+- [ ] `uv run pytest backend/tests/ -q` — no regressions
+
+**Engineer status**: not started
+**Blockers**: TASK-075, TASK-076
+
+---
+
+### TASK-078 — Telegram delivery for EOD reports (channel parity)
+**Priority**: MEDIUM
+**Phase**: Phase 4
+**Depends on**: TASK-077
+**Branch**: `feat/TASK-078-eod-telegram-delivery`
+
+**Spec**:
+
+Channel parity rule (Non-Negotiable #4): when an `eod_report` action enters the queue,
+the Telegram bot pushes the narrative to the configured chat.
+
+**Step 1 — `GetEODTelegramEnabled() bool` config accessor**
+
+In `devtrack_client/internal/config/config_env.go`:
+```go
+// GetEODTelegramEnabled returns true when EOD reports should be pushed to Telegram.
+// Reads EOD_TELEGRAM_ENABLED (default: false).
+func GetEODTelegramEnabled() bool
+```
+
+Add `EOD_TELEGRAM_ENABLED=false  # Set true to receive EOD reports in Telegram` to `.env_sample`.
+
+**Step 2 — `Bot.SendEODReport(narrative, date string, actionID int64) error`**
+
+In `devtrack_client/internal/telegram/`, add:
+
+```go
+// SendEODReport pushes the EOD narrative to the configured chat.
+// Message format:
+//   [DevTrack] EOD Report — {date}
+//   {narrative truncated to 4000 chars}
+//   [Approve] [Reject]
+func (b *Bot) SendEODReport(narrative, date string, actionID int64) error
+```
+
+Use the existing inline keyboard pattern from TASK-065 (`callback_data: "approve:<id>"` /
+`"reject:<id>"`). No new callback type needed — the existing handler processes it.
+Truncate narrative at 4000 chars (Telegram limit).
+
+**Step 3 — `QueueExecutor` calls `SendEODReport` for `eod_report` pending actions**
+
+In `devtrack_client/internal/infra/queue_executor.go`, when polling finds a new `pending`
+row with `action_type == "eod_report"`, and `GetEODTelegramEnabled()` is true:
+call `bot.SendEODReport(narrative, date, id)`. Add `ActionType` to `PendingActionSummary`
+if not already present (read the struct first to check).
+
+The Telegram push happens BEFORE the standard auto-approve check — the push is notification,
+auto-approve is separate.
+
+**Acceptance criteria**:
+- [ ] `GetEODTelegramEnabled()` accessor exists in `config_env.go`; `.env_sample` documents `EOD_TELEGRAM_ENABLED`
+- [ ] `Bot.SendEODReport(narrative, date, actionID)` exists; sends message + Approve/Reject inline buttons
+- [ ] `QueueExecutor` calls `SendEODReport` for `eod_report` pending rows when `GetEODTelegramEnabled()` is true
+- [ ] Narrative truncated to ≤4000 chars before sending
+- [ ] `go build ./...` and `go vet ./...` pass clean
+- [ ] No new Telegram API secrets introduced (uses existing `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`)
+
+**Engineer status**: not started
+**Blockers**: TASK-077
+
+---
+
+### TASK-079 — `devtrack eod` CLI command + Phase 4 exit criterion verification
+**Priority**: MEDIUM
+**Phase**: Phase 4
+**Depends on**: TASK-075, TASK-076, TASK-077, TASK-078
+**Branch**: `feat/TASK-079-eod-cli-phase4-exit`
+
+**Spec**:
+
+Two deliverables: (1) `devtrack eod` CLI command (Non-Negotiable #13: every server capability
+reachable via CLI), and (2) live verification run closing Phase 4.
+
+**Part A — `devtrack eod` CLI command**
+
+Add in `devtrack_client/cli.go` or a new `cli_eod.go`:
+
+```
+devtrack eod              # alias for "devtrack eod generate"
+devtrack eod generate     # POST /reports/eod, print narrative + "Queued as action <id>"
+devtrack eod status       # last EOD report date/time + action_id + queue status
+devtrack eod show         # most recent eod_report from pending_actions, print narrative
+```
+
+`devtrack eod show`: query `db.ListPendingActions("")`, filter `action_type == "eod_report"`,
+take most recent, parse `payload` JSON, extract `"narrative"`, print. If none: print
+"No EOD report on record".
+
+**Part B — Phase 4 exit criterion verification (mirrors TASK-074 pattern)**
+
+1. Build: `go build -o devtrack .` from `devtrack_client/`.
+2. Confirm EOD cron configured in `.env` (`EOD_REPORT_HOUR`, `EOD_REPORT_MINUTE`).
+3. Call `devtrack eod generate` manually.
+4. Confirm via `devtrack queue list` that an `eod_report` action appears.
+5. Confirm narrative is non-empty, contains at least one ticket reference if today had linked commits, reads naturally.
+6. Approve via `devtrack queue approve <id>` or let auto-approve fire.
+7. Run hardcoded-values scan across all Phase 4 files (TASK-075–078).
+8. Update `Data/agent_logs/feature_tracker.md` with Phase 4 completion entry.
+9. Open PR targeting `dev` with title "Phase 4: EOD pipeline — exit criterion verified".
+
+**Acceptance criteria**:
+- [ ] `devtrack eod generate`, `devtrack eod status`, `devtrack eod show` all work
+- [ ] `go build ./...` and `go vet ./...` pass clean
+- [ ] Live verification: `eod_report` action appears in queue; narrative is non-empty and personalized
+- [ ] Hardcoded-values scan clean across all Phase 4 files
+- [ ] Feature tracker updated with Phase 4 completion entry
+- [ ] PR opened targeting `dev` (never `main`)
+
+**Engineer status**: not started
+**Blockers**: TASK-075, TASK-076, TASK-077, TASK-078
+
+---
+
 ## DEPRIORITISED (pivot 2026-06-10)
 
 These sat on the old v3.x "Polish & Growth" board. The pivot moved them below the

--- a/devtrack_server/backend/daily_report_generator.py
+++ b/devtrack_server/backend/daily_report_generator.py
@@ -1651,13 +1651,161 @@ Be constructive and highlight patterns. Respond ONLY with valid JSON."""
         
         return sorted(reports, key=lambda x: x["date"], reverse=True)
     
+    # =========================================================================
+    # EOD NARRATIVE (Phase 4)
+    # =========================================================================
+
+    def generate_eod_narrative(self, target_date: Optional[str] = None) -> str:
+        """Generate an EOD report narrative by querying today's commits from the
+        triggers table, grouping by ticket_id, and producing a per-ticket
+        paragraph via the existing LLM provider chain.
+
+        The method applies inject_style(context_type="report") to each per-ticket
+        prompt before calling the LLM.  When the LLM is unavailable it falls back
+        to a plain-text bullet list of commit messages.  Unlinked commits (empty
+        or "unlinked" ticket_id) are collected under an "Other commits" section so
+        they are never silently dropped.  Returns "No commits recorded today."
+        when there are no commit rows for the day — never raises.
+
+        Args:
+            target_date: ISO date string YYYY-MM-DD (default: today in local time).
+
+        Returns:
+            A complete EOD report string.
+        """
+        try:
+            from datetime import date as _date
+            if target_date is None:
+                target_date = _date.today().isoformat()
+
+            rows = self._query_commit_rows(target_date)
+
+            if not rows:
+                return "No commits recorded today."
+
+            # Group by ticket_id.  Treat "" or "unlinked" as the unlinked bucket.
+            grouped: Dict[str, List[str]] = {}
+            unlinked: List[str] = []
+            for row in rows:
+                ticket_id = (row.get("ticket_id") or "").strip()
+                msg = row.get("commit_message") or row.get("message") or ""
+                if not ticket_id or ticket_id.lower() == "unlinked":
+                    unlinked.append(msg)
+                else:
+                    grouped.setdefault(ticket_id, []).append(msg)
+
+            sections: List[str] = []
+
+            # Per-ticket narrative sections
+            for ticket_id, messages in grouped.items():
+                narrative = self._generate_ticket_narrative(ticket_id, messages)
+                sections.append(f"## {ticket_id}\n\n{narrative}")
+
+            # Unlinked commits section
+            if unlinked:
+                bullet_list = "\n".join(f"- {m}" for m in unlinked if m)
+                sections.append(f"## Other commits\n\n{bullet_list}")
+
+            body = "\n\n".join(sections)
+            return f"EOD Report — {target_date}\n\n{body}"
+
+        except Exception as exc:  # Non-Negotiable #8: never raise
+            import logging as _logging
+            _logging.getLogger(__name__).warning(
+                "generate_eod_narrative failed, returning empty-day message: %s", exc
+            )
+            return "No commits recorded today."
+
+    def _query_commit_rows(self, target_date: str) -> List[Dict[str, Any]]:
+        """Query commit triggers from SQLite for *target_date*.
+
+        Returns a list of dicts with at least ``ticket_id`` and
+        ``commit_message`` keys.  Returns empty list on any error.
+        """
+        try:
+            conn = sqlite3.connect(self.db_path)
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT ticket_id,
+                       commit_message,
+                       commit_hash,
+                       timestamp
+                FROM triggers
+                WHERE trigger_type = 'commit'
+                  AND date(timestamp) = ?
+                ORDER BY timestamp ASC
+                """,
+                (target_date,),
+            )
+            rows = [dict(r) for r in cursor.fetchall()]
+            conn.close()
+            return rows
+        except Exception as exc:
+            import logging as _logging
+            _logging.getLogger(__name__).warning(
+                "_query_commit_rows failed for date=%s: %s", target_date, exc
+            )
+            return []
+
+    def _generate_ticket_narrative(self, ticket_id: str, messages: List[str]) -> str:
+        """Generate a 1–3 sentence narrative for *ticket_id* using the LLM.
+
+        Falls back to a bullet list of raw commit messages when the LLM is
+        unavailable or raises.  Never raises itself.
+        """
+        bullet_fallback = "\n".join(f"- {m}" for m in messages if m)
+
+        try:
+            provider = self._get_provider()
+            if provider is None:
+                return bullet_fallback
+
+            joined = "\n".join(f"- {m}" for m in messages if m)
+            prompt = (
+                f"Summarize what was accomplished on ticket {ticket_id} today "
+                f"based on these commit messages:\n{joined}\n\n"
+                "Write 1-3 sentences, first person, past tense. "
+                "Be concise and professional."
+            )
+
+            prompt = _inject_style(
+                prompt,
+                context_type="report",
+                query_text="\n".join(messages),
+            )
+
+            from backend.llm.base import LLMOptions
+            from backend.config import http_timeout, report_llm_temperature, report_llm_max_tokens
+
+            response = provider.generate(
+                prompt=prompt,
+                options=LLMOptions(
+                    temperature=report_llm_temperature(),
+                    max_tokens=report_llm_max_tokens(),
+                ),
+                timeout=http_timeout(),
+            )
+
+            if response and response.strip():
+                return response.strip()
+            return bullet_fallback
+
+        except Exception as exc:
+            import logging as _logging
+            _logging.getLogger(__name__).warning(
+                "_generate_ticket_narrative failed for ticket=%s: %s", ticket_id, exc
+            )
+            return bullet_fallback
+
     def get_productivity_trend(self, days: int = 7) -> Dict[str, Any]:
         """
         Calculate productivity trend over recent days.
-        
+
         Args:
             days: Number of days to analyze
-            
+
         Returns:
             Dictionary with trend data
         """

--- a/devtrack_server/backend/tests/test_eod_narrative.py
+++ b/devtrack_server/backend/tests/test_eod_narrative.py
@@ -1,0 +1,322 @@
+"""
+Tests for DailyReportGenerator.generate_eod_narrative() — TASK-076.
+
+Five test classes as specified by the task acceptance criteria:
+
+  1. LLM available (mocked provider) — returns multi-section string mentioning ticket IDs.
+  2. LLM unavailable — falls back to plain-text bullet list; no exception raised.
+  3. Empty commit history — returns "No commits recorded" string, never raises.
+  4. inject_style called with context_type="report" (mock/spy assertion).
+  5. Unlinked commits (ticket_id = "") — appear under "Other commits" section, not silently dropped.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure the project root is on sys.path so backend.* imports work.
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TODAY = date.today().isoformat()
+
+_LINKED_ROWS = [
+    {"ticket_id": "PROJ-1", "commit_message": "fix: resolve login bug", "commit_hash": "aaa", "timestamp": f"{TODAY} 09:00:00"},
+    {"ticket_id": "PROJ-1", "commit_message": "fix: add unit test for login", "commit_hash": "bbb", "timestamp": f"{TODAY} 10:00:00"},
+    {"ticket_id": "PROJ-2", "commit_message": "feat: add dashboard widget", "commit_hash": "ccc", "timestamp": f"{TODAY} 11:00:00"},
+]
+
+_UNLINKED_ROWS = [
+    {"ticket_id": "", "commit_message": "chore: update README", "commit_hash": "ddd", "timestamp": f"{TODAY} 12:00:00"},
+    {"ticket_id": "unlinked", "commit_message": "chore: bump version", "commit_hash": "eee", "timestamp": f"{TODAY} 13:00:00"},
+]
+
+_ALL_ROWS = _LINKED_ROWS + _UNLINKED_ROWS
+
+
+def _make_db_with_rows(rows: list[dict]) -> str:
+    """Create a temp SQLite DB populated with the given trigger rows.
+
+    Returns the path string so DailyReportGenerator can be pointed at it.
+    """
+    tf = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tf.close()
+    conn = sqlite3.connect(tf.name)
+    conn.execute(
+        """
+        CREATE TABLE triggers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            trigger_type TEXT NOT NULL,
+            ticket_id TEXT DEFAULT '',
+            commit_message TEXT DEFAULT '',
+            commit_hash TEXT DEFAULT '',
+            timestamp DATETIME DEFAULT (datetime('now'))
+        )
+        """
+    )
+    for r in rows:
+        conn.execute(
+            "INSERT INTO triggers (trigger_type, ticket_id, commit_message, commit_hash, timestamp) VALUES (?,?,?,?,?)",
+            ("commit", r.get("ticket_id", ""), r.get("commit_message", ""), r.get("commit_hash", ""), r.get("timestamp", TODAY)),
+        )
+    conn.commit()
+    conn.close()
+    return tf.name
+
+
+def _make_mock_provider(response: str) -> MagicMock:
+    provider = MagicMock()
+    provider.generate.return_value = response
+    return provider
+
+
+def _config_patches():
+    """Context managers that stub out backend.config calls used inside generate()."""
+    from contextlib import ExitStack
+    stack = ExitStack()
+    stack.enter_context(patch("backend.config.http_timeout", return_value=30))
+    stack.enter_context(patch("backend.config.report_llm_temperature", return_value=0.3))
+    stack.enter_context(patch("backend.config.report_llm_max_tokens", return_value=300))
+    return stack
+
+
+# ---------------------------------------------------------------------------
+# 1. LLM available — multi-section string with ticket IDs
+# ---------------------------------------------------------------------------
+
+class TestEODNarrativeLLMAvailable:
+    """When the LLM is reachable the report should contain per-ticket sections."""
+
+    def test_returns_string(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = _make_mock_provider("I fixed the login issue and resolved the bug.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert isinstance(result, str)
+        assert result.strip()
+
+    def test_contains_ticket_ids(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = _make_mock_provider("Completed work on the ticket.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert "PROJ-1" in result, f"Expected PROJ-1 in report; got:\n{result}"
+        assert "PROJ-2" in result, f"Expected PROJ-2 in report; got:\n{result}"
+
+    def test_header_contains_date(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = _make_mock_provider("Done.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert TODAY in result, f"Report header should contain target_date; got:\n{result}"
+
+    def test_llm_called_for_each_ticket(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = _make_mock_provider("Narrative paragraph.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            gen.generate_eod_narrative(target_date=TODAY)
+        # Two distinct ticket IDs → two LLM calls
+        assert mock_provider.generate.call_count == 2, (
+            f"Expected 2 LLM calls (one per ticket); got {mock_provider.generate.call_count}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. LLM unavailable — plain-text bullet fallback, no exception
+# ---------------------------------------------------------------------------
+
+class TestEODNarrativeLLMUnavailable:
+    """When the LLM raises the report should contain raw commit messages as bullets."""
+
+    def test_no_exception_propagates(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = MagicMock()
+        mock_provider.generate.side_effect = ConnectionError("Ollama unreachable")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            # Must not raise
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert isinstance(result, str)
+
+    def test_fallback_contains_commit_messages(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = MagicMock()
+        mock_provider.generate.side_effect = RuntimeError("model not loaded")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        # The fallback uses bullet lists of the raw commit messages
+        assert "fix: resolve login bug" in result or "fix: add unit test for login" in result, (
+            f"Fallback should contain raw commit messages; got:\n{result}"
+        )
+
+    def test_fallback_result_not_empty(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = MagicMock()
+        mock_provider.generate.side_effect = OSError("connection refused")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert result.strip(), "Fallback result must be a non-empty string"
+
+
+# ---------------------------------------------------------------------------
+# 3. Empty commit history — returns "No commits recorded", never raises
+# ---------------------------------------------------------------------------
+
+class TestEODNarrativeEmptyHistory:
+    """When there are no commits for today the method should return a safe message."""
+
+    def test_no_exception_on_empty_db(self):
+        db_path = _make_db_with_rows([])  # No rows at all
+        from backend.daily_report_generator import DailyReportGenerator
+        gen = DailyReportGenerator(db_path=db_path)
+        # Must not raise
+        result = gen.generate_eod_narrative(target_date=TODAY)
+        assert isinstance(result, str)
+
+    def test_returns_no_commits_message(self):
+        db_path = _make_db_with_rows([])
+        from backend.daily_report_generator import DailyReportGenerator
+        gen = DailyReportGenerator(db_path=db_path)
+        result = gen.generate_eod_narrative(target_date=TODAY)
+        assert "No commits recorded" in result, (
+            f"Expected 'No commits recorded' in empty-day result; got: {result!r}"
+        )
+
+    def test_no_commits_on_different_date(self):
+        """Rows exist but for a different date — should still return empty-day message."""
+        db_path = _make_db_with_rows([
+            {"ticket_id": "PROJ-1", "commit_message": "old commit", "commit_hash": "fff", "timestamp": "2020-01-01 09:00:00"},
+        ])
+        from backend.daily_report_generator import DailyReportGenerator
+        gen = DailyReportGenerator(db_path=db_path)
+        result = gen.generate_eod_narrative(target_date=TODAY)
+        assert "No commits recorded" in result
+
+
+# ---------------------------------------------------------------------------
+# 4. inject_style called with context_type="report"
+# ---------------------------------------------------------------------------
+
+class TestEODNarrativeInjectStyle:
+    """inject_style must be called with context_type='report' for each ticket section."""
+
+    def test_inject_style_called_with_report_context(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = _make_mock_provider("Done.")
+        with (
+            _config_patches(),
+            patch(
+                "backend.daily_report_generator._inject_style",
+                wraps=lambda p, context_type="general", query_text=None: p,
+            ) as mock_inject,
+        ):
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            gen.generate_eod_narrative(target_date=TODAY)
+
+        assert mock_inject.called, "_inject_style must have been called at least once"
+        # All calls should use context_type="report"
+        for call_args in mock_inject.call_args_list:
+            _, kwargs = call_args
+            assert kwargs.get("context_type") == "report", (
+                f"_inject_style must always be called with context_type='report'; "
+                f"got: {kwargs.get('context_type')!r}"
+            )
+
+    def test_inject_style_called_once_per_ticket(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = _make_mock_provider("Done.")
+        with (
+            _config_patches(),
+            patch(
+                "backend.daily_report_generator._inject_style",
+                wraps=lambda p, context_type="general", query_text=None: p,
+            ) as mock_inject,
+        ):
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            gen.generate_eod_narrative(target_date=TODAY)
+
+        # _LINKED_ROWS has 2 distinct ticket IDs → 2 inject_style calls
+        assert mock_inject.call_count == 2, (
+            f"Expected 2 inject_style calls (one per ticket); got {mock_inject.call_count}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Unlinked commits appear under "Other commits" section
+# ---------------------------------------------------------------------------
+
+class TestEODNarrativeUnlinkedCommits:
+    """Commits with empty or 'unlinked' ticket_id must appear under 'Other commits'."""
+
+    def test_other_commits_section_present(self):
+        db_path = _make_db_with_rows(_UNLINKED_ROWS)
+        mock_provider = _make_mock_provider("Done.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert "Other commits" in result, (
+            f"Expected 'Other commits' section for unlinked rows; got:\n{result}"
+        )
+
+    def test_unlinked_commits_not_silently_dropped(self):
+        db_path = _make_db_with_rows(_UNLINKED_ROWS)
+        mock_provider = _make_mock_provider("Done.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        # The actual commit messages from unlinked rows must be in the output
+        assert "update README" in result or "bump version" in result, (
+            f"Unlinked commit messages must appear in report; got:\n{result}"
+        )
+
+    def test_mixed_linked_and_unlinked(self):
+        db_path = _make_db_with_rows(_ALL_ROWS)
+        mock_provider = _make_mock_provider("Narrative for this ticket.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert "PROJ-1" in result
+        assert "PROJ-2" in result
+        assert "Other commits" in result
+
+    def test_unlinked_string_ticket_id_also_bucketed(self):
+        """The literal string 'unlinked' should go into Other commits, not its own section."""
+        db_path = _make_db_with_rows([
+            {"ticket_id": "unlinked", "commit_message": "chore: cleanup", "commit_hash": "ggg", "timestamp": f"{TODAY} 08:00:00"},
+        ])
+        from backend.daily_report_generator import DailyReportGenerator
+        gen = DailyReportGenerator(db_path=db_path)
+        result = gen.generate_eod_narrative(target_date=TODAY)
+        assert "Other commits" in result
+        # The section header should NOT be "## unlinked"
+        assert "## unlinked" not in result

--- a/devtrack_server/backend/webhook_server.py
+++ b/devtrack_server/backend/webhook_server.py
@@ -1846,11 +1846,11 @@ except Exception as _er_err:
     logger.warning(f"EmailReporter not available: {_er_err}")
 
 try:
-    from backend.work_tracker.eod_report_generator import EODReportGenerator as _EODGenerator
-    _eod_generator_available = True
-except Exception as _eod_err:
-    _eod_generator_available = False
-    logger.warning(f"EODReportGenerator not available: {_eod_err}")
+    from backend.daily_report_generator import DailyReportGenerator as _DailyReportGenerator
+    _daily_report_generator_available = True
+except Exception as _drg_err:
+    _daily_report_generator_available = False
+    logger.warning(f"DailyReportGenerator not available: {_drg_err}")
 
 
 @app.post("/reports/preview")
@@ -1931,28 +1931,24 @@ async def http_report_eod(
     request: Request,
     _auth: None = Depends(_verify_trigger_key),
 ) -> dict:
-    """Run the EOD report generator (used by the daemon scheduler)."""
-    if not _eod_generator_available:
-        raise HTTPException(status_code=503, detail="EODReportGenerator not available")
+    """Run the EOD report generator (Phase 4 — commit-grouped narrative).
+
+    Uses DailyReportGenerator.generate_eod_narrative() which queries the
+    triggers table, groups commits by ticket_id, generates per-ticket LLM
+    narratives in the developer's voice, and applies inject_style.
+    Falls back gracefully if the generator is unavailable.
+    """
     data = await request.json()
-    email = data.get("email") or None
     date_str = data.get("date") or None
     try:
-        gen = _EODGenerator()
-        report = await gen.generate(target_date=date_str)
-        total_h, total_m = divmod(report.total_minutes, 60)
-        lines = [
-            f"EOD Report — {report.date}",
-            f"Total: {total_h}h {total_m}m across {len(report.sessions)} session(s)",
-        ]
-        if report.narrative:
-            lines.append("")
-            lines.append(report.narrative)
-        output = "\n".join(lines)
-        return {"output": output, "success": True}
+        if not _daily_report_generator_available:
+            return {"output": "No commits recorded today.", "success": True, "narrative": "No commits recorded today."}
+        gen = _DailyReportGenerator()
+        narrative = await asyncio.to_thread(gen.generate_eod_narrative, date_str)
+        return {"output": narrative, "success": True, "narrative": narrative}
     except Exception as exc:
         logger.error(f"/reports/eod failed: {exc}")
-        return {"output": str(exc), "success": False}
+        return {"output": str(exc), "success": False, "narrative": ""}
 
 
 # ── Learning ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds \`DailyReportGenerator.generate_eod_narrative(target_date)\` to \`daily_report_generator.py\` — queries the \`triggers\` table for today's commits, groups by \`ticket_id\`, generates a per-ticket LLM narrative via the existing provider chain, applies \`inject_style(context_type=\"report\")\`, and assembles the full EOD report string
- Unlinked commits (empty or \`\"unlinked\"\` ticket_id) appear under an \"Other commits\" section — never silently dropped
- Falls back to plain-text bullet list of commit messages when LLM is unavailable — never raises
- Returns \`\"No commits recorded today.\"\` on empty commit history
- Updates \`/reports/eod\` endpoint in \`webhook_server.py\` to call \`generate_eod_narrative()\` instead of the old \`_EODGenerator\`
- Adds 16 new tests in \`backend/tests/test_eod_narrative.py\` covering all 5 acceptance criteria

## Test plan

- [x] \`uv run pytest backend/tests/test_eod_narrative.py -v\` — 16/16 passed
- [x] \`uv run pytest backend/tests/ -q\` — 680 passed, 1 pre-existing failure (\`test_ollama_host_returns_string\`), 0 regressions
- [x] No \`os.getenv\` introduced; all config via \`backend.config\` accessors
- [x] No hardcoded hosts/ports/timeouts in new code

Closes TASK-076 on project board.

Generated with Claude Code