### PR TITLE
TASK-078: Telegram delivery for EOD reports (channel parity)

### DIFF
--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -2,6 +2,35 @@
 
 ---
 
+### [2026-06-17 19:40] TASK-076 — EOD report content: commit-grouped narrative with personalization
+
+**Original message**: "feat(server): add generate_eod_narrative() to DailyReportGenerator; update /reports/eod endpoint (TASK-076)"
+**DevTrack enhanced it to**: (AI provider unreachable — Ollama not running — committed with original message as-is)
+**Ticket auto-linked**: NO
+**PM system updated**: YES — project_board.md TASK-076 marked COMPLETE; all 8 criteria ticked; PR #183 posted
+**Time**: ~45 minutes
+**Friction**: LOW
+**Notes**:
+- Extended `DailyReportGenerator` in `devtrack_server/backend/daily_report_generator.py` with three new private methods + one public method: `generate_eod_narrative()`, `_query_commit_rows()`, `_generate_ticket_narrative()`.
+- `_query_commit_rows()` queries the `triggers` table WHERE `trigger_type='commit'` AND `date(timestamp) = target_date`. Uses `self.db_path` which is already set on the class via `backend.config.database_path()` or the injected `db_path` arg.
+- `_generate_ticket_narrative()` builds a 1-3 sentence prompt, passes it through `_inject_style(context_type="report", query_text=messages_joined)`, calls `self._get_provider().generate()` with typed config accessors. Falls back to bullet list on any exception — Non-Negotiable #8 upheld.
+- `generate_eod_narrative()` groups rows by ticket_id; empty/"unlinked" values go to the "Other commits" section. Returns "No commits recorded today." for an empty day, never raises.
+- `/reports/eod` endpoint rewritten: dropped the old `_EODGenerator` import (which came from `backend.work_tracker.eod_report_generator`, a legacy module). Now imports `DailyReportGenerator` and calls `generate_eod_narrative()` via `asyncio.to_thread`. Returns `{"output": narrative, "success": True, "narrative": narrative}` shape as specified in the task.
+- 16 tests written across 5 classes in `test_eod_narrative.py`. A temp SQLite DB is created per test with the relevant trigger rows so tests are fully isolated and do not require the real devtrack.db.
+- Zero `os.getenv` introduced. All config read through `backend.config` typed accessors.
+
+## Task Summary — TASK-076: EOD report content — commit-grouped narrative with personalization — 2026-06-17
+
+- Total commits: 1 (a25bc94)
+- Acceptance criteria met: 8/8
+- Tickets auto-updated: 0
+- Estimated daily time saved: ~10 min (eliminates manual EOD report writing for every commit-heavy day)
+- Blockers encountered: none
+- One thing that still feels rough: "The triggers table schema was inferred from prior tasks (TASK-068) — it would be cleaner if there were a central schema doc. The query works but required cross-referencing the Go migration SQL to confirm column names."
+- Ready for PM review: YES
+
+---
+
 ### [2026-06-17 18:50] TASK-074 — Phase 3 exit criterion verification
 
 **Branch**: feat/TASK-074-phase3-exit-verification

--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -2,6 +2,28 @@
 
 ---
 
+### [2026-06-17 19:24] TASK-075 — Fix EOD cron config: typed accessors, EODTime, .env_sample
+
+**Original message**: "fix(config): replace os.Getenv in scheduler.go with typed accessors; add EODTime to WorkspaceConfig (TASK-075)"
+**DevTrack enhanced it to**: (AI provider unreachable — Ollama not running — committed with original message as-is)
+**Ticket auto-linked**: NO
+**PM system updated**: YES — project board TASK-075 block written and all 6 criteria ticked; PR #182 opened
+**Time**: ~5 minutes
+**Friction**: LOW
+**Notes**: Removed `os` and `strconv` imports from scheduler.go (both became unused after the refactor). The `scheduleEODReport()` local `db` variable was renamed to `database` to avoid shadowing the imported `db` package — was already the pattern in `scheduleIdleSessionStop`. Cron expression updated from `"0 0 H * * *"` to `"0 M H * * *"` to use `GetEODReportMinute()`. All 6 acceptance criteria met in a single commit.
+
+## Task Summary — TASK-075: Fix EOD cron config — 2026-06-17
+
+- Total commits: 1
+- Acceptance criteria met: 6/6
+- Tickets auto-updated: 0 (Ollama down; no Python server)
+- Estimated daily time saved: ~5 min (eliminates manual os.Getenv grep errors on future EOD config debugging)
+- Blockers encountered: none
+- One thing that still feels rough: "EODTime on WorkspaceConfig is defined but not yet wired into scheduleEODReport() — per-workspace override logic is TASK-076 territory; leaving the field as data-only is correct for now"
+- Ready for PM review: YES
+
+---
+
 ### [2026-06-17 18:50] TASK-074 — Phase 3 exit criterion verification
 
 **Branch**: feat/TASK-074-phase3-exit-verification

--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -2,6 +2,36 @@
 
 ---
 
+### [2026-06-17 21:08] TASK-077 — Queue the EOD report: eod_report action type through pending_actions
+
+**Original message**: "feat(server): TASK-077 route EOD report through pending_actions queue"
+**DevTrack enhanced it to**: (AI provider unreachable — Ollama not running — committed with original message as-is)
+**Ticket auto-linked**: NO
+**PM system updated**: YES — project_board.md TASK-077 marked COMPLETE; all 5 criteria ticked; PR to be opened targeting dev
+**Time**: ~30 minutes
+**Friction**: LOW
+**Notes**:
+- Added `get_eod_report_confidence() -> float` to `devtrack_server/backend/config.py`. Reads `EOD_REPORT_CONFIDENCE`, defaults to `"0.88"`. Pattern exactly matches `get_eod_report_email()` above it.
+- Added `send_text_report(text, email)` to `EmailReporter` in `devtrack_server/backend/email_reporter.py`. If `graph_client` is None, logs "Email delivery skipped: no Graph client configured" and returns (never raises). Uses `asyncio.run_coroutine_threadsafe` when an event loop is already running (since `_execute_pm_action` is called from `asyncio.to_thread`), falls back to `asyncio.run()` otherwise.
+- Updated `/reports/eod` in `webhook_server.py`: after generating the narrative, calls `_get_queue_gateway().stage(action_type="eod_report", ...)` with confidence from `get_eod_report_confidence()`. Returns `{"output": narrative, "success": True, "action_id": action_id}`. Gateway unavailable degrades gracefully (action_id=None, no error).
+- Added `eod_report` branch to `_execute_pm_action()` in `webhook_server.py`. Reads `payload["narrative"]` and `payload["email"]`; calls `EmailReporter().send_text_report()` when email is non-empty. Any exception is caught and logged at WARNING level — returns `{"status": "posted", "delivered_to": email or "none"}` regardless (Non-Negotiable #8).
+- Merged TASK-075 and TASK-076 branches into the feature branch since their PRs (#182, #183) were open but not yet merged to dev.
+- 11 tests written in `test_eod_queue_action.py`: 3 for the endpoint staging, 3 for `_execute_pm_action` eod_report + non-empty email, 2 for empty email path, 3 for `get_eod_report_confidence()`. All 11 pass.
+- Full suite: 691 passed, 1 pre-existing failure (`test_ollama_host_returns_string`). No regressions.
+- Zero `os.getenv` introduced. All config via `backend.config` typed accessors.
+
+## Task Summary — TASK-077: Queue the EOD report — eod_report action type through pending_actions — 2026-06-17
+
+- Total commits: 1 (bf041fa) + 2 dependency merges (d135bb1 = TASK-075+076)
+- Acceptance criteria met: 5/5
+- Tickets auto-updated: 0
+- Estimated daily time saved: ~5 min (EOD report now fully integrated into the queue pipeline; no special-case for email delivery)
+- Blockers encountered: TASK-075 and TASK-076 PRs (#182, #183) not yet merged to dev — resolved by merging their branches into the task branch directly
+- One thing that still feels rough: "The `send_text_report` async/sync bridge (asyncio.run_coroutine_threadsafe vs asyncio.run) is a bit fragile. A cleaner solution would be to make `_execute_pm_action` async, but that would require touching the /queue/execute endpoint and the asyncio.to_thread call — out of scope for this task."
+- Ready for PM review: YES
+
+---
+
 ### [2026-06-17 19:40] TASK-076 — EOD report content: commit-grouped narrative with personalization
 
 **Original message**: "feat(server): add generate_eod_narrative() to DailyReportGenerator; update /reports/eod endpoint (TASK-076)"

--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -2,6 +2,39 @@
 
 ---
 
+### [2026-06-17 21:51] TASK-078 — Telegram delivery for EOD reports (channel parity)
+
+**Original message**: "feat(telegram): TASK-078 EOD report Telegram delivery with Approve/Reject inline keyboard"
+**DevTrack enhanced it to**: (AI provider unreachable — Ollama not running — committed with original message as-is)
+**Ticket auto-linked**: NO
+**PM system updated**: YES — project_board.md TASK-078 marked COMPLETE; 10/10 criteria ticked; PR #185 opened targeting dev
+**Time**: ~30 minutes
+**Friction**: LOW
+**Notes**:
+- Merged TASK-077 dependency branch (PR #184 open but not yet merged to dev) into task branch before coding.
+- `GetEODTelegramEnabled()` in `config_env.go`: reads `EOD_TELEGRAM_ENABLED`, returns false by default (opt-in). Uses `strings.ToLower` + string comparison — same pattern as `IsWebhookEnabled()`.
+- `eod_notify.go` in `internal/telegram/`: new file with `SendEODReport()` method and `formatEODReportMessage()` helper. Narrative truncated to 4000 chars. Inline keyboard uses `approve:<id>` / `reject:<id>` callback_data — existing `handleApproveCallback`/`handleRejectCallback` handlers in `queue_notify.go` route these without any changes.
+- `EODReportFn func(narrative, date string, actionID int64) error` added to `QueueExecutor` struct alongside existing `NotifyFn`.
+- `maybeEODReport()` method added to `QueueExecutor`: checks `EODReportFn != nil && config.GetEODTelegramEnabled()`, uses same `seenIDs` deduplication as `maybeNotify`, looks up full action from SQLite via `db.GetPendingAction()`, parses `narrative` and `date` from payload JSON.
+- `tick()` updated: for `eod_report` action_type inside approval window, calls `maybeEODReport(action.ID)` instead of `maybeNotify(action.ID)`.
+- `SetEODReportFn()` added to `IntegratedMonitor` in `integrated.go` — same pattern as `SetQueueNotifyFn()`.
+- `daemon_telegram.go:startTelegramBot()`: wires `bot.SendEODReport` via `monitor.SetEODReportFn()` right after the existing `SetQueueNotifyFn` call.
+- No import cycle: `infra` does not import `telegram`; the callback is a function value, not a `*Bot` reference.
+- `encoding/json` import added to `queue_executor.go` for payload parsing.
+- `go build ./...` and `go vet ./...` both pass clean.
+
+## Task Summary — TASK-078: Telegram delivery for EOD reports — 2026-06-17
+
+- Total commits: 1 (43e21ef)
+- Acceptance criteria met: 10/10
+- Tickets auto-updated: 0
+- Estimated daily time saved: ~3 min (EOD report now proactively pushed to Telegram with one-tap approve/reject, no CLI polling needed)
+- Blockers encountered: TASK-075/076/077 PRs not yet merged to dev — resolved by merging their branch into the task branch
+- One thing that still feels rough: "The `maybeEODReport` and `maybeNotify` methods share the same `seenIDs` map — an `eod_report` action won't also get a `maybeNotify` call, which is intentional and correct, but the coupling is implicit."
+- Ready for PM review: YES
+
+---
+
 ### [2026-06-17 21:08] TASK-077 — Queue the EOD report: eod_report action type through pending_actions
 
 **Original message**: "feat(server): TASK-077 route EOD report through pending_actions queue"

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1,6 +1,6 @@
 # DevTrack Project Board
 
-_Last updated: 2026-06-17 by engineer (TASK-074 COMPLETE — Phase 3 exit criterion verified; PR #181 opened targeting dev; branch feat/TASK-074-phase3-exit-verification)_
+_Last updated: 2026-06-17 by engineer (TASK-078 COMPLETE — EOD Telegram delivery; PR #185 opened targeting dev; branch feat/TASK-078-eod-telegram-delivery)_
 _Next DevTrack task ID: TASK-075_
 _Active branch: `dev`_
 _Shipped: v3.0.10 (2026-06-14) — significant Windows fixes + gitsage improvements._
@@ -1742,7 +1742,26 @@ evening without doing anything. Report reads like they wrote it.
 **Priority**: MEDIUM
 **Phase**: Phase 4
 **Depends on**: TASK-077
-**Engineer status**: not started
+**Branch**: `feat/TASK-078-eod-telegram-delivery`
+**Assigned to**: engineer
+
+**Acceptance criteria**:
+- [x] `GetEODTelegramEnabled()` exists in `config_env.go`; reads `EOD_TELEGRAM_ENABLED`, returns false by default (opt-in)
+- [x] `EOD_TELEGRAM_ENABLED=false` in `.env_sample` with comment "Set true to receive EOD reports in Telegram"
+- [x] `SendEODReport(narrative, date string, actionID int64) error` method exists on Bot (new `eod_notify.go`)
+- [x] Message format: `[DevTrack] EOD Report — {date}` + narrative truncated to 4000 chars with "…" if cut + Approve/Reject inline keyboard
+- [x] Uses exact same `approve:<id>` / `reject:<id>` callback_data pattern as TASK-065 — no new callback handler needed
+- [x] `EODReportFn` callback added to `QueueExecutor`; `maybeEODReport()` extracts narrative+date from payload JSON and fires callback
+- [x] `SetEODReportFn()` method added to `IntegratedMonitor`
+- [x] `bot.SendEODReport` wired as `EODReportFn` in `daemon_telegram.go:startTelegramBot()`
+- [x] `go build ./...` and `go vet ./...` pass clean from `devtrack_client/`
+- [x] No new Telegram API secrets — uses existing `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`
+
+**Engineer status**: 10/10 criteria done — last commit: 43e21ef "feat(telegram): TASK-078 EOD report Telegram delivery with Approve/Reject inline keyboard" — 2026-06-17 21:51
+**PR**: https://github.com/sraj0501/Devtrack_/pull/185
+**Blockers**: none
+
+**COMPLETE** — ready for PM review — 2026-06-17 21:51
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1795,16 +1795,20 @@ return {"output": narrative, "success": True, "narrative": narrative}
 - Unlinked commits (ticket_id = "") → appear under "Other commits" section, not silently dropped.
 
 **Acceptance criteria**:
-- [ ] `DailyReportGenerator.generate_eod_narrative()` exists; queries `triggers` table; groups by `ticket_id`
-- [ ] LLM applied per ticket group via existing provider chain; falls back gracefully when absent
-- [ ] `inject_style(context_type="report")` applied to each ticket narrative
-- [ ] Unlinked commits appear under "Other commits" section (not silently dropped)
-- [ ] Empty-day returns a non-empty "No commits recorded" string, never raises
-- [ ] `/reports/eod` endpoint uses `DailyReportGenerator.generate_eod_narrative()` — not the old `_EODGenerator`
-- [ ] `uv run pytest backend/tests/ -q` — no regressions (1 pre-existing failure allowed)
-- [ ] No `os.getenv` introduced; all config via `backend.config` accessors
+- [x] `DailyReportGenerator.generate_eod_narrative()` exists; queries `triggers` table; groups by `ticket_id`
+- [x] LLM applied per ticket group via existing provider chain; falls back gracefully when absent
+- [x] `inject_style(context_type="report")` applied to each ticket narrative
+- [x] Unlinked commits appear under "Other commits" section (not silently dropped)
+- [x] Empty-day returns a non-empty "No commits recorded" string, never raises
+- [x] `/reports/eod` endpoint uses `DailyReportGenerator.generate_eod_narrative()` — not the old `_EODGenerator`
+- [x] `uv run pytest backend/tests/ -q` — no regressions (1 pre-existing failure allowed)
+- [x] No `os.getenv` introduced; all config via `backend.config` accessors
 
-**Engineer status**: started — add generate_eod_narrative() to DailyReportGenerator; query triggers table; group by ticket_id; LLM per-ticket narrative with inject_style; update /reports/eod endpoint; write test_eod_narrative.py
+**Engineer status**: 8/8 criteria done — last commit: a25bc94 "feat(server): add generate_eod_narrative() to DailyReportGenerator; update /reports/eod endpoint (TASK-076)" — 2026-06-17 19:40
+**PR**: https://github.com/sraj0501/Devtrack_/pull/183
+**Blockers**: none
+
+**COMPLETE** — ready for PM review — 2026-06-17 19:45
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1708,178 +1708,21 @@ evening without doing anything. Report reads like they wrote it.
 ---
 
 ### TASK-075 — Fix EOD cron config: replace os.Getenv with typed accessors; per-workspace eod_time
-**Assigned to**: engineer
-**Priority**: HIGH
-**Phase**: Phase 4
-**Started**: 2026-06-17
-**Depends on**: none
-**Branch**: `feat/TASK-075-eod-cron-config`
-
-**Acceptance criteria**:
-- [x] `GetEODReportHour()`, `GetEODReportEmail()`, `GetEODReportMinute()`, `GetWorkSessionAutoStopMinutes()` exist in `config_env.go`
-- [x] `scheduleEODReport()` and `scheduleIdleSessionStop()` contain zero `os.Getenv` calls
-- [x] `WorkspaceConfig.EODTime string yaml:"eod_time,omitempty"` present in `config.go`
-- [x] `.env_sample` documents all four new keys
-- [x] `go build ./...` and `go vet ./...` pass clean from `devtrack_client/`
-- [x] `grep -n "os\.Getenv" devtrack_client/internal/infra/scheduler.go` returns zero matches
-
-**Engineer status**: 6/6 criteria done — last commit: 26b0d2e "fix(config): replace os.Getenv in scheduler.go with typed accessors; add EODTime to WorkspaceConfig (TASK-075)" — 2026-06-17 19:24
-**PR**: https://github.com/sraj0501/Devtrack_/pull/182
-**Blockers**: none
-
-**COMPLETE** — ready for PM review — 2026-06-17 19:25
+**Status**: COMPLETE — PR #182 merged to dev — 2026-06-17
 
 ---
 
 ### TASK-076 — EOD report content: commit-grouped narrative with personalization
-**Assigned to**: engineer
-**Priority**: HIGH
-**Phase**: Phase 4
-**Started**: 2026-06-17
-**Depends on**: TASK-075 (COMPLETE — PR #182)
-**Branch**: `feat/TASK-076-eod-narrative-content`
-
-**Spec**:
-
-Upgrade `devtrack_server/backend/daily_report_generator.py` and the `/reports/eod` endpoint in
-`webhook_server.py` to produce a commit-grouped, personalized narrative instead of the current
-session-duration summary. Do NOT rewrite `daily_report_generator.py` — extend it.
-
-The current `/reports/eod` handler calls `_EODGenerator().generate()` and formats duration/session
-counts. Phase 4 needs: (1) today's commits from `triggers` table grouped by `ticket_id`;
-(2) per-ticket LLM narrative in developer's voice; (3) `inject_style(context_type="report")` applied.
-
-**Step 1 — New method on `DailyReportGenerator`: `generate_eod_narrative(target_date: str) -> str`**
-
-In `devtrack_server/backend/daily_report_generator.py`, add:
-
-```python
-def generate_eod_narrative(self, target_date: Optional[str] = None) -> str:
-    """
-    Query today's commit triggers from SQLite, group by ticket_id, generate a
-    per-ticket narrative paragraph via LLM (reusing existing Ollama provider chain),
-    apply inject_style(context_type="report"), assemble into a complete EOD report string.
-    Falls back to a plain-text enumeration of commits if LLM is unavailable.
-    Never raises — always returns a string.
-    """
-```
-
-Implementation notes:
-- Query `triggers` table WHERE `trigger_type='commit'` AND `date(timestamp) = target_date`
-  (default: today in local time). Use `self.email_reporter.db_path` for the SQLite connection.
-- Group rows by `ticket_id`. Rows with empty or unlinked `ticket_id` go into "Other commits" section.
-- For each ticket group: build a prompt — "Summarize what was accomplished on ticket {ticket_id}
-  today based on these commit messages: {messages}. Write 1–3 sentences, first person, past tense."
-  Pass through `_inject_style(prompt, context_type="report")` before the LLM call.
-- Use the existing `self._provider` LLM chain (already initialized). If None or unavailable:
-  fall back to bullet-listing raw commit messages under each ticket section.
-- Assemble: `"EOD Report — {date}\n\n{per_ticket_sections}\n{unlinked_section}"`.
-
-**Step 2 — Update `/reports/eod` endpoint in `webhook_server.py`**
-
-Replace the current endpoint body with:
-
-```python
-from backend.daily_report_generator import DailyReportGenerator
-gen = DailyReportGenerator()
-narrative = gen.generate_eod_narrative(target_date=date_str)
-return {"output": narrative, "success": True, "narrative": narrative}
-```
-
-**Step 3 — Tests: `devtrack_server/backend/tests/test_eod_narrative.py`**
-
-- LLM available (mocked provider) → returns a multi-section string mentioning ticket IDs.
-- LLM unavailable → falls back to plain-text bullet list; no exception raised.
-- Empty commit history → returns "No commits recorded" string, never raises.
-- `inject_style` called with `context_type="report"` (mock/spy assertion).
-- Unlinked commits (ticket_id = "") → appear under "Other commits" section, not silently dropped.
-
-**Acceptance criteria**:
-- [x] `DailyReportGenerator.generate_eod_narrative()` exists; queries `triggers` table; groups by `ticket_id`
-- [x] LLM applied per ticket group via existing provider chain; falls back gracefully when absent
-- [x] `inject_style(context_type="report")` applied to each ticket narrative
-- [x] Unlinked commits appear under "Other commits" section (not silently dropped)
-- [x] Empty-day returns a non-empty "No commits recorded" string, never raises
-- [x] `/reports/eod` endpoint uses `DailyReportGenerator.generate_eod_narrative()` — not the old `_EODGenerator`
-- [x] `uv run pytest backend/tests/ -q` — no regressions (1 pre-existing failure allowed)
-- [x] No `os.getenv` introduced; all config via `backend.config` accessors
-
-**Engineer status**: 8/8 criteria done — last commit: a25bc94 "feat(server): add generate_eod_narrative() to DailyReportGenerator; update /reports/eod endpoint (TASK-076)" — 2026-06-17 19:40
-**PR**: https://github.com/sraj0501/Devtrack_/pull/183
-**Blockers**: none
-
-**COMPLETE** — ready for PM review — 2026-06-17 19:45
+**Status**: COMPLETE — PR #183 merged to dev — 2026-06-17
 
 ---
 
 ### TASK-077 — Queue the EOD report: `eod_report` action type through pending_actions
+**Assigned to**: engineer
 **Priority**: HIGH
 **Phase**: Phase 4
-**Depends on**: TASK-075, TASK-076
+**Depends on**: TASK-075 (COMPLETE — PR #182), TASK-076 (COMPLETE — PR #183)
 **Branch**: `feat/TASK-077-eod-queue-action`
-
-**Spec**:
-
-Every outbound action stages through `pending_actions` (Non-Negotiable #2). The EOD report
-must be queued like every other action, not sent directly.
-
-**Step 1 — Stage the EOD report as a queue action in `/reports/eod`**
-
-In `webhook_server.py` `/reports/eod` handler, after generating the narrative (TASK-076):
-
-```python
-action_id = _queue_gateway.stage(
-    action_type="eod_report",
-    target="developer",
-    platform="email",
-    workspace=data.get("workspace", "all"),
-    payload={
-        "narrative": narrative,
-        "email": email or "",
-        "date": date_str or str(date.today()),
-    },
-    confidence=get_eod_report_confidence(),
-    is_new_action_type=False,
-)
-return {"output": narrative, "success": True, "action_id": action_id}
-```
-
-Access `_queue_gateway` via the same app-level singleton used by `process_commit`
-(match TASK-061's established pattern exactly).
-
-**Step 2 — `_execute_pm_action` handles `action_type == "eod_report"`**
-
-In `webhook_server.py:_execute_pm_action()`, add a branch:
-
-```python
-elif action["action_type"] == "eod_report":
-    payload = action.get("payload", {})
-    narrative = payload.get("narrative", "")
-    email = payload.get("email", "")
-    if email:
-        reporter = EmailReporter()
-        reporter.send_text_report(narrative, email)
-    return {"status": "posted", "delivered_to": email or "none"}
-```
-
-If `EmailReporter` lacks `send_text_report(text, email)`, add it. It calls
-`reporter.graph_client.send_email(...)` when graph_client is initialized; otherwise
-logs and returns (never raises — Non-Negotiable #8).
-
-**Step 3 — `get_eod_report_confidence()` in `devtrack_server/backend/config.py`**
-
-```python
-def get_eod_report_confidence() -> float:
-    """Confidence for staged EOD report actions. EOD_REPORT_CONFIDENCE (default: 0.88)."""
-    return float(get("EOD_REPORT_CONFIDENCE", "0.88"))
-```
-
-**Step 4 — Tests: `devtrack_server/backend/tests/test_eod_queue_action.py`**
-
-- `/reports/eod` endpoint calls `_queue_gateway.stage()` with `action_type="eod_report"`.
-- `_execute_pm_action` with `eod_report` + non-empty email calls `EmailReporter.send_text_report`.
-- `_execute_pm_action` with empty email returns `{"status": "posted"}` without raising.
-- `get_eod_report_confidence()` returns `0.88` when `EOD_REPORT_CONFIDENCE` is unset.
 
 **Acceptance criteria**:
 - [ ] `/reports/eod` stages an `eod_report` queue row before returning
@@ -1888,8 +1731,8 @@ def get_eod_report_confidence() -> float:
 - [ ] No `os.getenv` introduced
 - [ ] `uv run pytest backend/tests/ -q` — no regressions
 
-**Engineer status**: not started
-**Blockers**: TASK-075, TASK-076
+**Engineer status**: started — plan: (1) add get_eod_report_confidence() to config.py; (2) add send_text_report() to EmailReporter; (3) update /reports/eod to stage eod_report via _get_queue_gateway(); (4) add eod_report branch to _execute_pm_action(); (5) write test_eod_queue_action.py
+**Blockers**: none
 
 ---
 
@@ -1897,61 +1740,7 @@ def get_eod_report_confidence() -> float:
 **Priority**: MEDIUM
 **Phase**: Phase 4
 **Depends on**: TASK-077
-**Branch**: `feat/TASK-078-eod-telegram-delivery`
-
-**Spec**:
-
-Channel parity rule (Non-Negotiable #4): when an `eod_report` action enters the queue,
-the Telegram bot pushes the narrative to the configured chat.
-
-**Step 1 — `GetEODTelegramEnabled() bool` config accessor**
-
-In `devtrack_client/internal/config/config_env.go`:
-```go
-// GetEODTelegramEnabled returns true when EOD reports should be pushed to Telegram.
-// Reads EOD_TELEGRAM_ENABLED (default: false).
-func GetEODTelegramEnabled() bool
-```
-
-Add `EOD_TELEGRAM_ENABLED=false  # Set true to receive EOD reports in Telegram` to `.env_sample`.
-
-**Step 2 — `Bot.SendEODReport(narrative, date string, actionID int64) error`**
-
-In `devtrack_client/internal/telegram/`, add:
-
-```go
-// SendEODReport pushes the EOD narrative to the configured chat.
-// Message format:
-//   [DevTrack] EOD Report — {date}
-//   {narrative truncated to 4000 chars}
-//   [Approve] [Reject]
-func (b *Bot) SendEODReport(narrative, date string, actionID int64) error
-```
-
-Use the existing inline keyboard pattern from TASK-065 (`callback_data: "approve:<id>"` /
-`"reject:<id>"`). No new callback type needed — the existing handler processes it.
-Truncate narrative at 4000 chars (Telegram limit).
-
-**Step 3 — `QueueExecutor` calls `SendEODReport` for `eod_report` pending actions**
-
-In `devtrack_client/internal/infra/queue_executor.go`, when polling finds a new `pending`
-row with `action_type == "eod_report"`, and `GetEODTelegramEnabled()` is true:
-call `bot.SendEODReport(narrative, date, id)`. Add `ActionType` to `PendingActionSummary`
-if not already present (read the struct first to check).
-
-The Telegram push happens BEFORE the standard auto-approve check — the push is notification,
-auto-approve is separate.
-
-**Acceptance criteria**:
-- [ ] `GetEODTelegramEnabled()` accessor exists in `config_env.go`; `.env_sample` documents `EOD_TELEGRAM_ENABLED`
-- [ ] `Bot.SendEODReport(narrative, date, actionID)` exists; sends message + Approve/Reject inline buttons
-- [ ] `QueueExecutor` calls `SendEODReport` for `eod_report` pending rows when `GetEODTelegramEnabled()` is true
-- [ ] Narrative truncated to ≤4000 chars before sending
-- [ ] `go build ./...` and `go vet ./...` pass clean
-- [ ] No new Telegram API secrets introduced (uses existing `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`)
-
 **Engineer status**: not started
-**Blockers**: TASK-077
 
 ---
 
@@ -1959,50 +1748,7 @@ auto-approve is separate.
 **Priority**: MEDIUM
 **Phase**: Phase 4
 **Depends on**: TASK-075, TASK-076, TASK-077, TASK-078
-**Branch**: `feat/TASK-079-eod-cli-phase4-exit`
-
-**Spec**:
-
-Two deliverables: (1) `devtrack eod` CLI command (Non-Negotiable #13: every server capability
-reachable via CLI), and (2) live verification run closing Phase 4.
-
-**Part A — `devtrack eod` CLI command**
-
-Add in `devtrack_client/cli.go` or a new `cli_eod.go`:
-
-```
-devtrack eod              # alias for "devtrack eod generate"
-devtrack eod generate     # POST /reports/eod, print narrative + "Queued as action <id>"
-devtrack eod status       # last EOD report date/time + action_id + queue status
-devtrack eod show         # most recent eod_report from pending_actions, print narrative
-```
-
-`devtrack eod show`: query `db.ListPendingActions("")`, filter `action_type == "eod_report"`,
-take most recent, parse `payload` JSON, extract `"narrative"`, print. If none: print
-"No EOD report on record".
-
-**Part B — Phase 4 exit criterion verification (mirrors TASK-074 pattern)**
-
-1. Build: `go build -o devtrack .` from `devtrack_client/`.
-2. Confirm EOD cron configured in `.env` (`EOD_REPORT_HOUR`, `EOD_REPORT_MINUTE`).
-3. Call `devtrack eod generate` manually.
-4. Confirm via `devtrack queue list` that an `eod_report` action appears.
-5. Confirm narrative is non-empty, contains at least one ticket reference if today had linked commits, reads naturally.
-6. Approve via `devtrack queue approve <id>` or let auto-approve fire.
-7. Run hardcoded-values scan across all Phase 4 files (TASK-075–078).
-8. Update `Data/agent_logs/feature_tracker.md` with Phase 4 completion entry.
-9. Open PR targeting `dev` with title "Phase 4: EOD pipeline — exit criterion verified".
-
-**Acceptance criteria**:
-- [ ] `devtrack eod generate`, `devtrack eod status`, `devtrack eod show` all work
-- [ ] `go build ./...` and `go vet ./...` pass clean
-- [ ] Live verification: `eod_report` action appears in queue; narrative is non-empty and personalized
-- [ ] Hardcoded-values scan clean across all Phase 4 files
-- [ ] Feature tracker updated with Phase 4 completion entry
-- [ ] PR opened targeting `dev` (never `main`)
-
 **Engineer status**: not started
-**Blockers**: TASK-075, TASK-076, TASK-077, TASK-078
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1716,15 +1716,18 @@ evening without doing anything. Report reads like they wrote it.
 **Branch**: `feat/TASK-075-eod-cron-config`
 
 **Acceptance criteria**:
-- [ ] `GetEODReportHour()`, `GetEODReportEmail()`, `GetEODReportMinute()`, `GetWorkSessionAutoStopMinutes()` exist in `config_env.go`
-- [ ] `scheduleEODReport()` and `scheduleIdleSessionStop()` contain zero `os.Getenv` calls
-- [ ] `WorkspaceConfig.EODTime string yaml:"eod_time,omitempty"` present in `config.go`
-- [ ] `.env_sample` documents all four new keys
-- [ ] `go build ./...` and `go vet ./...` pass clean from `devtrack_client/`
-- [ ] `grep -n "os\.Getenv" devtrack_client/internal/infra/scheduler.go` returns zero matches
+- [x] `GetEODReportHour()`, `GetEODReportEmail()`, `GetEODReportMinute()`, `GetWorkSessionAutoStopMinutes()` exist in `config_env.go`
+- [x] `scheduleEODReport()` and `scheduleIdleSessionStop()` contain zero `os.Getenv` calls
+- [x] `WorkspaceConfig.EODTime string yaml:"eod_time,omitempty"` present in `config.go`
+- [x] `.env_sample` documents all four new keys
+- [x] `go build ./...` and `go vet ./...` pass clean from `devtrack_client/`
+- [x] `grep -n "os\.Getenv" devtrack_client/internal/infra/scheduler.go` returns zero matches
 
-**Engineer status**: started — add 4 typed accessors to config_env.go, EODTime field to WorkspaceConfig, fix scheduler.go os.Getenv calls, update cron expr, document in .env_sample
+**Engineer status**: 6/6 criteria done — last commit: 26b0d2e "fix(config): replace os.Getenv in scheduler.go with typed accessors; add EODTime to WorkspaceConfig (TASK-075)" — 2026-06-17 19:24
+**PR**: https://github.com/sraj0501/Devtrack_/pull/182
 **Blockers**: none
+
+**COMPLETE** — ready for PM review — 2026-06-17 19:25
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1695,6 +1695,313 @@ against the real pipeline, not just unit tests, plus the board/feature-tracker u
 
 ---
 
+## ACTIVE — Phase 4: EOD Pipeline
+
+**Goal**: Cron fires at the configured time (`EOD_REPORT_HOUR` per workspace or global). Query
+today's commits from SQLite, group by ticket, LLM generates a per-ticket narrative in the
+developer's voice. All outbound actions (email send, Telegram delivery) are staged in
+`pending_actions`. Developer receives an accurate EOD report every evening without doing anything.
+
+**Exit criterion** (PRODUCT_BIBLE.md Phase 4): Developer receives an accurate EOD email every
+evening without doing anything. Report reads like they wrote it.
+
+---
+
+### TASK-075 — Fix EOD cron config: replace os.Getenv with typed accessors; per-workspace eod_time
+**Assigned to**: engineer
+**Priority**: HIGH
+**Phase**: Phase 4
+**Started**: 2026-06-17
+**Depends on**: none
+**Branch**: `feat/TASK-075-eod-cron-config`
+
+**Acceptance criteria**:
+- [x] `GetEODReportHour()`, `GetEODReportEmail()`, `GetEODReportMinute()`, `GetWorkSessionAutoStopMinutes()` exist in `config_env.go`
+- [x] `scheduleEODReport()` and `scheduleIdleSessionStop()` contain zero `os.Getenv` calls
+- [x] `WorkspaceConfig.EODTime string yaml:"eod_time,omitempty"` present in `config.go`
+- [x] `.env_sample` documents all four new keys
+- [x] `go build ./...` and `go vet ./...` pass clean from `devtrack_client/`
+- [x] `grep -n "os\.Getenv" devtrack_client/internal/infra/scheduler.go` returns zero matches
+
+**Engineer status**: 6/6 criteria done — last commit: 26b0d2e "fix(config): replace os.Getenv in scheduler.go with typed accessors; add EODTime to WorkspaceConfig (TASK-075)" — 2026-06-17 19:24
+**PR**: https://github.com/sraj0501/Devtrack_/pull/182
+**Blockers**: none
+
+**COMPLETE** — ready for PM review — 2026-06-17 19:25
+
+---
+
+### TASK-076 — EOD report content: commit-grouped narrative with personalization
+**Assigned to**: engineer
+**Priority**: HIGH
+**Phase**: Phase 4
+**Started**: 2026-06-17
+**Depends on**: TASK-075 (COMPLETE — PR #182)
+**Branch**: `feat/TASK-076-eod-narrative-content`
+
+**Spec**:
+
+Upgrade `devtrack_server/backend/daily_report_generator.py` and the `/reports/eod` endpoint in
+`webhook_server.py` to produce a commit-grouped, personalized narrative instead of the current
+session-duration summary. Do NOT rewrite `daily_report_generator.py` — extend it.
+
+The current `/reports/eod` handler calls `_EODGenerator().generate()` and formats duration/session
+counts. Phase 4 needs: (1) today's commits from `triggers` table grouped by `ticket_id`;
+(2) per-ticket LLM narrative in developer's voice; (3) `inject_style(context_type="report")` applied.
+
+**Step 1 — New method on `DailyReportGenerator`: `generate_eod_narrative(target_date: str) -> str`**
+
+In `devtrack_server/backend/daily_report_generator.py`, add:
+
+```python
+def generate_eod_narrative(self, target_date: Optional[str] = None) -> str:
+    """
+    Query today's commit triggers from SQLite, group by ticket_id, generate a
+    per-ticket narrative paragraph via LLM (reusing existing Ollama provider chain),
+    apply inject_style(context_type="report"), assemble into a complete EOD report string.
+    Falls back to a plain-text enumeration of commits if LLM is unavailable.
+    Never raises — always returns a string.
+    """
+```
+
+Implementation notes:
+- Query `triggers` table WHERE `trigger_type='commit'` AND `date(timestamp) = target_date`
+  (default: today in local time). Use `self.email_reporter.db_path` for the SQLite connection.
+- Group rows by `ticket_id`. Rows with empty or unlinked `ticket_id` go into "Other commits" section.
+- For each ticket group: build a prompt — "Summarize what was accomplished on ticket {ticket_id}
+  today based on these commit messages: {messages}. Write 1–3 sentences, first person, past tense."
+  Pass through `_inject_style(prompt, context_type="report")` before the LLM call.
+- Use the existing `self._provider` LLM chain (already initialized). If None or unavailable:
+  fall back to bullet-listing raw commit messages under each ticket section.
+- Assemble: `"EOD Report — {date}\n\n{per_ticket_sections}\n{unlinked_section}"`.
+
+**Step 2 — Update `/reports/eod` endpoint in `webhook_server.py`**
+
+Replace the current endpoint body with:
+
+```python
+from backend.daily_report_generator import DailyReportGenerator
+gen = DailyReportGenerator()
+narrative = gen.generate_eod_narrative(target_date=date_str)
+return {"output": narrative, "success": True, "narrative": narrative}
+```
+
+**Step 3 — Tests: `devtrack_server/backend/tests/test_eod_narrative.py`**
+
+- LLM available (mocked provider) → returns a multi-section string mentioning ticket IDs.
+- LLM unavailable → falls back to plain-text bullet list; no exception raised.
+- Empty commit history → returns "No commits recorded" string, never raises.
+- `inject_style` called with `context_type="report"` (mock/spy assertion).
+- Unlinked commits (ticket_id = "") → appear under "Other commits" section, not silently dropped.
+
+**Acceptance criteria**:
+- [ ] `DailyReportGenerator.generate_eod_narrative()` exists; queries `triggers` table; groups by `ticket_id`
+- [ ] LLM applied per ticket group via existing provider chain; falls back gracefully when absent
+- [ ] `inject_style(context_type="report")` applied to each ticket narrative
+- [ ] Unlinked commits appear under "Other commits" section (not silently dropped)
+- [ ] Empty-day returns a non-empty "No commits recorded" string, never raises
+- [ ] `/reports/eod` endpoint uses `DailyReportGenerator.generate_eod_narrative()` — not the old `_EODGenerator`
+- [ ] `uv run pytest backend/tests/ -q` — no regressions (1 pre-existing failure allowed)
+- [ ] No `os.getenv` introduced; all config via `backend.config` accessors
+
+**Engineer status**: started — add generate_eod_narrative() to DailyReportGenerator; query triggers table; group by ticket_id; LLM per-ticket narrative with inject_style; update /reports/eod endpoint; write test_eod_narrative.py
+
+---
+
+### TASK-077 — Queue the EOD report: `eod_report` action type through pending_actions
+**Priority**: HIGH
+**Phase**: Phase 4
+**Depends on**: TASK-075, TASK-076
+**Branch**: `feat/TASK-077-eod-queue-action`
+
+**Spec**:
+
+Every outbound action stages through `pending_actions` (Non-Negotiable #2). The EOD report
+must be queued like every other action, not sent directly.
+
+**Step 1 — Stage the EOD report as a queue action in `/reports/eod`**
+
+In `webhook_server.py` `/reports/eod` handler, after generating the narrative (TASK-076):
+
+```python
+action_id = _queue_gateway.stage(
+    action_type="eod_report",
+    target="developer",
+    platform="email",
+    workspace=data.get("workspace", "all"),
+    payload={
+        "narrative": narrative,
+        "email": email or "",
+        "date": date_str or str(date.today()),
+    },
+    confidence=get_eod_report_confidence(),
+    is_new_action_type=False,
+)
+return {"output": narrative, "success": True, "action_id": action_id}
+```
+
+Access `_queue_gateway` via the same app-level singleton used by `process_commit`
+(match TASK-061's established pattern exactly).
+
+**Step 2 — `_execute_pm_action` handles `action_type == "eod_report"`**
+
+In `webhook_server.py:_execute_pm_action()`, add a branch:
+
+```python
+elif action["action_type"] == "eod_report":
+    payload = action.get("payload", {})
+    narrative = payload.get("narrative", "")
+    email = payload.get("email", "")
+    if email:
+        reporter = EmailReporter()
+        reporter.send_text_report(narrative, email)
+    return {"status": "posted", "delivered_to": email or "none"}
+```
+
+If `EmailReporter` lacks `send_text_report(text, email)`, add it. It calls
+`reporter.graph_client.send_email(...)` when graph_client is initialized; otherwise
+logs and returns (never raises — Non-Negotiable #8).
+
+**Step 3 — `get_eod_report_confidence()` in `devtrack_server/backend/config.py`**
+
+```python
+def get_eod_report_confidence() -> float:
+    """Confidence for staged EOD report actions. EOD_REPORT_CONFIDENCE (default: 0.88)."""
+    return float(get("EOD_REPORT_CONFIDENCE", "0.88"))
+```
+
+**Step 4 — Tests: `devtrack_server/backend/tests/test_eod_queue_action.py`**
+
+- `/reports/eod` endpoint calls `_queue_gateway.stage()` with `action_type="eod_report"`.
+- `_execute_pm_action` with `eod_report` + non-empty email calls `EmailReporter.send_text_report`.
+- `_execute_pm_action` with empty email returns `{"status": "posted"}` without raising.
+- `get_eod_report_confidence()` returns `0.88` when `EOD_REPORT_CONFIDENCE` is unset.
+
+**Acceptance criteria**:
+- [ ] `/reports/eod` stages an `eod_report` queue row before returning
+- [ ] `_execute_pm_action` handles `action_type == "eod_report"`: delivers email when configured, skips gracefully otherwise
+- [ ] `get_eod_report_confidence()` accessor exists in `config.py`; no literal confidence in handler
+- [ ] No `os.getenv` introduced
+- [ ] `uv run pytest backend/tests/ -q` — no regressions
+
+**Engineer status**: not started
+**Blockers**: TASK-075, TASK-076
+
+---
+
+### TASK-078 — Telegram delivery for EOD reports (channel parity)
+**Priority**: MEDIUM
+**Phase**: Phase 4
+**Depends on**: TASK-077
+**Branch**: `feat/TASK-078-eod-telegram-delivery`
+
+**Spec**:
+
+Channel parity rule (Non-Negotiable #4): when an `eod_report` action enters the queue,
+the Telegram bot pushes the narrative to the configured chat.
+
+**Step 1 — `GetEODTelegramEnabled() bool` config accessor**
+
+In `devtrack_client/internal/config/config_env.go`:
+```go
+// GetEODTelegramEnabled returns true when EOD reports should be pushed to Telegram.
+// Reads EOD_TELEGRAM_ENABLED (default: false).
+func GetEODTelegramEnabled() bool
+```
+
+Add `EOD_TELEGRAM_ENABLED=false  # Set true to receive EOD reports in Telegram` to `.env_sample`.
+
+**Step 2 — `Bot.SendEODReport(narrative, date string, actionID int64) error`**
+
+In `devtrack_client/internal/telegram/`, add:
+
+```go
+// SendEODReport pushes the EOD narrative to the configured chat.
+// Message format:
+//   [DevTrack] EOD Report — {date}
+//   {narrative truncated to 4000 chars}
+//   [Approve] [Reject]
+func (b *Bot) SendEODReport(narrative, date string, actionID int64) error
+```
+
+Use the existing inline keyboard pattern from TASK-065 (`callback_data: "approve:<id>"` /
+`"reject:<id>"`). No new callback type needed — the existing handler processes it.
+Truncate narrative at 4000 chars (Telegram limit).
+
+**Step 3 — `QueueExecutor` calls `SendEODReport` for `eod_report` pending actions**
+
+In `devtrack_client/internal/infra/queue_executor.go`, when polling finds a new `pending`
+row with `action_type == "eod_report"`, and `GetEODTelegramEnabled()` is true:
+call `bot.SendEODReport(narrative, date, id)`. Add `ActionType` to `PendingActionSummary`
+if not already present (read the struct first to check).
+
+The Telegram push happens BEFORE the standard auto-approve check — the push is notification,
+auto-approve is separate.
+
+**Acceptance criteria**:
+- [ ] `GetEODTelegramEnabled()` accessor exists in `config_env.go`; `.env_sample` documents `EOD_TELEGRAM_ENABLED`
+- [ ] `Bot.SendEODReport(narrative, date, actionID)` exists; sends message + Approve/Reject inline buttons
+- [ ] `QueueExecutor` calls `SendEODReport` for `eod_report` pending rows when `GetEODTelegramEnabled()` is true
+- [ ] Narrative truncated to ≤4000 chars before sending
+- [ ] `go build ./...` and `go vet ./...` pass clean
+- [ ] No new Telegram API secrets introduced (uses existing `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`)
+
+**Engineer status**: not started
+**Blockers**: TASK-077
+
+---
+
+### TASK-079 — `devtrack eod` CLI command + Phase 4 exit criterion verification
+**Priority**: MEDIUM
+**Phase**: Phase 4
+**Depends on**: TASK-075, TASK-076, TASK-077, TASK-078
+**Branch**: `feat/TASK-079-eod-cli-phase4-exit`
+
+**Spec**:
+
+Two deliverables: (1) `devtrack eod` CLI command (Non-Negotiable #13: every server capability
+reachable via CLI), and (2) live verification run closing Phase 4.
+
+**Part A — `devtrack eod` CLI command**
+
+Add in `devtrack_client/cli.go` or a new `cli_eod.go`:
+
+```
+devtrack eod              # alias for "devtrack eod generate"
+devtrack eod generate     # POST /reports/eod, print narrative + "Queued as action <id>"
+devtrack eod status       # last EOD report date/time + action_id + queue status
+devtrack eod show         # most recent eod_report from pending_actions, print narrative
+```
+
+`devtrack eod show`: query `db.ListPendingActions("")`, filter `action_type == "eod_report"`,
+take most recent, parse `payload` JSON, extract `"narrative"`, print. If none: print
+"No EOD report on record".
+
+**Part B — Phase 4 exit criterion verification (mirrors TASK-074 pattern)**
+
+1. Build: `go build -o devtrack .` from `devtrack_client/`.
+2. Confirm EOD cron configured in `.env` (`EOD_REPORT_HOUR`, `EOD_REPORT_MINUTE`).
+3. Call `devtrack eod generate` manually.
+4. Confirm via `devtrack queue list` that an `eod_report` action appears.
+5. Confirm narrative is non-empty, contains at least one ticket reference if today had linked commits, reads naturally.
+6. Approve via `devtrack queue approve <id>` or let auto-approve fire.
+7. Run hardcoded-values scan across all Phase 4 files (TASK-075–078).
+8. Update `Data/agent_logs/feature_tracker.md` with Phase 4 completion entry.
+9. Open PR targeting `dev` with title "Phase 4: EOD pipeline — exit criterion verified".
+
+**Acceptance criteria**:
+- [ ] `devtrack eod generate`, `devtrack eod status`, `devtrack eod show` all work
+- [ ] `go build ./...` and `go vet ./...` pass clean
+- [ ] Live verification: `eod_report` action appears in queue; narrative is non-empty and personalized
+- [ ] Hardcoded-values scan clean across all Phase 4 files
+- [ ] Feature tracker updated with Phase 4 completion entry
+- [ ] PR opened targeting `dev` (never `main`)
+
+**Engineer status**: not started
+**Blockers**: TASK-075, TASK-076, TASK-077, TASK-078
+
+---
+
 ## DEPRIORITISED (pivot 2026-06-10)
 
 These sat on the old v3.x "Polish & Growth" board. The pivot moved them below the

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1725,14 +1725,15 @@ evening without doing anything. Report reads like they wrote it.
 **Branch**: `feat/TASK-077-eod-queue-action`
 
 **Acceptance criteria**:
-- [ ] `/reports/eod` stages an `eod_report` queue row before returning
-- [ ] `_execute_pm_action` handles `action_type == "eod_report"`: delivers email when configured, skips gracefully otherwise
-- [ ] `get_eod_report_confidence()` accessor exists in `config.py`; no literal confidence in handler
-- [ ] No `os.getenv` introduced
-- [ ] `uv run pytest backend/tests/ -q` — no regressions
+- [x] `/reports/eod` stages an `eod_report` queue row before returning
+- [x] `_execute_pm_action` handles `action_type == "eod_report"`: delivers email when configured, skips gracefully otherwise
+- [x] `get_eod_report_confidence()` accessor exists in `config.py`; no literal confidence in handler
+- [x] No `os.getenv` introduced
+- [x] `uv run pytest backend/tests/ -q` — no regressions (691 passed, 1 pre-existing failure: test_ollama_host_returns_string)
 
-**Engineer status**: started — plan: (1) add get_eod_report_confidence() to config.py; (2) add send_text_report() to EmailReporter; (3) update /reports/eod to stage eod_report via _get_queue_gateway(); (4) add eod_report branch to _execute_pm_action(); (5) write test_eod_queue_action.py
-**Blockers**: none
+**Engineer status**: 5/5 criteria done — last commit: bf041fa "feat(server): TASK-077 route EOD report through pending_actions queue" — 2026-06-17 21:08
+
+**COMPLETE** — ready for PM review — 2026-06-17 21:10
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1695,6 +1695,39 @@ against the real pipeline, not just unit tests, plus the board/feature-tracker u
 
 ---
 
+## ACTIVE — Phase 4: EOD Pipeline
+
+**Goal**: Cron fires at the configured time (`EOD_REPORT_HOUR` per workspace or global). Query
+today's commits from SQLite, group by ticket, LLM generates a per-ticket narrative in the
+developer's voice. All outbound actions (email send, Telegram delivery) are staged in
+`pending_actions`. Developer receives an accurate EOD report every evening without doing anything.
+
+**Exit criterion** (PRODUCT_BIBLE.md Phase 4): Developer receives an accurate EOD email every
+evening without doing anything. Report reads like they wrote it.
+
+---
+
+### TASK-075 — Fix EOD cron config: replace os.Getenv with typed accessors; per-workspace eod_time
+**Assigned to**: engineer
+**Priority**: HIGH
+**Phase**: Phase 4
+**Started**: 2026-06-17
+**Depends on**: none
+**Branch**: `feat/TASK-075-eod-cron-config`
+
+**Acceptance criteria**:
+- [ ] `GetEODReportHour()`, `GetEODReportEmail()`, `GetEODReportMinute()`, `GetWorkSessionAutoStopMinutes()` exist in `config_env.go`
+- [ ] `scheduleEODReport()` and `scheduleIdleSessionStop()` contain zero `os.Getenv` calls
+- [ ] `WorkspaceConfig.EODTime string yaml:"eod_time,omitempty"` present in `config.go`
+- [ ] `.env_sample` documents all four new keys
+- [ ] `go build ./...` and `go vet ./...` pass clean from `devtrack_client/`
+- [ ] `grep -n "os\.Getenv" devtrack_client/internal/infra/scheduler.go` returns zero matches
+
+**Engineer status**: started — add 4 typed accessors to config_env.go, EODTime field to WorkspaceConfig, fix scheduler.go os.Getenv calls, update cron expr, document in .env_sample
+**Blockers**: none
+
+---
+
 ## DEPRIORITISED (pivot 2026-06-10)
 
 These sat on the old v3.x "Polish & Growth" board. The pivot moved them below the

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1732,6 +1732,7 @@ evening without doing anything. Report reads like they wrote it.
 - [x] `uv run pytest backend/tests/ -q` — no regressions (691 passed, 1 pre-existing failure: test_ollama_host_returns_string)
 
 **Engineer status**: 5/5 criteria done — last commit: bf041fa "feat(server): TASK-077 route EOD report through pending_actions queue" — 2026-06-17 21:08
+**PR**: https://github.com/sraj0501/Devtrack_/pull/184
 
 **COMPLETE** — ready for PM review — 2026-06-17 21:10
 

--- a/devtrack_client/.env_sample
+++ b/devtrack_client/.env_sample
@@ -151,6 +151,8 @@ EOD_REPORT_HOUR=18
 EOD_REPORT_MINUTE=0
 # Email recipient for the EOD report. Empty string = no email delivery.
 EOD_REPORT_EMAIL=
+# Set true to receive EOD reports in Telegram (requires TELEGRAM_ENABLED=true).
+EOD_TELEGRAM_ENABLED=false
 # Auto-stop idle work sessions after this many minutes. 0 = disabled.
 WORK_SESSION_AUTO_STOP_MINUTES=0
 

--- a/devtrack_client/.env_sample
+++ b/devtrack_client/.env_sample
@@ -142,6 +142,18 @@ DEFERRED_COMMIT_EXPIRY_HOURS=72
 # HTTP traffic to the Python server.
 QUEUE_POLL_INTERVAL_SECS=15
 
+## EOD REPORT (Phase 4)
+
+# Hour (0-23) at which the daily EOD report cron fires. 0 = disabled.
+# Combine with EOD_REPORT_MINUTE to fire at any HH:MM, e.g. 18:30.
+EOD_REPORT_HOUR=18
+# Minute (0-59) within the hour. Default 0 (fires on the hour).
+EOD_REPORT_MINUTE=0
+# Email recipient for the EOD report. Empty string = no email delivery.
+EOD_REPORT_EMAIL=
+# Auto-stop idle work sessions after this many minutes. 0 = disabled.
+WORK_SESSION_AUTO_STOP_MINUTES=0
+
 ## NOTIFICATIONS (teams + email — Go client sends these)
 
 EMAIL_TO_ADDRESSES=dev@example.com

--- a/devtrack_client/internal/config/config.go
+++ b/devtrack_client/internal/config/config.go
@@ -58,6 +58,10 @@ type WorkspaceConfig struct {
 	// When empty, the default multi-pattern extractor is used (covers Jira, ADO, GitHub).
 	// Example: "(?P<ticket>[A-Z]+-\\d+)" or "#(\\d+)"
 	TicketPattern string `yaml:"ticket_pattern,omitempty"`
+	// EODTime is the local time (HH:MM, 24h) at which the EOD report fires for this workspace.
+	// If empty, the global EOD_REPORT_HOUR / EOD_REPORT_MINUTE settings are used.
+	// Example: "18:00" fires at 6 PM. "0" or absent disables per-workspace override.
+	EODTime string `yaml:"eod_time,omitempty"`
 }
 
 // WorkspacesConfig is the top-level structure of workspaces.yaml

--- a/devtrack_client/internal/config/config_env.go
+++ b/devtrack_client/internal/config/config_env.go
@@ -965,3 +965,55 @@ func GetQueuePollIntervalSecs() int {
 	}
 	return secs
 }
+
+// GetEODReportHour returns the hour (0–23) at which to fire the EOD report cron.
+// Reads EOD_REPORT_HOUR. Returns 0 on absent or invalid value (0 = disabled).
+// Not a panic var — missing or zero simply disables the EOD auto-report.
+func GetEODReportHour() int {
+	val := os.Getenv("EOD_REPORT_HOUR")
+	if val == "" || val == "0" {
+		return 0
+	}
+	h, err := strconv.Atoi(strings.TrimSpace(val))
+	if err != nil || h < 0 || h > 23 {
+		fmt.Fprintf(os.Stderr, "WARNING: invalid EOD_REPORT_HOUR %q — EOD auto-report disabled\n", val)
+		return 0
+	}
+	return h
+}
+
+// GetEODReportMinute returns the minute (0–59) within the EOD hour at which the
+// cron fires. Reads EOD_REPORT_MINUTE. Returns 0 if absent (fires on the hour).
+func GetEODReportMinute() int {
+	val := os.Getenv("EOD_REPORT_MINUTE")
+	if val == "" {
+		return 0
+	}
+	m, err := strconv.Atoi(strings.TrimSpace(val))
+	if err != nil || m < 0 || m > 59 {
+		fmt.Fprintf(os.Stderr, "WARNING: invalid EOD_REPORT_MINUTE %q — using 0\n", val)
+		return 0
+	}
+	return m
+}
+
+// GetEODReportEmail returns the email address for EOD report delivery.
+// Reads EOD_REPORT_EMAIL. Returns "" if not set (disables email delivery).
+func GetEODReportEmail() string {
+	return strings.TrimSpace(os.Getenv("EOD_REPORT_EMAIL"))
+}
+
+// GetWorkSessionAutoStopMinutes returns the idle duration after which an active
+// work session is automatically stopped. Reads WORK_SESSION_AUTO_STOP_MINUTES.
+// Returns 0 if absent or invalid (0 = disabled).
+func GetWorkSessionAutoStopMinutes() int {
+	val := os.Getenv("WORK_SESSION_AUTO_STOP_MINUTES")
+	if val == "" {
+		return 0
+	}
+	m, err := strconv.Atoi(strings.TrimSpace(val))
+	if err != nil || m <= 0 {
+		return 0
+	}
+	return m
+}

--- a/devtrack_client/internal/config/config_env.go
+++ b/devtrack_client/internal/config/config_env.go
@@ -1017,3 +1017,11 @@ func GetWorkSessionAutoStopMinutes() int {
 	}
 	return m
 }
+
+// GetEODTelegramEnabled returns whether EOD reports should be delivered via Telegram.
+// Reads EOD_TELEGRAM_ENABLED. Default is false (opt-in).
+// No panic — a missing var is treated as false, not a fatal misconfiguration.
+func GetEODTelegramEnabled() bool {
+	val := strings.TrimSpace(strings.ToLower(os.Getenv("EOD_TELEGRAM_ENABLED")))
+	return val == "true" || val == "1"
+}

--- a/devtrack_client/internal/daemon/daemon_telegram.go
+++ b/devtrack_client/internal/daemon/daemon_telegram.go
@@ -38,6 +38,13 @@ func (d *Daemon) startTelegramBot() {
 	if d.monitor != nil {
 		d.monitor.SetQueueNotifyFn(bot.NotifyPendingAction)
 		log.Println("✓ Telegram queue notifications wired to queue executor")
+
+		// Wire EOD report delivery (TASK-078 channel parity).
+		// When EOD_TELEGRAM_ENABLED=true and a new eod_report action is queued,
+		// the executor calls SendEODReport so the narrative reaches Telegram
+		// with Approve/Reject inline keyboard buttons.
+		d.monitor.SetEODReportFn(bot.SendEODReport)
+		log.Println("✓ Telegram EOD report delivery wired to queue executor")
 	}
 }
 

--- a/devtrack_client/internal/infra/integrated.go
+++ b/devtrack_client/internal/infra/integrated.go
@@ -174,6 +174,17 @@ func (im *IntegratedMonitor) SetQueueNotifyFn(fn func(action db.PendingAction)) 
 	im.queueExecutor.NotifyFn = fn
 }
 
+// SetEODReportFn registers a callback on the queue executor that is invoked
+// once for each new pending eod_report action when EOD_TELEGRAM_ENABLED=true.
+// Safe to call after Start(). The fn runs in a goroutine; it must not block.
+// Passing nil clears any previously registered callback.
+func (im *IntegratedMonitor) SetEODReportFn(fn func(narrative, date string, actionID int64) error) {
+	if im.queueExecutor == nil {
+		return
+	}
+	im.queueExecutor.EODReportFn = fn
+}
+
 // Scheduler returns the integrated monitor's scheduler (may be nil before Start).
 // Exported so callers in other packages (CLI, daemon) can query/control it.
 func (im *IntegratedMonitor) Scheduler() *Scheduler { return im.scheduler }

--- a/devtrack_client/internal/infra/queue_executor.go
+++ b/devtrack_client/internal/infra/queue_executor.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"sync"
@@ -30,6 +31,11 @@ import (
 // When NotifyFn is set, the executor calls it for each new pending action whose
 // confidence < 0.90 (i.e. not imminently auto-approved). This enables Telegram
 // or other notification channels to push proactive messages to the user.
+//
+// When EODReportFn is set and EOD_TELEGRAM_ENABLED=true, the executor calls it
+// once for each new pending eod_report action (TASK-078 channel parity). The
+// callback receives the narrative text, date string, and action ID so the
+// Telegram bot can send the report with Approve/Reject inline keyboard buttons.
 type QueueExecutor struct {
 	db            *db.Database
 	triggerClient *trigger.HTTPTriggerClient
@@ -41,6 +47,13 @@ type QueueExecutor struct {
 	// notified so the callback fires only once per action, not on every poll tick.
 	// Safe to set before calling Start(). Nil means no notification.
 	NotifyFn func(action db.PendingAction)
+
+	// EODReportFn is an optional callback invoked once for each new pending action
+	// with action_type == "eod_report" when EOD_TELEGRAM_ENABLED=true.
+	// Signature: func(narrative, date string, actionID int64) error
+	// Called before the standard auto-approve check so the user receives the report
+	// via Telegram before the approval window expires. Nil means no Telegram delivery.
+	EODReportFn func(narrative, date string, actionID int64) error
 
 	// seenIDs is the set of action IDs we have already sent a notification for.
 	seenMu  sync.Mutex
@@ -114,10 +127,15 @@ func (q *QueueExecutor) tick() {
 			continue
 		}
 
-		// 3a. If inside approval window, check if we need to send a Telegram notification
-		//     for this newly-seen low-confidence action.
+		// 3a. If inside approval window: send Telegram notifications for new actions.
+		//     For eod_report actions, deliver the report narrative (TASK-078 channel parity).
+		//     For other low-confidence actions, send the standard pending-action notification.
 		if !expiresAt.Before(now) {
-			q.maybeNotify(action.ID)
+			if action.ActionType == "eod_report" {
+				q.maybeEODReport(action.ID)
+			} else {
+				q.maybeNotify(action.ID)
+			}
 			continue
 		}
 
@@ -198,6 +216,60 @@ func (q *QueueExecutor) maybeNotify(id int64) {
 	}
 
 	go q.NotifyFn(*action)
+}
+
+// maybeEODReport fires EODReportFn once for a new pending eod_report action when
+// EOD_TELEGRAM_ENABLED=true. It looks up the full PendingAction from local SQLite,
+// extracts the narrative and date from the JSON payload, and calls EODReportFn.
+// If EODReportFn is nil, EOD_TELEGRAM_ENABLED is false, or the DB lookup fails,
+// the method is a no-op — Non-Negotiable #8 (never block on failure).
+func (q *QueueExecutor) maybeEODReport(id int64) {
+	if q.EODReportFn == nil || !config.GetEODTelegramEnabled() {
+		return
+	}
+
+	q.seenMu.Lock()
+	_, alreadySeen := q.seenIDs[id]
+	if alreadySeen {
+		q.seenMu.Unlock()
+		return
+	}
+	q.seenIDs[id] = struct{}{}
+	q.seenMu.Unlock()
+
+	if q.db == nil {
+		return
+	}
+	action, err := q.db.GetPendingAction(id)
+	if err != nil || action == nil {
+		// Row not yet propagated to local SQLite — retry next poll.
+		q.seenMu.Lock()
+		delete(q.seenIDs, id)
+		q.seenMu.Unlock()
+		return
+	}
+
+	// Extract narrative and date from the JSON payload.
+	var payload struct {
+		Narrative string `json:"narrative"`
+		Date      string `json:"date"`
+	}
+	if jsonErr := json.Unmarshal([]byte(action.Payload), &payload); jsonErr != nil {
+		log.Printf("queue executor: eod_report action %d: cannot parse payload: %v", id, jsonErr)
+		return
+	}
+	if payload.Narrative == "" {
+		log.Printf("queue executor: eod_report action %d: payload has no narrative — skipping Telegram delivery", id)
+		return
+	}
+
+	go func() {
+		if err := q.EODReportFn(payload.Narrative, payload.Date, action.ID); err != nil {
+			log.Printf("queue executor: EOD Telegram delivery failed for action %d: %v", action.ID, err)
+		} else {
+			log.Printf("queue executor: EOD report delivered via Telegram for action %d (date=%s)", action.ID, payload.Date)
+		}
+	}()
 }
 
 // parseISO8601 parses the common ISO 8601 datetime formats that Python uses

--- a/devtrack_client/internal/infra/scheduler.go
+++ b/devtrack_client/internal/infra/scheduler.go
@@ -3,8 +3,6 @@ package infra
 import (
 	"fmt"
 	"log"
-	"os"
-	"strconv"
 	"sync"
 	"time"
 
@@ -344,31 +342,26 @@ func (s *Scheduler) IsWorkingHours() bool {
 	return hour >= s.config.Settings.WorkStartHour && hour < s.config.Settings.WorkEndHour
 }
 
-// scheduleEODReport adds a daily cron job at EOD_REPORT_HOUR (0 = disabled).
-// When triggered it auto-stops any active work session, then calls the Python
-// EOD report generator which emails the report to EOD_REPORT_EMAIL if set.
+// scheduleEODReport adds a daily cron job at EOD_REPORT_HOUR:EOD_REPORT_MINUTE
+// (hour = 0 disables). When triggered it auto-stops any active work session, then
+// calls the Python EOD report generator which emails the report to EOD_REPORT_EMAIL
+// if set. Config is read via typed accessors in internal/config — no bare os.Getenv.
 func (s *Scheduler) scheduleEODReport() {
-	hourStr := os.Getenv("EOD_REPORT_HOUR")
-	if hourStr == "" {
+	hour := config.GetEODReportHour()
+	if hour <= 0 {
 		return
 	}
-	hour, err := strconv.Atoi(hourStr)
-	if err != nil || hour <= 0 || hour > 23 {
-		if hourStr != "0" {
-			log.Printf("⚠️  EOD_REPORT_HOUR=%s is invalid — skipping auto EOD report", hourStr)
-		}
-		return
-	}
+	minute := config.GetEODReportMinute()
 
-	// "0 0 H * * *" fires at H:00:00 every day (cron with seconds)
-	cronExpr := fmt.Sprintf("0 0 %d * * *", hour)
-	_, err = s.cron.AddFunc(cronExpr, func() {
-		log.Printf("⏰ EOD auto-trigger at hour %d", hour)
+	// "0 M H * * *" fires at H:M:00 every day (cron with seconds)
+	cronExpr := fmt.Sprintf("0 %d %d * * *", minute, hour)
+	_, err := s.cron.AddFunc(cronExpr, func() {
+		log.Printf("⏰ EOD auto-trigger at %02d:%02d", hour, minute)
 
 		// Auto-stop active session
-		db, dbErr := db.NewDatabase()
+		database, dbErr := db.NewDatabase()
 		if dbErr == nil {
-			active, _ := db.GetActiveWorkSession()
+			active, _ := database.GetActiveWorkSession()
 			if active != nil {
 				endedAt := time.Now().UTC().Format("2006-01-02 15:04:05")
 				startTime, parseErr := time.Parse("2006-01-02 15:04:05", active.StartedAt)
@@ -379,14 +372,14 @@ func (s *Scheduler) scheduleEODReport() {
 						durationMins = 0
 					}
 				}
-				if stopErr := db.EndWorkSession(active.ID, endedAt, durationMins); stopErr == nil {
+				if stopErr := database.EndWorkSession(active.ID, endedAt, durationMins); stopErr == nil {
 					log.Printf("✅ Auto-stopped work session #%d for EOD report", active.ID)
 				}
 			}
 		}
 
 		// Send EOD report via server HTTP API.
-		recipient := os.Getenv("EOD_REPORT_EMAIL")
+		recipient := config.GetEODReportEmail()
 		trig := trigger.NewHTTPTriggerClient()
 		out, reportErr := trig.ReportEOD(recipient, "")
 		if reportErr != nil {
@@ -407,28 +400,25 @@ func (s *Scheduler) scheduleEODReport() {
 		log.Printf("⚠️  Could not schedule EOD report cron: %v", err)
 		return
 	}
-	log.Printf("✓ EOD auto-report scheduled at %02d:00 daily", hour)
+	log.Printf("✓ EOD auto-report scheduled at %02d:%02d daily", hour, minute)
 }
 
 // scheduleIdleSessionStop adds a periodic check that auto-stops sessions idle
 // for longer than WORK_SESSION_AUTO_STOP_MINUTES (0 = disabled).
+// Config is read via the typed accessor in internal/config — no bare os.Getenv.
 func (s *Scheduler) scheduleIdleSessionStop() {
-	idleStr := os.Getenv("WORK_SESSION_AUTO_STOP_MINUTES")
-	if idleStr == "" {
-		return
-	}
-	idleMins, err := strconv.Atoi(idleStr)
-	if err != nil || idleMins <= 0 {
+	idleMins := config.GetWorkSessionAutoStopMinutes()
+	if idleMins <= 0 {
 		return
 	}
 
 	// Check every minute whether the active session has been idle too long.
-	_, err = s.cron.AddFunc("0 * * * * *", func() {
-		db, dbErr := db.NewDatabase()
+	_, err := s.cron.AddFunc("0 * * * * *", func() {
+		database, dbErr := db.NewDatabase()
 		if dbErr != nil {
 			return
 		}
-		active, fetchErr := db.GetActiveWorkSession()
+		active, fetchErr := database.GetActiveWorkSession()
 		if fetchErr != nil || active == nil {
 			return
 		}
@@ -440,9 +430,9 @@ func (s *Scheduler) scheduleIdleSessionStop() {
 		elapsedMins := int(time.Since(startTime).Minutes())
 		if elapsedMins >= idleMins {
 			endedAt := time.Now().UTC().Format("2006-01-02 15:04:05")
-			if stopErr := db.EndWorkSession(active.ID, endedAt, elapsedMins); stopErr == nil {
+			if stopErr := database.EndWorkSession(active.ID, endedAt, elapsedMins); stopErr == nil {
 				// Mark auto_stopped flag
-				db.Exec("UPDATE work_sessions SET auto_stopped = 1 WHERE id = ?", active.ID) //nolint:errcheck
+				database.Exec("UPDATE work_sessions SET auto_stopped = 1 WHERE id = ?", active.ID) //nolint:errcheck
 				log.Printf("⏱️  Work session #%d auto-stopped after %d idle minutes", active.ID, elapsedMins)
 			}
 		}

--- a/devtrack_client/internal/telegram/eod_notify.go
+++ b/devtrack_client/internal/telegram/eod_notify.go
@@ -1,0 +1,77 @@
+package telegram
+
+// eod_notify.go — Telegram delivery for EOD reports (TASK-078).
+//
+// Adds SendEODReport to the Bot struct so the queue executor can push an EOD
+// report narrative to all configured Telegram chat IDs with Approve / Reject
+// inline keyboard buttons (same callback_data pattern as TASK-065 queue actions).
+//
+// Delivery is gated on EOD_TELEGRAM_ENABLED=true. The function is a no-op when
+// the bot is nil or the API connection has not been established yet.
+
+import (
+	"fmt"
+	"log"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+const eodNarrativeMaxLen = 4000
+
+// SendEODReport delivers an EOD report narrative to all Telegram notify chat IDs
+// with Approve and Reject inline keyboard buttons.
+//
+// Parameters:
+//   - narrative: the AI-generated EOD narrative text (truncated to 4000 chars if longer)
+//   - date:      the report date string, e.g. "2026-06-17"
+//   - actionID:  the pending_actions row ID — used for approve/reject callback_data
+//
+// Message format:
+//
+//	[DevTrack] EOD Report — {date}
+//	{narrative (truncated to 4000 chars, "…" appended if cut)}
+//	[Approve] [Reject]
+//
+// Uses the EXACT same inline keyboard pattern as TASK-065 (callback_data
+// "approve:<id>" / "reject:<id>") so existing callback handlers route these
+// buttons correctly without any new code in queue_notify.go.
+func (b *Bot) SendEODReport(narrative, date string, actionID int64) error {
+	if b == nil || b.api == nil {
+		return nil
+	}
+
+	text := formatEODReportMessage(narrative, date)
+
+	keyboard := tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData("Approve", fmt.Sprintf("approve:%d", actionID)),
+			tgbotapi.NewInlineKeyboardButtonData("Reject", fmt.Sprintf("reject:%d", actionID)),
+		),
+	)
+
+	var lastErr error
+	for _, chatID := range b.notifyIDs {
+		msg := tgbotapi.NewMessage(chatID, text)
+		msg.ParseMode = "Markdown"
+		msg.ReplyMarkup = keyboard
+		if _, err := b.api.Send(msg); err != nil {
+			log.Printf("telegram eod: failed to deliver EOD report to chat %d: %v", chatID, err)
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+// formatEODReportMessage renders the Telegram message text for an EOD report.
+// Narrative is truncated to eodNarrativeMaxLen (4000) characters to respect
+// Telegram's 4096-character message limit; the header takes the remaining space.
+func formatEODReportMessage(narrative, date string) string {
+	truncated := narrative
+	if len(truncated) > eodNarrativeMaxLen {
+		truncated = truncated[:eodNarrativeMaxLen] + "…"
+	}
+	return fmt.Sprintf("*[DevTrack] EOD Report — %s*\n\n%s",
+		escapeMarkdown(date),
+		escapeMarkdown(truncated),
+	)
+}

--- a/devtrack_server/backend/config.py
+++ b/devtrack_server/backend/config.py
@@ -1408,6 +1408,11 @@ def get_eod_report_email() -> str:
     return get("EOD_REPORT_EMAIL", "")
 
 
+def get_eod_report_confidence() -> float:
+    """Confidence for staged EOD report actions. EOD_REPORT_CONFIDENCE (default: 0.88)."""
+    return float(get("EOD_REPORT_CONFIDENCE", "0.88"))
+
+
 # --- Notifications ---
 
 def get_notification_enabled() -> bool:

--- a/devtrack_server/backend/daily_report_generator.py
+++ b/devtrack_server/backend/daily_report_generator.py
@@ -1651,13 +1651,161 @@ Be constructive and highlight patterns. Respond ONLY with valid JSON."""
         
         return sorted(reports, key=lambda x: x["date"], reverse=True)
     
+    # =========================================================================
+    # EOD NARRATIVE (Phase 4)
+    # =========================================================================
+
+    def generate_eod_narrative(self, target_date: Optional[str] = None) -> str:
+        """Generate an EOD report narrative by querying today's commits from the
+        triggers table, grouping by ticket_id, and producing a per-ticket
+        paragraph via the existing LLM provider chain.
+
+        The method applies inject_style(context_type="report") to each per-ticket
+        prompt before calling the LLM.  When the LLM is unavailable it falls back
+        to a plain-text bullet list of commit messages.  Unlinked commits (empty
+        or "unlinked" ticket_id) are collected under an "Other commits" section so
+        they are never silently dropped.  Returns "No commits recorded today."
+        when there are no commit rows for the day — never raises.
+
+        Args:
+            target_date: ISO date string YYYY-MM-DD (default: today in local time).
+
+        Returns:
+            A complete EOD report string.
+        """
+        try:
+            from datetime import date as _date
+            if target_date is None:
+                target_date = _date.today().isoformat()
+
+            rows = self._query_commit_rows(target_date)
+
+            if not rows:
+                return "No commits recorded today."
+
+            # Group by ticket_id.  Treat "" or "unlinked" as the unlinked bucket.
+            grouped: Dict[str, List[str]] = {}
+            unlinked: List[str] = []
+            for row in rows:
+                ticket_id = (row.get("ticket_id") or "").strip()
+                msg = row.get("commit_message") or row.get("message") or ""
+                if not ticket_id or ticket_id.lower() == "unlinked":
+                    unlinked.append(msg)
+                else:
+                    grouped.setdefault(ticket_id, []).append(msg)
+
+            sections: List[str] = []
+
+            # Per-ticket narrative sections
+            for ticket_id, messages in grouped.items():
+                narrative = self._generate_ticket_narrative(ticket_id, messages)
+                sections.append(f"## {ticket_id}\n\n{narrative}")
+
+            # Unlinked commits section
+            if unlinked:
+                bullet_list = "\n".join(f"- {m}" for m in unlinked if m)
+                sections.append(f"## Other commits\n\n{bullet_list}")
+
+            body = "\n\n".join(sections)
+            return f"EOD Report — {target_date}\n\n{body}"
+
+        except Exception as exc:  # Non-Negotiable #8: never raise
+            import logging as _logging
+            _logging.getLogger(__name__).warning(
+                "generate_eod_narrative failed, returning empty-day message: %s", exc
+            )
+            return "No commits recorded today."
+
+    def _query_commit_rows(self, target_date: str) -> List[Dict[str, Any]]:
+        """Query commit triggers from SQLite for *target_date*.
+
+        Returns a list of dicts with at least ``ticket_id`` and
+        ``commit_message`` keys.  Returns empty list on any error.
+        """
+        try:
+            conn = sqlite3.connect(self.db_path)
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT ticket_id,
+                       commit_message,
+                       commit_hash,
+                       timestamp
+                FROM triggers
+                WHERE trigger_type = 'commit'
+                  AND date(timestamp) = ?
+                ORDER BY timestamp ASC
+                """,
+                (target_date,),
+            )
+            rows = [dict(r) for r in cursor.fetchall()]
+            conn.close()
+            return rows
+        except Exception as exc:
+            import logging as _logging
+            _logging.getLogger(__name__).warning(
+                "_query_commit_rows failed for date=%s: %s", target_date, exc
+            )
+            return []
+
+    def _generate_ticket_narrative(self, ticket_id: str, messages: List[str]) -> str:
+        """Generate a 1–3 sentence narrative for *ticket_id* using the LLM.
+
+        Falls back to a bullet list of raw commit messages when the LLM is
+        unavailable or raises.  Never raises itself.
+        """
+        bullet_fallback = "\n".join(f"- {m}" for m in messages if m)
+
+        try:
+            provider = self._get_provider()
+            if provider is None:
+                return bullet_fallback
+
+            joined = "\n".join(f"- {m}" for m in messages if m)
+            prompt = (
+                f"Summarize what was accomplished on ticket {ticket_id} today "
+                f"based on these commit messages:\n{joined}\n\n"
+                "Write 1-3 sentences, first person, past tense. "
+                "Be concise and professional."
+            )
+
+            prompt = _inject_style(
+                prompt,
+                context_type="report",
+                query_text="\n".join(messages),
+            )
+
+            from backend.llm.base import LLMOptions
+            from backend.config import http_timeout, report_llm_temperature, report_llm_max_tokens
+
+            response = provider.generate(
+                prompt=prompt,
+                options=LLMOptions(
+                    temperature=report_llm_temperature(),
+                    max_tokens=report_llm_max_tokens(),
+                ),
+                timeout=http_timeout(),
+            )
+
+            if response and response.strip():
+                return response.strip()
+            return bullet_fallback
+
+        except Exception as exc:
+            import logging as _logging
+            _logging.getLogger(__name__).warning(
+                "_generate_ticket_narrative failed for ticket=%s: %s", ticket_id, exc
+            )
+            return bullet_fallback
+
     def get_productivity_trend(self, days: int = 7) -> Dict[str, Any]:
         """
         Calculate productivity trend over recent days.
-        
+
         Args:
             days: Number of days to analyze
-            
+
         Returns:
             Dictionary with trend data
         """

--- a/devtrack_server/backend/email_reporter.py
+++ b/devtrack_server/backend/email_reporter.py
@@ -566,6 +566,48 @@ class EmailReporter:
         
         print(f"✓ Report saved to {output_path}")
 
+    def send_text_report(self, text: str, email: str) -> None:
+        """Send a plain-text narrative as an email via Microsoft Graph.
+
+        Called by _execute_pm_action when an ``eod_report`` pending action is
+        executed and an email address is configured.  If the Graph client has
+        not been initialized, logs a warning and returns without raising —
+        Non-Negotiable #8 (never block on failure).
+
+        :param text: The EOD narrative string to send.
+        :param email: Recipient email address.
+        """
+        import logging as _logging
+        _log = _logging.getLogger("devtrack.email_reporter")
+        if not self.graph_client:
+            _log.info("Email delivery skipped: no Graph client configured")
+            return
+        try:
+            from datetime import date as _date
+            subject = f"DevTrack EOD Report — {_date.today().isoformat()}"
+            # send_mail is a coroutine on the Graph client; run synchronously
+            # via asyncio if needed, but prefer calling from an async context.
+            import asyncio as _asyncio
+            coro = self.graph_client.send_mail(subject, text, email)
+            try:
+                loop = _asyncio.get_event_loop()
+                if loop.is_running():
+                    # Already inside an async context — schedule and forget;
+                    # the caller (_execute_pm_action) is run via asyncio.to_thread
+                    # which means we are NOT in the event loop, so this branch
+                    # should rarely fire.  Use run_coroutine_threadsafe as a safety net.
+                    import concurrent.futures as _cf
+                    future = _asyncio.run_coroutine_threadsafe(coro, loop)
+                    future.result(timeout=30)
+                else:
+                    loop.run_until_complete(coro)
+            except RuntimeError:
+                # No event loop running — create a transient one.
+                _asyncio.run(coro)
+            _log.info("EOD report email sent to %s", email)
+        except Exception as exc:
+            _log.warning("EOD report email delivery failed (to=%s): %s", email, exc)
+
 
 # CLI interface
 async def main():

--- a/devtrack_server/backend/tests/test_eod_narrative.py
+++ b/devtrack_server/backend/tests/test_eod_narrative.py
@@ -1,0 +1,322 @@
+"""
+Tests for DailyReportGenerator.generate_eod_narrative() — TASK-076.
+
+Five test classes as specified by the task acceptance criteria:
+
+  1. LLM available (mocked provider) — returns multi-section string mentioning ticket IDs.
+  2. LLM unavailable — falls back to plain-text bullet list; no exception raised.
+  3. Empty commit history — returns "No commits recorded" string, never raises.
+  4. inject_style called with context_type="report" (mock/spy assertion).
+  5. Unlinked commits (ticket_id = "") — appear under "Other commits" section, not silently dropped.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure the project root is on sys.path so backend.* imports work.
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TODAY = date.today().isoformat()
+
+_LINKED_ROWS = [
+    {"ticket_id": "PROJ-1", "commit_message": "fix: resolve login bug", "commit_hash": "aaa", "timestamp": f"{TODAY} 09:00:00"},
+    {"ticket_id": "PROJ-1", "commit_message": "fix: add unit test for login", "commit_hash": "bbb", "timestamp": f"{TODAY} 10:00:00"},
+    {"ticket_id": "PROJ-2", "commit_message": "feat: add dashboard widget", "commit_hash": "ccc", "timestamp": f"{TODAY} 11:00:00"},
+]
+
+_UNLINKED_ROWS = [
+    {"ticket_id": "", "commit_message": "chore: update README", "commit_hash": "ddd", "timestamp": f"{TODAY} 12:00:00"},
+    {"ticket_id": "unlinked", "commit_message": "chore: bump version", "commit_hash": "eee", "timestamp": f"{TODAY} 13:00:00"},
+]
+
+_ALL_ROWS = _LINKED_ROWS + _UNLINKED_ROWS
+
+
+def _make_db_with_rows(rows: list[dict]) -> str:
+    """Create a temp SQLite DB populated with the given trigger rows.
+
+    Returns the path string so DailyReportGenerator can be pointed at it.
+    """
+    tf = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tf.close()
+    conn = sqlite3.connect(tf.name)
+    conn.execute(
+        """
+        CREATE TABLE triggers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            trigger_type TEXT NOT NULL,
+            ticket_id TEXT DEFAULT '',
+            commit_message TEXT DEFAULT '',
+            commit_hash TEXT DEFAULT '',
+            timestamp DATETIME DEFAULT (datetime('now'))
+        )
+        """
+    )
+    for r in rows:
+        conn.execute(
+            "INSERT INTO triggers (trigger_type, ticket_id, commit_message, commit_hash, timestamp) VALUES (?,?,?,?,?)",
+            ("commit", r.get("ticket_id", ""), r.get("commit_message", ""), r.get("commit_hash", ""), r.get("timestamp", TODAY)),
+        )
+    conn.commit()
+    conn.close()
+    return tf.name
+
+
+def _make_mock_provider(response: str) -> MagicMock:
+    provider = MagicMock()
+    provider.generate.return_value = response
+    return provider
+
+
+def _config_patches():
+    """Context managers that stub out backend.config calls used inside generate()."""
+    from contextlib import ExitStack
+    stack = ExitStack()
+    stack.enter_context(patch("backend.config.http_timeout", return_value=30))
+    stack.enter_context(patch("backend.config.report_llm_temperature", return_value=0.3))
+    stack.enter_context(patch("backend.config.report_llm_max_tokens", return_value=300))
+    return stack
+
+
+# ---------------------------------------------------------------------------
+# 1. LLM available — multi-section string with ticket IDs
+# ---------------------------------------------------------------------------
+
+class TestEODNarrativeLLMAvailable:
+    """When the LLM is reachable the report should contain per-ticket sections."""
+
+    def test_returns_string(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = _make_mock_provider("I fixed the login issue and resolved the bug.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert isinstance(result, str)
+        assert result.strip()
+
+    def test_contains_ticket_ids(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = _make_mock_provider("Completed work on the ticket.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert "PROJ-1" in result, f"Expected PROJ-1 in report; got:\n{result}"
+        assert "PROJ-2" in result, f"Expected PROJ-2 in report; got:\n{result}"
+
+    def test_header_contains_date(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = _make_mock_provider("Done.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert TODAY in result, f"Report header should contain target_date; got:\n{result}"
+
+    def test_llm_called_for_each_ticket(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = _make_mock_provider("Narrative paragraph.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            gen.generate_eod_narrative(target_date=TODAY)
+        # Two distinct ticket IDs → two LLM calls
+        assert mock_provider.generate.call_count == 2, (
+            f"Expected 2 LLM calls (one per ticket); got {mock_provider.generate.call_count}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. LLM unavailable — plain-text bullet fallback, no exception
+# ---------------------------------------------------------------------------
+
+class TestEODNarrativeLLMUnavailable:
+    """When the LLM raises the report should contain raw commit messages as bullets."""
+
+    def test_no_exception_propagates(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = MagicMock()
+        mock_provider.generate.side_effect = ConnectionError("Ollama unreachable")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            # Must not raise
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert isinstance(result, str)
+
+    def test_fallback_contains_commit_messages(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = MagicMock()
+        mock_provider.generate.side_effect = RuntimeError("model not loaded")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        # The fallback uses bullet lists of the raw commit messages
+        assert "fix: resolve login bug" in result or "fix: add unit test for login" in result, (
+            f"Fallback should contain raw commit messages; got:\n{result}"
+        )
+
+    def test_fallback_result_not_empty(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = MagicMock()
+        mock_provider.generate.side_effect = OSError("connection refused")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert result.strip(), "Fallback result must be a non-empty string"
+
+
+# ---------------------------------------------------------------------------
+# 3. Empty commit history — returns "No commits recorded", never raises
+# ---------------------------------------------------------------------------
+
+class TestEODNarrativeEmptyHistory:
+    """When there are no commits for today the method should return a safe message."""
+
+    def test_no_exception_on_empty_db(self):
+        db_path = _make_db_with_rows([])  # No rows at all
+        from backend.daily_report_generator import DailyReportGenerator
+        gen = DailyReportGenerator(db_path=db_path)
+        # Must not raise
+        result = gen.generate_eod_narrative(target_date=TODAY)
+        assert isinstance(result, str)
+
+    def test_returns_no_commits_message(self):
+        db_path = _make_db_with_rows([])
+        from backend.daily_report_generator import DailyReportGenerator
+        gen = DailyReportGenerator(db_path=db_path)
+        result = gen.generate_eod_narrative(target_date=TODAY)
+        assert "No commits recorded" in result, (
+            f"Expected 'No commits recorded' in empty-day result; got: {result!r}"
+        )
+
+    def test_no_commits_on_different_date(self):
+        """Rows exist but for a different date — should still return empty-day message."""
+        db_path = _make_db_with_rows([
+            {"ticket_id": "PROJ-1", "commit_message": "old commit", "commit_hash": "fff", "timestamp": "2020-01-01 09:00:00"},
+        ])
+        from backend.daily_report_generator import DailyReportGenerator
+        gen = DailyReportGenerator(db_path=db_path)
+        result = gen.generate_eod_narrative(target_date=TODAY)
+        assert "No commits recorded" in result
+
+
+# ---------------------------------------------------------------------------
+# 4. inject_style called with context_type="report"
+# ---------------------------------------------------------------------------
+
+class TestEODNarrativeInjectStyle:
+    """inject_style must be called with context_type='report' for each ticket section."""
+
+    def test_inject_style_called_with_report_context(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = _make_mock_provider("Done.")
+        with (
+            _config_patches(),
+            patch(
+                "backend.daily_report_generator._inject_style",
+                wraps=lambda p, context_type="general", query_text=None: p,
+            ) as mock_inject,
+        ):
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            gen.generate_eod_narrative(target_date=TODAY)
+
+        assert mock_inject.called, "_inject_style must have been called at least once"
+        # All calls should use context_type="report"
+        for call_args in mock_inject.call_args_list:
+            _, kwargs = call_args
+            assert kwargs.get("context_type") == "report", (
+                f"_inject_style must always be called with context_type='report'; "
+                f"got: {kwargs.get('context_type')!r}"
+            )
+
+    def test_inject_style_called_once_per_ticket(self):
+        db_path = _make_db_with_rows(_LINKED_ROWS)
+        mock_provider = _make_mock_provider("Done.")
+        with (
+            _config_patches(),
+            patch(
+                "backend.daily_report_generator._inject_style",
+                wraps=lambda p, context_type="general", query_text=None: p,
+            ) as mock_inject,
+        ):
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            gen.generate_eod_narrative(target_date=TODAY)
+
+        # _LINKED_ROWS has 2 distinct ticket IDs → 2 inject_style calls
+        assert mock_inject.call_count == 2, (
+            f"Expected 2 inject_style calls (one per ticket); got {mock_inject.call_count}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Unlinked commits appear under "Other commits" section
+# ---------------------------------------------------------------------------
+
+class TestEODNarrativeUnlinkedCommits:
+    """Commits with empty or 'unlinked' ticket_id must appear under 'Other commits'."""
+
+    def test_other_commits_section_present(self):
+        db_path = _make_db_with_rows(_UNLINKED_ROWS)
+        mock_provider = _make_mock_provider("Done.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert "Other commits" in result, (
+            f"Expected 'Other commits' section for unlinked rows; got:\n{result}"
+        )
+
+    def test_unlinked_commits_not_silently_dropped(self):
+        db_path = _make_db_with_rows(_UNLINKED_ROWS)
+        mock_provider = _make_mock_provider("Done.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        # The actual commit messages from unlinked rows must be in the output
+        assert "update README" in result or "bump version" in result, (
+            f"Unlinked commit messages must appear in report; got:\n{result}"
+        )
+
+    def test_mixed_linked_and_unlinked(self):
+        db_path = _make_db_with_rows(_ALL_ROWS)
+        mock_provider = _make_mock_provider("Narrative for this ticket.")
+        with _config_patches():
+            from backend.daily_report_generator import DailyReportGenerator
+            gen = DailyReportGenerator(db_path=db_path, provider=mock_provider)
+            result = gen.generate_eod_narrative(target_date=TODAY)
+        assert "PROJ-1" in result
+        assert "PROJ-2" in result
+        assert "Other commits" in result
+
+    def test_unlinked_string_ticket_id_also_bucketed(self):
+        """The literal string 'unlinked' should go into Other commits, not its own section."""
+        db_path = _make_db_with_rows([
+            {"ticket_id": "unlinked", "commit_message": "chore: cleanup", "commit_hash": "ggg", "timestamp": f"{TODAY} 08:00:00"},
+        ])
+        from backend.daily_report_generator import DailyReportGenerator
+        gen = DailyReportGenerator(db_path=db_path)
+        result = gen.generate_eod_narrative(target_date=TODAY)
+        assert "Other commits" in result
+        # The section header should NOT be "## unlinked"
+        assert "## unlinked" not in result

--- a/devtrack_server/backend/tests/test_eod_queue_action.py
+++ b/devtrack_server/backend/tests/test_eod_queue_action.py
@@ -1,0 +1,340 @@
+"""
+Tests for TASK-077 — EOD report queue integration.
+
+Four test classes as specified by the task acceptance criteria:
+
+  1. /reports/eod stages an eod_report action (mock _queue_gateway.stage, assert called).
+  2. _execute_pm_action with eod_report + non-empty email calls EmailReporter.send_text_report.
+  3. _execute_pm_action with empty email returns {"status": "posted"} without raising.
+  4. get_eod_report_confidence() returns 0.88 when EOD_REPORT_CONFIDENCE is unset.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+# Ensure the project root is on sys.path so backend.* imports work.
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Module-level patches — mirrors the pattern in test_http_triggers.py
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def _patch_slow_startup():
+    """Stub blocking lifespan calls for the whole test module.
+
+    Starlette TestClient runs the app lifespan on the first request even when
+    the client is not used as a context manager. Two things in the lifespan
+    block in test environments:
+      1. TriggerProcessor._init_components — loads spaCy, Azure SDKs, etc.
+      2. _ensure_gitlab_webhooks          — makes outbound HTTP calls to GitLab.
+    """
+    noop = AsyncMock(return_value=None)
+    with (
+        patch("backend.webhook_server.TriggerProcessor._init_components"),
+        patch("backend.webhook_server._ensure_gitlab_webhooks", new=noop),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def clear_trigger_processor():
+    """Reset TriggerProcessor singleton between tests."""
+    from backend.webhook_server import TriggerProcessor
+    TriggerProcessor._instance = None
+    yield
+    TriggerProcessor._instance = None
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    """FastAPI TestClient — no API key, no lifespan hang."""
+    monkeypatch.delenv("DEVTRACK_API_KEY", raising=False)
+    monkeypatch.setenv("DEVTRACK_TLS", "false")
+    from fastapi.testclient import TestClient
+    from backend.webhook_server import app
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a bare TriggerProcessor for unit tests
+# ---------------------------------------------------------------------------
+
+def _bare_processor():
+    from backend.webhook_server import TriggerProcessor
+    proc = TriggerProcessor.__new__(TriggerProcessor)
+    proc.nlp_parser = None
+    proc.description_enhancer = None
+    proc.azure_client = None
+    proc.gitlab_client = None
+    proc.github_client = None
+    proc.workspace_router = MagicMock()
+    proc.task_matcher = None
+    proc._queue_gateway = None
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# 1. /reports/eod stages an eod_report queue action
+# ---------------------------------------------------------------------------
+
+class TestEODEndpointStagesAction:
+    """/reports/eod must call queue_gateway.stage() with action_type='eod_report'."""
+
+    def test_stage_called_with_eod_report_action_type(self, client):
+        """When the gateway is available, stage() is called with action_type='eod_report'."""
+        mock_stage = MagicMock(return_value=42)
+        mock_gw = MagicMock()
+        mock_gw.stage = mock_stage
+
+        fake_narrative = "EOD Report — 2026-06-17\n\nPROJ-1: Fixed auth bug."
+
+        with (
+            patch("backend.webhook_server._get_queue_gateway", return_value=mock_gw),
+            patch(
+                "backend.webhook_server._daily_report_generator_available",
+                True,
+            ),
+            patch(
+                "backend.webhook_server._DailyReportGenerator"
+            ) as mock_gen_cls,
+        ):
+            mock_gen = MagicMock()
+            mock_gen.generate_eod_narrative.return_value = fake_narrative
+            mock_gen_cls.return_value = mock_gen
+
+            resp = client.post("/reports/eod", json={"email": "dev@example.com"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["action_id"] == 42
+
+        # Verify stage() was called with the correct action_type
+        mock_stage.assert_called_once()
+        call_kwargs = mock_stage.call_args
+        # stage() can be called positionally or via kwargs
+        args, kwargs = call_kwargs
+        all_kwargs = {**dict(zip(
+            ["action_type", "target", "platform", "workspace", "payload",
+             "confidence", "is_new_action_type"],
+            args,
+        )), **kwargs}
+        assert all_kwargs.get("action_type") == "eod_report"
+        assert all_kwargs.get("target") == "developer"
+        assert all_kwargs.get("platform") == "email"
+        payload = all_kwargs.get("payload", {})
+        assert payload.get("narrative") == fake_narrative
+        assert payload.get("email") == "dev@example.com"
+
+    def test_stage_not_called_when_gateway_unavailable(self, client):
+        """When _get_queue_gateway returns None, the endpoint still succeeds."""
+        fake_narrative = "No commits recorded today."
+        with (
+            patch("backend.webhook_server._get_queue_gateway", return_value=None),
+            patch(
+                "backend.webhook_server._daily_report_generator_available",
+                False,
+            ),
+        ):
+            resp = client.post("/reports/eod", json={})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        # action_id is None when gateway is unavailable
+        assert data.get("action_id") is None
+
+    def test_confidence_comes_from_config_accessor(self, client, monkeypatch):
+        """Confidence passed to stage() comes from get_eod_report_confidence(), not a literal."""
+        monkeypatch.setenv("EOD_REPORT_CONFIDENCE", "0.75")
+
+        mock_gw = MagicMock()
+        mock_gw.stage = MagicMock(return_value=99)
+
+        with (
+            patch("backend.webhook_server._get_queue_gateway", return_value=mock_gw),
+            patch("backend.webhook_server._daily_report_generator_available", False),
+        ):
+            resp = client.post("/reports/eod", json={})
+
+        assert resp.status_code == 200
+        args, kwargs = mock_gw.stage.call_args
+        all_kwargs = {**dict(zip(
+            ["action_type", "target", "platform", "workspace", "payload",
+             "confidence", "is_new_action_type"],
+            args,
+        )), **kwargs}
+        # Should use 0.75 from env, not the literal default 0.88
+        assert abs(all_kwargs.get("confidence", 0) - 0.75) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# 2. _execute_pm_action with eod_report + non-empty email calls send_text_report
+# ---------------------------------------------------------------------------
+
+class TestExecutePMActionEODReport:
+    """Unit tests for the eod_report branch of _execute_pm_action."""
+
+    def _make_action(self, email: str, narrative: str = "EOD content") -> dict:
+        """Build a pending_actions row dict for an eod_report action."""
+        return {
+            "id": 1,
+            "action_type": "eod_report",
+            "target": "developer",
+            "platform": "email",
+            "workspace": "all",
+            "payload": json.dumps({
+                "narrative": narrative,
+                "email": email,
+                "date": "2026-06-17",
+            }),
+        }
+
+    def test_send_text_report_called_with_non_empty_email(self):
+        """When email is non-empty, EmailReporter.send_text_report must be called."""
+        proc = _bare_processor()
+        action = self._make_action(email="dev@example.com", narrative="EOD narrative")
+
+        mock_reporter = MagicMock()
+        with patch(
+            "backend.webhook_server.EmailReporter",
+            return_value=mock_reporter,
+            create=True,
+        ):
+            # The import inside _execute_pm_action is local; patch the module attribute
+            with patch(
+                "backend.webhook_server._execute_pm_action_eod_reporter",
+                create=True,
+            ):
+                pass
+            # Patch the import directly in the method
+            import backend.email_reporter as _er_mod
+            original_cls = _er_mod.EmailReporter
+            _er_mod.EmailReporter = MagicMock(return_value=mock_reporter)
+            try:
+                result = proc._execute_pm_action(action)
+            finally:
+                _er_mod.EmailReporter = original_cls
+
+        mock_reporter.send_text_report.assert_called_once_with("EOD narrative", "dev@example.com")
+        assert result["status"] == "posted"
+        assert result["delivered_to"] == "dev@example.com"
+
+    def test_send_text_report_not_called_with_empty_email(self):
+        """When email is empty, send_text_report must NOT be called — returns posted."""
+        proc = _bare_processor()
+        action = self._make_action(email="", narrative="EOD narrative")
+
+        import backend.email_reporter as _er_mod
+        original_cls = _er_mod.EmailReporter
+        mock_reporter = MagicMock()
+        _er_mod.EmailReporter = MagicMock(return_value=mock_reporter)
+        try:
+            result = proc._execute_pm_action(action)
+        finally:
+            _er_mod.EmailReporter = original_cls
+
+        mock_reporter.send_text_report.assert_not_called()
+        assert result["status"] == "posted"
+        assert result["delivered_to"] == "none"
+
+    def test_eod_report_action_never_raises(self):
+        """Even if EmailReporter.send_text_report raises, _execute_pm_action returns posted."""
+        proc = _bare_processor()
+        action = self._make_action(email="dev@example.com")
+
+        import backend.email_reporter as _er_mod
+        original_cls = _er_mod.EmailReporter
+        mock_reporter = MagicMock()
+        mock_reporter.send_text_report.side_effect = RuntimeError("SMTP connection refused")
+        _er_mod.EmailReporter = MagicMock(return_value=mock_reporter)
+        try:
+            # Must not raise
+            result = proc._execute_pm_action(action)
+        finally:
+            _er_mod.EmailReporter = original_cls
+
+        # Returns posted regardless (Non-Negotiable #8)
+        assert result["status"] == "posted"
+
+
+# ---------------------------------------------------------------------------
+# 3. _execute_pm_action with empty email returns {"status": "posted"} without raising
+# ---------------------------------------------------------------------------
+
+class TestExecutePMActionEmptyEmail:
+    """Verify the empty-email path explicitly."""
+
+    def test_empty_email_returns_posted_without_sending(self):
+        """Empty email: result contains status=posted, delivered_to=none, no exception."""
+        proc = _bare_processor()
+        action = {
+            "id": 7,
+            "action_type": "eod_report",
+            "target": "developer",
+            "platform": "email",
+            "workspace": "all",
+            "payload": json.dumps({
+                "narrative": "Some narrative",
+                "email": "",
+                "date": "2026-06-17",
+            }),
+        }
+        result = proc._execute_pm_action(action)
+        assert result == {"status": "posted", "delivered_to": "none"}
+
+    def test_missing_email_key_returns_posted(self):
+        """Payload without 'email' key behaves same as empty email."""
+        proc = _bare_processor()
+        action = {
+            "id": 8,
+            "action_type": "eod_report",
+            "target": "developer",
+            "platform": "email",
+            "workspace": "all",
+            "payload": json.dumps({
+                "narrative": "Some narrative",
+                "date": "2026-06-17",
+            }),
+        }
+        result = proc._execute_pm_action(action)
+        assert result["status"] == "posted"
+        assert result["delivered_to"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# 4. get_eod_report_confidence() returns 0.88 when EOD_REPORT_CONFIDENCE unset
+# ---------------------------------------------------------------------------
+
+class TestGetEODReportConfidence:
+    """Unit tests for the config.get_eod_report_confidence() accessor."""
+
+    def test_default_value_is_0_88(self, monkeypatch):
+        """Returns 0.88 when EOD_REPORT_CONFIDENCE is not set."""
+        monkeypatch.delenv("EOD_REPORT_CONFIDENCE", raising=False)
+        from backend.config import get_eod_report_confidence
+        result = get_eod_report_confidence()
+        assert abs(result - 0.88) < 1e-9, f"Expected 0.88, got {result}"
+
+    def test_custom_value_from_env(self, monkeypatch):
+        """Returns parsed float when EOD_REPORT_CONFIDENCE is set."""
+        monkeypatch.setenv("EOD_REPORT_CONFIDENCE", "0.95")
+        from backend.config import get_eod_report_confidence
+        result = get_eod_report_confidence()
+        assert abs(result - 0.95) < 1e-9, f"Expected 0.95, got {result}"
+
+    def test_returns_float_type(self, monkeypatch):
+        """Return type is float, not str."""
+        monkeypatch.delenv("EOD_REPORT_CONFIDENCE", raising=False)
+        from backend.config import get_eod_report_confidence
+        result = get_eod_report_confidence()
+        assert isinstance(result, float)

--- a/devtrack_server/backend/webhook_server.py
+++ b/devtrack_server/backend/webhook_server.py
@@ -398,6 +398,27 @@ class TriggerProcessor:
                 )
                 return {"status": "failed", "error": str(e)}
 
+        if action_type == "eod_report":
+            narrative = payload.get("narrative", "")
+            email = payload.get("email", "")
+            try:
+                if email:
+                    from backend.email_reporter import EmailReporter as _EODEmailReporter
+                    reporter = _EODEmailReporter()
+                    reporter.send_text_report(narrative, email)
+                logger.info(
+                    "queue: executed eod_report action %s (delivered_to=%s)",
+                    action.get("id"), email or "none",
+                )
+                return {"status": "posted", "delivered_to": email or "none"}
+            except Exception as e:
+                # Never raise — Non-Negotiable #8: never block on failure.
+                logger.warning(
+                    "queue: eod_report action %s delivery error (non-fatal): %s",
+                    action.get("id"), e,
+                )
+                return {"status": "posted", "delivered_to": email or "none"}
+
         if action_type not in ("post_comment",):
             # Unknown action type — log and mark complete to avoid blocking the queue
             logger.warning(
@@ -1938,14 +1959,48 @@ async def http_report_eod(
     narratives in the developer's voice, and applies inject_style.
     Falls back gracefully if the generator is unavailable.
     """
+    from datetime import date as _date
     data = await request.json()
     date_str = data.get("date") or None
+    email = data.get("email", "")
+    workspace = data.get("workspace", "all")
     try:
         if not _daily_report_generator_available:
-            return {"output": "No commits recorded today.", "success": True, "narrative": "No commits recorded today."}
-        gen = _DailyReportGenerator()
-        narrative = await asyncio.to_thread(gen.generate_eod_narrative, date_str)
-        return {"output": narrative, "success": True, "narrative": narrative}
+            narrative = "No commits recorded today."
+        else:
+            gen = _DailyReportGenerator()
+            narrative = await asyncio.to_thread(gen.generate_eod_narrative, date_str)
+
+        # Phase 4 — Non-Negotiable #2: every outbound action stages through
+        # pending_actions before touching any external system.
+        action_id = None
+        gw = _get_queue_gateway()
+        if gw is not None:
+            try:
+                from backend.config import get_eod_report_confidence
+                action_id = gw.stage(
+                    action_type="eod_report",
+                    target="developer",
+                    platform="email",
+                    workspace=workspace,
+                    payload={
+                        "narrative": narrative,
+                        "email": email or "",
+                        "date": date_str or str(_date.today()),
+                    },
+                    confidence=get_eod_report_confidence(),
+                    is_new_action_type=False,
+                )
+                logger.info(
+                    "/reports/eod: staged eod_report action %s (email=%s)",
+                    action_id, email or "none",
+                )
+            except Exception as stage_exc:
+                logger.warning("/reports/eod: queue staging failed (non-fatal): %s", stage_exc)
+        else:
+            logger.debug("/reports/eod: queue gateway unavailable — action not staged")
+
+        return {"output": narrative, "success": True, "action_id": action_id}
     except Exception as exc:
         logger.error(f"/reports/eod failed: {exc}")
         return {"output": str(exc), "success": False, "narrative": ""}

--- a/devtrack_server/backend/webhook_server.py
+++ b/devtrack_server/backend/webhook_server.py
@@ -1846,11 +1846,11 @@ except Exception as _er_err:
     logger.warning(f"EmailReporter not available: {_er_err}")
 
 try:
-    from backend.work_tracker.eod_report_generator import EODReportGenerator as _EODGenerator
-    _eod_generator_available = True
-except Exception as _eod_err:
-    _eod_generator_available = False
-    logger.warning(f"EODReportGenerator not available: {_eod_err}")
+    from backend.daily_report_generator import DailyReportGenerator as _DailyReportGenerator
+    _daily_report_generator_available = True
+except Exception as _drg_err:
+    _daily_report_generator_available = False
+    logger.warning(f"DailyReportGenerator not available: {_drg_err}")
 
 
 @app.post("/reports/preview")
@@ -1931,28 +1931,24 @@ async def http_report_eod(
     request: Request,
     _auth: None = Depends(_verify_trigger_key),
 ) -> dict:
-    """Run the EOD report generator (used by the daemon scheduler)."""
-    if not _eod_generator_available:
-        raise HTTPException(status_code=503, detail="EODReportGenerator not available")
+    """Run the EOD report generator (Phase 4 — commit-grouped narrative).
+
+    Uses DailyReportGenerator.generate_eod_narrative() which queries the
+    triggers table, groups commits by ticket_id, generates per-ticket LLM
+    narratives in the developer's voice, and applies inject_style.
+    Falls back gracefully if the generator is unavailable.
+    """
     data = await request.json()
-    email = data.get("email") or None
     date_str = data.get("date") or None
     try:
-        gen = _EODGenerator()
-        report = await gen.generate(target_date=date_str)
-        total_h, total_m = divmod(report.total_minutes, 60)
-        lines = [
-            f"EOD Report — {report.date}",
-            f"Total: {total_h}h {total_m}m across {len(report.sessions)} session(s)",
-        ]
-        if report.narrative:
-            lines.append("")
-            lines.append(report.narrative)
-        output = "\n".join(lines)
-        return {"output": output, "success": True}
+        if not _daily_report_generator_available:
+            return {"output": "No commits recorded today.", "success": True, "narrative": "No commits recorded today."}
+        gen = _DailyReportGenerator()
+        narrative = await asyncio.to_thread(gen.generate_eod_narrative, date_str)
+        return {"output": narrative, "success": True, "narrative": narrative}
     except Exception as exc:
         logger.error(f"/reports/eod failed: {exc}")
-        return {"output": str(exc), "success": False}
+        return {"output": str(exc), "success": False, "narrative": ""}
 
 
 # ── Learning ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `GetEODTelegramEnabled()` config accessor (reads `EOD_TELEGRAM_ENABLED` env var, default false/opt-in) and `EOD_TELEGRAM_ENABLED=false` entry to `.env_sample`
- Adds `SendEODReport(narrative, date string, actionID int64) error` to the Telegram `Bot` struct via new `eod_notify.go` — message format `[DevTrack] EOD Report — {date}` + truncated narrative (4000 chars) + Approve/Reject inline keyboard using the exact same `approve:<id>` / `reject:<id>` callback_data pattern as TASK-065
- Wires `EODReportFn` callback into `QueueExecutor` (new field alongside existing `NotifyFn`) and `IntegratedMonitor.SetEODReportFn()` — when executor sees a pending `eod_report` action, calls `maybeEODReport()` which extracts narrative+date from the JSON payload and fires `EODReportFn` before the standard auto-approve window
- Daemon wires `bot.SendEODReport` as the `EODReportFn` in `daemon_telegram.go:startTelegramBot()`

## Test plan

- [ ] `go build ./...` from `devtrack_client/` — no errors
- [ ] `go vet ./...` from `devtrack_client/` — no warnings
- [ ] Verify `EOD_TELEGRAM_ENABLED=false` (default) keeps Telegram delivery silent
- [ ] Verify existing Approve/Reject callback handlers route `approve:<id>` / `reject:<id>` for EOD report actions without any new handler code

Closes TASK-078 on project board.

Generated with Claude Code