### PR TITLE
TASK-082: Tier 1 background sync of PR descriptions and issue comments

### DIFF
--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -2064,20 +2064,23 @@ Follow the exact same pattern used for the existing EOD cron job.
 - Single platform failure (mocked exception): other platforms still sync; exception not raised.
 
 **Acceptance criteria**:
-- [ ] `voice_sync.py` exists with `VoiceSync` class, `sync_pr_descriptions(workspace) -> int` and `sync_issue_comments(workspace) -> int`
-- [ ] Author filter enforced: only items matching `pm_username` are embedded — verified by unit test
-- [ ] Idempotent: second call with same item IDs returns 0 newly embedded
-- [ ] Single platform failure does not prevent other platforms from syncing
-- [ ] `POST /voice/sync` endpoint exists, auth-gated, returns per-platform counts
-- [ ] `GetVoiceSyncIntervalHours()` accessor in `config_env.go`; `VOICE_SYNC_INTERVAL_HOURS=24` in `.env_sample`
-- [ ] `get_voice_sync_interval_hours()` accessor in `config.py`; no `os.getenv` in `voice_sync.py`
-- [ ] Daemon scheduler fires `POST /voice/sync` on the configured interval (cron entry in `scheduler.go`)
-- [ ] `devtrack voice sync` CLI command exists, calls the endpoint, prints per-platform counts
-- [ ] Python tests pass (author filter, idempotency, per-platform failure isolation)
-- [ ] `go build ./...` and `go vet ./...` pass clean
+- [x] `voice_sync.py` exists with `VoiceSync` class, `sync_pr_descriptions(workspace) -> int` and `sync_issue_comments(workspace) -> int`
+- [x] Author filter enforced: only items matching `pm_username` are embedded — verified by unit test
+- [x] Idempotent: second call with same item IDs returns 0 newly embedded
+- [x] Single platform failure does not prevent other platforms from syncing
+- [x] `POST /voice/sync` endpoint exists, auth-gated, returns per-platform counts
+- [x] `GetVoiceSyncIntervalHours()` accessor in `config_env.go`; `VOICE_SYNC_INTERVAL_HOURS=24` in `.env_sample`
+- [x] `get_voice_sync_interval_hours()` accessor in `config.py`; no `os.getenv` in `voice_sync.py`
+- [x] Daemon scheduler fires `POST /voice/sync` on the configured interval (cron entry in `scheduler.go`)
+- [x] `devtrack voice sync` CLI command exists, calls the endpoint, prints per-platform counts
+- [x] Python tests pass (author filter, idempotency, per-platform failure isolation)
+- [x] `go build ./...` and `go vet ./...` pass clean
 
-**Engineer status**: started — creating voice_sync.py, POST /voice/sync endpoint, config accessors, scheduler cron, CLI command, and tests
+**Engineer status**: 11/11 criteria done — last commit: 825b1e7 "feat(voice): Implement background PR/comment synchronization" — 2026-06-18 12:00
+**PR**: https://github.com/sraj0501/Devtrack_/pull/190
 **Blockers**: none
+
+**COMPLETE** — ready for PM review — 2026-06-18 12:00
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `voice_sync.py` with `VoiceSync` class that polls GitHub, Azure DevOps, and GitLab for developer-authored PR descriptions and issue comments, embedding them into ChromaDB to enrich the voice corpus
- Adds `POST /voice/sync` endpoint (auth-gated) and `devtrack voice sync` CLI command for on-demand sync
- Adds daemon scheduler cron job firing `POST /voice/sync` on `VOICE_SYNC_INTERVAL_HOURS` interval with 60s startup delay

## Key implementation details

- Author filter enforced via `workspace.pm_username` — other authors' content is never embedded
- Idempotent: `voice_synced_items` SQLite table tracks platform/item_id/context_type tuples; duplicates return 0
- Per-platform failure isolation: GitHub failure does not block Azure or GitLab sync
- `context_type="description"` for PR bodies; `context_type="comment"` for issue comments
- `GetVoiceSyncIntervalHours()` Go accessor and `get_voice_sync_interval_hours()` Python accessor; no `os.getenv` in new files
- 10 new tests passing; 0 regressions (1 pre-existing `test_ollama_host_returns_string` failure unchanged)

## Test plan

- [x] `uv run pytest backend/tests/test_voice_sync.py -v` — 10/10 pass
- [x] `uv run pytest backend/tests/ -q` — 740 pass, 1 pre-existing failure
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] All acceptance criteria met (see project board TASK-082)

Closes TASK-082 on project board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)