### PR TITLE
TASK-087: Inference-to-generation injection — Signal 3 into inject_style()

### DIFF
--- a/.claude/memory/project_current_state.md
+++ b/.claude/memory/project_current_state.md
@@ -1,27 +1,21 @@
 ---
 name: Project current state
-description: Post-pivot (2026-06-10) — direction now PRODUCT_BIBLE.md Phase 0→8; Phase 0-2 complete, Phase 3 active; v3.0.10 shipped; platform quirks
+description: Phase 6 IN PROGRESS (TASK-087 active on feat/TASK-087-inference-injection); Phases 0–5 COMPLETE; v3.0.10; platform quirks
 type: project
 ---
 
-**Live phase/task status:** tracked in user auto-memory `project_current_state.md`, not here — check that file for current Phase/TASK-NNN status (this file covers build history and platform quirks, which change less often).
+**Version:** v3.0.10. Active branch: `feat/TASK-087-inference-injection` (from dev tip `b557b58`), all PRs through #193 merged. GitHub (`sraj0501/Devtrack_`) sole source. Releases: `.\scripts\release.ps1 [-Bump patch|minor|major]`.
 
-**Version:** v3.0.10 (latest tag). Active branch: `dev`. GitHub (`sraj0501/Devtrack_`) sole source. Releases: `.\scripts\release.ps1 [-Bump patch|minor|major]`.
+**Build arc (PRODUCT_BIBLE.md pivot 2026-06-10):** Phases 0–5 COMPLETE. Phase 6 (dialectic self-improvement) IN PROGRESS — TASK-085 + TASK-086 merged; TASK-087 (inference-to-generation injection) ACTIVE. Then Phases 7-8 (TUI-as-visibility, PR puppet master). See `Data/agent_logs/project_board.md`.
 
-**Migration COMPLETE (2026-06-10):** GitLab→GitHub migration achieved. The `migration` branch and the `gitlab-client` / `gitlab-server` / `gitlab-wiki` remotes are now vestigial — safe to remove. (Former "do NOT delete `migration`" protection lifted.)
+**Python test baseline:** 753 pass, 1 pre-existing failure (`test_ollama_host_returns_string`).
 
-**Layout:** `devtrack_client/` (Go + gitsage), `devtrack_server/` (Python, port 8089), `devtrack_wiki/` (Netlify → devtrack.cloud). Legacy: `devtrack-bin/` + root `backend/` (TASK-048, no new code).
+**Layout:** `devtrack_client/` (Go + gitsage), `devtrack_server/` (Python, port 8089), `devtrack_wiki/` (Netlify → devtrack.cloud). Legacy `devtrack-bin/` + root `backend/` retired (TASK-048).
 
-**Go internal packages** (`devtrack_client/internal/`): `config`, `db`, `health`, `learning`, `trigger`, `infra`, `daemon`, `tui`, `match`, `alerts`, `notify`, `telegram`. Layer: config/db/health/learning ← trigger ← infra ← daemon; trigger ← tui.
+**Go internal packages** (`devtrack_client/internal/`): `config`, `db`, `health`, `learning`, `trigger`, `infra`, `daemon`, `tui`, `alerts`, `notify`, `telegram`. Layer order: config/db/health/learning ← trigger ← infra ← daemon; trigger ← tui.
 
-**Recently shipped (v3.0 line):** `motor` optional dep; `upgrade.go` → GitHub API + semver guard; Telegram bot migrated to Go (`internal/telegram/`); boardroom + `devtrack plan` live; Windows CLI parity + autostart (Task Scheduler); automated GitHub Actions release pipeline; stale-health fix (migration 005 prunes legacy Redis/MongoDB rows); v3.0.9 `skip_issues` workspace field for dual-platform (GitHub+ADO) duplicate-ticket fix; v3.0.10 significant Windows fixes (isatty via mattn/go-isatty, editor-commit BeforeCommit/AfterCommit hooks, background auto-enhance via `DEVTRACK_AUTO_ENHANCE=true`).
-
-**Build arc — driven by PRODUCT_BIBLE.md (pivot 2026-06-10):** Phase 0 (silent daemon), Phase 1 (pending actions queue), Phase 2 (ticket extractor) COMPLETE. Phase 3 (silent commit handler) ACTIVE. Then Phase 4 EOD pipeline → Phases 5-8 voice training, dialectic self-improvement, TUI-as-visibility, PR-review puppet master. See `Data/agent_logs/project_board.md`.
-
-**DEPRIORITISED (post-pivot):** PG-5 (`stats_client.py` → `/internal/stats`), Redis R-1→R-6, CLI aesthetics/theming, savings counter, how-to videos, boardroom/plan as primary features. Not cancelled — below the phases.
-
-**Open decision:** gitsage AI commit enhancement is client-native (→Ollama), collides with "AI=server" rule — `docs/CAPABILITIES_OWNERSHIP.md`.
+**DEPRIORITISED (post-pivot):** PG-5, Redis R-1→R-6, CLI aesthetics, savings counter, videos, boardroom/plan as primary.
 
 **Platform quirks (non-obvious):**
-- Azure WIQL only accepts date-only precision (`2006-01-02`, not RFC3339) — `connectors/azure/list.go:ListWorkItemsChangedAfter`. Affects at minimum `process_intelligence` and `ei-rd-eff-deliverymetrics` projects.
-- Go notify constructors (`NewTelegramFromConfig`, `NewSlackFromConfig` in `internal/notify/`) must return `Notifier` interface, not concrete `*Telegram`/`*Slack` — returning concrete type causes nil pointer panic in alert poller when feature is disabled.
+- Azure WIQL only accepts date-only precision (`2006-01-02`, not RFC3339) — `connectors/azure/list.go:ListWorkItemsChangedAfter`.
+- Go notify constructors (`NewTelegramFromConfig`, `NewSlackFromConfig` in `internal/notify/`) must return `Notifier` interface, not concrete type — concrete type causes nil-panic in alert poller when feature is disabled.

--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -2,6 +2,35 @@
 
 ---
 
+### [2026-06-21 23:26] TASK-087 — Inference-to-generation injection: Signal 3 into inject_style()
+
+**Original message**: "feat(personalization): add Signal 3 inference injection into inject_style() (TASK-087)"
+**DevTrack enhanced it to**: (AI provider unreachable — Ollama offline; committed with original message as-is)
+**Ticket auto-linked**: NO
+**PM system updated**: YES — project_board.md TASK-087 marked COMPLETE; 8/8 criteria ticked; PR #194 URL posted
+**Time**: ~35 minutes
+**Friction**: LOW
+**Notes**:
+- Step 1 (`inference_retriever.py`): `InferenceRetriever.get_top_inferences()` calls `GET /dialectic/query` on Go daemon's internal HTTP API. Uses `urllib.request` (stdlib — no extra deps). All config via `backend.config.ipc_host()` and `backend.config.get_devtrack_control_port()`. Zero `os.getenv` calls. Graceful: catches all exceptions, returns `[]`.
+- Step 2 (Go `/dialectic/query`): Added `handleDialecticQuery` to `http_api.go`. Auth-gated by `DEVTRACK_API_KEY` env var (403 on mismatch when key is set; open when empty). Calls `SearchInferences(q, limit)` when `q` is non-empty, else `ListInferencesByConfidence(contextType, limit)`. Also added `ListInferencesByConfidence` to `inferences.go` — orders by confidence DESC, optionally filters by context_type.
+- Step 3 (`personalization.py` Signal 3): Added lazy singleton `_get_inference_retriever()` matching the same pattern as `_load_personalized_ai`. Signal 3 injected after Signal 2 (RAG) — appended to `augmented` string. Low-confidence inferences (< `INFERENCE_MIN_CONFIDENCE=0.4`) excluded. Fully graceful: wrapped in `try/except Exception: pass`.
+- Step 4 (tests): 11 new tests in `test_inference_injection.py` — all 11 pass. Covers injection present, graceful degradation (exception), None retriever, confidence gate, mixed confidence, HTTP response parsing, network error, malformed JSON, sorted order, and os.getenv scan.
+- `go build ./...` and `go vet ./...` both clean from `devtrack_client/`.
+- Full suite: 764 pass (was 753 + 11 new), 1 pre-existing failure (`test_ollama_host_returns_string`) — no regressions.
+- Added `get_devtrack_control_port()` to `backend/config.py` so `inference_retriever.py` can read `DEVTRACK_SERVER_HTTP_PORT` without `os.getenv`. Pattern: `get_int("DEVTRACK_SERVER_HTTP_PORT", 35894)`.
+
+## Task Summary — TASK-087: Inference-to-generation injection — 2026-06-21
+
+- Total commits: 1 (7e61734)
+- Acceptance criteria met: 8/8
+- Tickets auto-updated: 0
+- Estimated daily time saved: ~2 min/day (inject_style enriched with inferences automatically; all prompts get smarter context without developer action)
+- Blockers encountered: none
+- One thing that still feels rough: "The inference_retriever uses urllib with a 1s timeout but if the Go daemon is in the middle of a restart during a commit trigger, that 1s wait adds up across all inject_style() calls — acceptable for now, could be made async later."
+- Ready for PM review: YES
+
+---
+
 ### [2026-06-18 21:10] TASK-086 — Hermes 3 reasoning loop (all parts)
 
 **Original message**: "feat(dialectic): TASK-086 add Hermes 3 reasoning loop — Python module, endpoint, Go client, tests"

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -2816,12 +2816,12 @@ Run `uv run pytest backend/tests/ -q` — no regressions beyond documented basel
 - [x] Python tests pass: injection present, graceful degradation, confidence gate
 - [x] `uv run pytest backend/tests/ -q` — no regressions (764 pass, 1 pre-existing failure)
 
-**Engineer status**: 8/8 criteria done — last commit: 7e61734 "feat(personalization): add Signal 3 inference injection into inject_style() (TASK-087)" — 2026-06-21 23:26
+**Engineer status**: 8/8 criteria done — last commit: 0441d34 "chore(board): TASK-087 COMPLETE" — 2026-06-21
 **Started**: 2026-06-21
 **Blockers**: none (TASK-086 merged at PR #193)
-**PR**: https://github.com/sraj0501/Devtrack_/pull/194
+**PR**: https://github.com/sraj0501/Devtrack_/pull/195
 
-**COMPLETE** — ready for PM review — 2026-06-21 23:26
+**COMPLETE** — ready for PM review — 2026-06-21
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -2804,21 +2804,24 @@ If `InferenceRetriever` cannot reach the Go daemon, `get_top_inferences` returns
 Run `uv run pytest backend/tests/ -q` — no regressions beyond documented baseline.
 
 **Acceptance criteria**:
-- [ ] `inference_retriever.py` exists with `InferenceRetriever.get_top_inferences()`; returns
+- [x] `inference_retriever.py` exists with `InferenceRetriever.get_top_inferences()`; returns
       `[]` on failure, never raises
-- [ ] `GET /dialectic/query` endpoint exists in Go daemon's internal API; auth-gated; calls
+- [x] `GET /dialectic/query` endpoint exists in Go daemon's internal API; auth-gated; calls
       `SearchInferences` or `ListInferencesByConfidence`
-- [ ] `inject_style()` in `personalization.py` injects Signal 3 (inferences) after Signal 2
+- [x] `inject_style()` in `personalization.py` injects Signal 3 (inferences) after Signal 2
       (RAG); low-confidence inferences (<0.4) excluded
-- [ ] `inject_style()` behavior unchanged when `InferenceRetriever` returns `[]`
-- [ ] No `os.getenv` in `inference_retriever.py`
-- [ ] `go build ./...` and `go vet ./...` pass clean
-- [ ] Python tests pass: injection present, graceful degradation, confidence gate
-- [ ] `uv run pytest backend/tests/ -q` — no regressions
+- [x] `inject_style()` behavior unchanged when `InferenceRetriever` returns `[]`
+- [x] No `os.getenv` in `inference_retriever.py`
+- [x] `go build ./...` and `go vet ./...` pass clean
+- [x] Python tests pass: injection present, graceful degradation, confidence gate
+- [x] `uv run pytest backend/tests/ -q` — no regressions (764 pass, 1 pre-existing failure)
 
-**Engineer status**: started — Step 1: inference_retriever.py + config entry; Step 2: Go /dialectic/query endpoint + ListInferencesByConfidence; Step 3: inject_style() Signal 3; Step 4: tests
+**Engineer status**: 8/8 criteria done — last commit: 7e61734 "feat(personalization): add Signal 3 inference injection into inject_style() (TASK-087)" — 2026-06-21 23:26
 **Started**: 2026-06-21
 **Blockers**: none (TASK-086 merged at PR #193)
+**PR**: https://github.com/sraj0501/Devtrack_/pull/194
+
+**COMPLETE** — ready for PM review — 2026-06-21 23:26
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -1,8 +1,8 @@
 # DevTrack Project Board
 
-_Last updated: 2026-06-18 by PM — TASK-085 + TASK-086 COMPLETE (PRs #192, #193 merged); TASK-087 next_
-_Next DevTrack task ID: TASK-087_
-_Active branch: `dev`_
+_Last updated: 2026-06-21 by PM — TASK-087 IN PROGRESS on feat/TASK-087-inference-injection_
+_Next DevTrack task ID: TASK-088_
+_Active branch: `feat/TASK-087-inference-injection`_
 _Shipped: v3.0.10 (2026-06-14) — significant Windows fixes + gitsage improvements._
 _Direction: **PRODUCT_BIBLE.md** (pivot 2026-06-10) — `../../PRODUCT_BIBLE.md`_
 
@@ -2816,8 +2816,9 @@ Run `uv run pytest backend/tests/ -q` — no regressions beyond documented basel
 - [ ] Python tests pass: injection present, graceful degradation, confidence gate
 - [ ] `uv run pytest backend/tests/ -q` — no regressions
 
-**Engineer status**: not started
-**Blockers**: TASK-086 must be merged first
+**Engineer status**: started — Step 1: inference_retriever.py + config entry; Step 2: Go /dialectic/query endpoint + ListInferencesByConfidence; Step 3: inject_style() Signal 3; Step 4: tests
+**Started**: 2026-06-21
+**Blockers**: none (TASK-086 merged at PR #193)
 
 ---
 

--- a/devtrack_client/internal/daemon/http_api.go
+++ b/devtrack_client/internal/daemon/http_api.go
@@ -72,6 +72,10 @@ const RouteInternalStats = "/internal/stats"
 // RouteInternalActiveSession serves the active work session for the Python server.
 const RouteInternalActiveSession = "/internal/sessions/active"
 
+// RouteDialecticQuery serves the inference query endpoint for the Python server's
+// inject_style() Signal 3 path. Auth-gated by X-DevTrack-API-Key.
+const RouteDialecticQuery = "/dialectic/query"
+
 // startInternalHTTPServer starts a lightweight HTTP server on
 // config.GetIPCHost():config.GetDevTrackServerHTTPPort() that exposes internal control
 // endpoints not intended for external consumers.
@@ -82,12 +86,14 @@ const RouteInternalActiveSession = "/internal/sessions/active"
 //	POST /internal/reload-config      — reload .env + YAML config without restart
 //	GET  /internal/stats              — trigger throughput stats for Python admin panel
 //	GET  /internal/sessions/active    — active work session for Python server
+//	GET  /dialectic/query             — FTS5 inference search for Python inject_style()
 func (d *Daemon) startInternalHTTPServer() {
 	mux := http.NewServeMux()
 	mux.HandleFunc(RouteInternalForceTrigger, d.handleInternalForceTrigger)
 	mux.HandleFunc(RouteInternalReloadConfig, d.handleInternalReloadConfig)
 	mux.HandleFunc(RouteInternalStats, d.handleInternalStats)
 	mux.HandleFunc(RouteInternalActiveSession, d.handleInternalActiveSession)
+	mux.HandleFunc(RouteDialecticQuery, d.handleDialecticQuery)
 
 	addr := fmt.Sprintf("%s:%d", config.GetIPCHost(), config.GetDevTrackServerHTTPPort())
 	server := &http.Server{
@@ -247,6 +253,89 @@ func (d *Daemon) handleInternalReloadConfig(w http.ResponseWriter, r *http.Reque
 		"reloaded": reloaded,
 		"errors":   errs,
 	})
+}
+
+// handleDialecticQuery handles GET /dialectic/query.
+// Auth: X-DevTrack-API-Key header (checked when DEVTRACK_API_KEY env var is set).
+//
+// Query params:
+//
+//	q            — FTS5 search query; if empty, returns inferences ordered by confidence DESC
+//	context_type — optional filter by context type (commit, comment, report, etc.)
+//	limit        — max results (default 5)
+//
+// Response: {"inferences": [{"id": N, "subject": "...", "inference": "...", "confidence": 0.85}, ...]}
+func (d *Daemon) handleDialecticQuery(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Auth gate — check API key when configured.
+	configuredKey := os.Getenv("DEVTRACK_API_KEY")
+	if configuredKey != "" {
+		sentKey := r.Header.Get("X-DevTrack-API-Key")
+		if sentKey != configuredKey {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			json.NewEncoder(w).Encode(map[string]string{"error": "forbidden"})
+			return
+		}
+	}
+
+	q := r.URL.Query().Get("q")
+	contextType := r.URL.Query().Get("context_type")
+
+	limit := 5
+	if lStr := r.URL.Query().Get("limit"); lStr != "" {
+		if parsed, err := fmt.Sscanf(lStr, "%d", &limit); err != nil || parsed != 1 || limit < 1 {
+			limit = 5
+		}
+	}
+
+	database, err := db.NewDatabase()
+	if err != nil {
+		log.Printf("dialectic/query: failed to open DB: %v", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]string{"error": "db unavailable"})
+		return
+	}
+	defer database.Close()
+
+	var inferences []db.Inference
+	if q != "" {
+		inferences, err = database.SearchInferences(q, limit)
+	} else {
+		inferences, err = database.ListInferencesByConfidence(contextType, limit)
+	}
+	if err != nil {
+		log.Printf("dialectic/query: query error: %v", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	// Serialize to the response shape expected by InferenceRetriever.
+	type inferenceJSON struct {
+		ID         int64   `json:"id"`
+		Subject    string  `json:"subject"`
+		Inference  string  `json:"inference"`
+		Confidence float64 `json:"confidence"`
+	}
+	out := make([]inferenceJSON, 0, len(inferences))
+	for _, inf := range inferences {
+		out = append(out, inferenceJSON{
+			ID:         inf.ID,
+			Subject:    inf.Subject,
+			Inference:  inf.Inference,
+			Confidence: inf.Confidence,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"inferences": out})
 }
 
 // startHeartbeatLoop sends a client heartbeat to the server on startup and

--- a/devtrack_client/internal/db/inferences.go
+++ b/devtrack_client/internal/db/inferences.go
@@ -121,6 +121,35 @@ func (d *Database) ListInferences(contextType string, limit int) ([]Inference, e
 	return scanInferences(rows)
 }
 
+// ListInferencesByConfidence returns up to limit inferences ordered by confidence DESC,
+// optionally filtered by contextType. Pass contextType="" to return all context types.
+// This is used by /dialectic/query when no search query is provided.
+func (d *Database) ListInferencesByConfidence(contextType string, limit int) ([]Inference, error) {
+	var rows *sql.Rows
+	var err error
+	if contextType == "" {
+		rows, err = d.db.Query(`
+			SELECT id, context_type, subject, inference, evidence, confidence, source, created_at, updated_at
+			FROM inferences
+			ORDER BY confidence DESC
+			LIMIT ?
+		`, limit)
+	} else {
+		rows, err = d.db.Query(`
+			SELECT id, context_type, subject, inference, evidence, confidence, source, created_at, updated_at
+			FROM inferences
+			WHERE context_type = ?
+			ORDER BY confidence DESC
+			LIMIT ?
+		`, contextType, limit)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("ListInferencesByConfidence: %w", err)
+	}
+	defer rows.Close()
+	return scanInferences(rows)
+}
+
 // SearchInferences performs a full-text search over the inferences_fts virtual table.
 // It returns up to limit results ordered by FTS5 rank (best match first).
 func (d *Database) SearchInferences(query string, limit int) ([]Inference, error) {

--- a/devtrack_server/backend/config.py
+++ b/devtrack_server/backend/config.py
@@ -206,6 +206,13 @@ def ipc_port() -> str:
     return get("IPC_PORT", "35893")
 
 
+def get_devtrack_control_port() -> int:
+    """Port for the Go daemon's internal HTTP control API.
+    DEVTRACK_SERVER_HTTP_PORT (default: 35894).
+    Used by Python modules that call back to the Go daemon (e.g. /dialectic/query)."""
+    return get_int("DEVTRACK_SERVER_HTTP_PORT", 35894)
+
+
 # --- Azure DevOps (supports both AZURE_DEVOPS_PAT and AZURE_API_KEY for compatibility) ---
 def azure_pat() -> str:
     """Azure DevOps Personal Access Token."""

--- a/devtrack_server/backend/inference_retriever.py
+++ b/devtrack_server/backend/inference_retriever.py
@@ -1,0 +1,111 @@
+"""
+InferenceRetriever — retrieves top-k reasoned inferences from the Go daemon's
+/dialectic/query internal HTTP endpoint and presents them as plain dicts for
+injection into LLM prompts via inject_style().
+
+Never calls os.getenv directly — all config via backend.config.
+Returns [] on any failure (network error, daemon unavailable, JSON parse failure).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Minimum confidence for an inference to be injected into a prompt.
+# This is a module constant — NOT a config var.
+INFERENCE_MIN_CONFIDENCE: float = 0.4
+
+
+class InferenceRetriever:
+    """
+    Retrieves top-k inferences from the inferences SQLite table via the Go
+    client's /dialectic/query HTTP endpoint. Falls back to [] if unavailable.
+
+    Config (via backend.config, never os.getenv):
+      IPC_HOST                  — Go daemon bind host (default: 127.0.0.1)
+      DEVTRACK_SERVER_HTTP_PORT — Go daemon internal HTTP port (default: 35894)
+      DEVTRACK_API_KEY          — API key sent as X-DevTrack-API-Key header
+    """
+
+    _TIMEOUT: float = 1.0  # seconds — keep fast so callers are never blocked
+
+    def get_top_inferences(
+        self,
+        context_type: str,
+        query_text: str,
+        top_k: int = 5,
+    ) -> list[dict]:
+        """Return up to top_k inference dicts sorted by confidence DESC.
+
+        Each dict has keys: "subject", "inference", "confidence"
+        (and optionally "id" from the DB).
+
+        Returns [] on ANY failure — never raises.
+        """
+        try:
+            return self._fetch(context_type, query_text, top_k)
+        except Exception as exc:
+            logger.debug("inference_retriever: get_top_inferences failed: %s", exc)
+            return []
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_url(self, context_type: str, query_text: str, limit: int) -> str:
+        """Build the /dialectic/query URL from config."""
+        from backend import config  # noqa: PLC0415 — local import keeps top-level import-free
+        import urllib.parse  # noqa: PLC0415
+
+        host = config.ipc_host()
+        port = config.get_devtrack_control_port()
+        base = f"http://{host}:{port}/dialectic/query"
+        params = {
+            "context_type": context_type,
+            "q": query_text,
+            "limit": str(limit),
+        }
+        return base + "?" + urllib.parse.urlencode(params)
+
+    def _fetch(self, context_type: str, query_text: str, top_k: int) -> list[dict]:
+        """Perform the HTTP GET and return parsed inference list."""
+        import json  # noqa: PLC0415
+        import urllib.request  # noqa: PLC0415
+        from backend import config  # noqa: PLC0415
+
+        url = self._build_url(context_type, query_text, top_k)
+        api_key = config.get_devtrack_api_key()
+
+        req = urllib.request.Request(url)
+        if api_key:
+            req.add_header("X-DevTrack-API-Key", api_key)
+
+        with urllib.request.urlopen(req, timeout=self._TIMEOUT) as resp:
+            if resp.status != 200:
+                logger.debug(
+                    "inference_retriever: /dialectic/query returned HTTP %d", resp.status
+                )
+                return []
+            data = json.loads(resp.read().decode("utf-8"))
+
+        raw_inferences: list[dict] = data.get("inferences", [])
+
+        # Normalise: keep only the keys we need and sort by confidence DESC.
+        result: list[dict] = []
+        for item in raw_inferences:
+            try:
+                result.append(
+                    {
+                        "id": item.get("id"),
+                        "subject": str(item.get("subject", "")),
+                        "inference": str(item.get("inference", "")),
+                        "confidence": float(item.get("confidence", 0.0)),
+                    }
+                )
+            except (TypeError, ValueError):
+                continue  # skip malformed rows
+
+        result.sort(key=lambda x: x["confidence"], reverse=True)
+        return result[:top_k]

--- a/devtrack_server/backend/personalization.py
+++ b/devtrack_server/backend/personalization.py
@@ -35,10 +35,15 @@ import logging
 import os
 from typing import Optional
 
+from backend.inference_retriever import INFERENCE_MIN_CONFIDENCE, InferenceRetriever
+
 logger = logging.getLogger(__name__)
 
 _instance = None   # PersonalizedAI | None
 _loaded = False    # True once load has been attempted (avoids repeated retries)
+
+_inference_retriever: Optional[InferenceRetriever] = None  # lazy singleton
+_inference_retriever_loaded: bool = False
 
 
 # ── singleton loader ──────────────────────────────────────────────────────────
@@ -120,6 +125,21 @@ def _trigger_rag_index(ai) -> None:
         logger.debug("personalization: RAG indexing error: %s", exc)
 
 
+# ── Inference retriever singleton ─────────────────────────────────────────────
+
+def _get_inference_retriever() -> Optional[InferenceRetriever]:
+    """Return singleton InferenceRetriever (created on first call)."""
+    global _inference_retriever, _inference_retriever_loaded
+    if _inference_retriever_loaded:
+        return _inference_retriever
+    _inference_retriever_loaded = True
+    try:
+        _inference_retriever = InferenceRetriever()
+    except Exception as exc:
+        logger.debug("personalization: could not create InferenceRetriever: %s", exc)
+    return _inference_retriever
+
+
 # ── RAG retrieval ─────────────────────────────────────────────────────────────
 
 def _rag_examples(query_text: str, context_type: str) -> str:
@@ -188,13 +208,37 @@ def inject_style(
         prefix_parts.append(examples)
 
     if not prefix_parts:
-        return prompt
+        augmented = prompt
+    else:
+        augmented = "\n\n".join(prefix_parts) + "\n\n" + prompt
 
-    return "\n\n".join(prefix_parts) + "\n\n" + prompt
+    # 3. Reasoned inferences from the dialectic model (Signal 3 — Phase 6)
+    inference_section = ""
+    try:
+        retriever = _get_inference_retriever()
+        if retriever is not None:
+            top_infs = retriever.get_top_inferences(context_type, query_text or "", top_k=5)
+            if top_infs:
+                lines = [
+                    f"- {inf['inference']}"
+                    for inf in top_infs
+                    if inf.get("confidence", 0) > INFERENCE_MIN_CONFIDENCE
+                ]
+                if lines:
+                    inference_section = (
+                        "\n\nInferred developer patterns (from past interactions):\n"
+                        + "\n".join(lines)
+                    )
+    except Exception:
+        pass  # graceful — never raises
+
+    return augmented + inference_section
 
 
 def reset_cache() -> None:
-    """Reset the singleton — useful in tests when the data dir changes."""
-    global _instance, _loaded
+    """Reset the singletons — useful in tests when the data dir changes."""
+    global _instance, _loaded, _inference_retriever, _inference_retriever_loaded
     _instance = None
     _loaded = False
+    _inference_retriever = None
+    _inference_retriever_loaded = False

--- a/devtrack_server/backend/tests/test_inference_injection.py
+++ b/devtrack_server/backend/tests/test_inference_injection.py
@@ -1,0 +1,300 @@
+"""
+Tests for TASK-087 — Inference-to-generation injection.
+
+Coverage:
+  1. injection_present: inject_style() includes inference text when InferenceRetriever
+     returns inferences with confidence > 0.4.
+  2. graceful_degradation: inject_style() returns original prompt unchanged when
+     InferenceRetriever.get_top_inferences() raises an exception.
+  3. confidence_gate: Inference with confidence=0.3 is excluded from the injected section.
+  4. get_dialectic_query_endpoint: InferenceRetriever.get_top_inferences() correctly
+     parses the JSON response from the mocked Go daemon HTTP endpoint.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_GOOD_INFERENCES = [
+    {"id": 1, "subject": "commit tone", "inference": "Developer uses imperative mood.", "confidence": 0.82},
+    {"id": 2, "subject": "ticket refs", "inference": "Developer always references ticket IDs.", "confidence": 0.71},
+]
+
+_LOW_CONF_INFERENCE = [
+    {"id": 3, "subject": "style", "inference": "Developer prefers lowercase messages.", "confidence": 0.30},
+]
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — injection_present
+# ---------------------------------------------------------------------------
+
+class TestInjectionPresent:
+    """inject_style() should include inference text when retriever returns valid inferences."""
+
+    def test_inference_text_in_returned_prompt(self, monkeypatch):
+        import backend.personalization as p
+
+        # Reset singletons so we start clean.
+        p.reset_cache()
+
+        # Build a mock retriever that returns two high-confidence inferences.
+        mock_retriever = MagicMock()
+        mock_retriever.get_top_inferences.return_value = _GOOD_INFERENCES
+
+        # Patch _get_inference_retriever to return our mock.
+        monkeypatch.setattr(p, "_get_inference_retriever", lambda: mock_retriever)
+
+        # Disable Signal 1 and Signal 2 so only Signal 3 is active.
+        monkeypatch.setattr(p, "get_style_instruction", lambda ct: "")
+        monkeypatch.setattr(p, "_rag_examples", lambda q, ct: "")
+
+        result = p.inject_style("Write a commit message.", "commit", "test query")
+
+        assert "Developer uses imperative mood." in result
+        assert "Developer always references ticket IDs." in result
+        assert "Inferred developer patterns" in result
+
+    def test_original_prompt_still_present(self, monkeypatch):
+        import backend.personalization as p
+
+        p.reset_cache()
+
+        mock_retriever = MagicMock()
+        mock_retriever.get_top_inferences.return_value = _GOOD_INFERENCES
+
+        monkeypatch.setattr(p, "_get_inference_retriever", lambda: mock_retriever)
+        monkeypatch.setattr(p, "get_style_instruction", lambda ct: "")
+        monkeypatch.setattr(p, "_rag_examples", lambda q, ct: "")
+
+        original = "Write a commit message."
+        result = p.inject_style(original, "commit", "test query")
+
+        assert original in result, "Original prompt must be present in the returned string"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — graceful_degradation
+# ---------------------------------------------------------------------------
+
+class TestGracefulDegradation:
+    """inject_style() must not crash and must return the original prompt unchanged
+    when InferenceRetriever.get_top_inferences() raises an Exception."""
+
+    def test_exception_in_retriever_returns_original(self, monkeypatch):
+        import backend.personalization as p
+
+        p.reset_cache()
+
+        mock_retriever = MagicMock()
+        mock_retriever.get_top_inferences.side_effect = RuntimeError("daemon unavailable")
+
+        monkeypatch.setattr(p, "_get_inference_retriever", lambda: mock_retriever)
+        monkeypatch.setattr(p, "get_style_instruction", lambda ct: "")
+        monkeypatch.setattr(p, "_rag_examples", lambda q, ct: "")
+
+        original = "Write a commit message."
+        result = p.inject_style(original, "commit", "test query")
+
+        # No crash and inference section should NOT be present.
+        assert result == original, (
+            f"Expected original prompt unchanged, got: {result!r}"
+        )
+
+    def test_none_retriever_does_not_crash(self, monkeypatch):
+        """If _get_inference_retriever() returns None, inject_style() should not crash."""
+        import backend.personalization as p
+
+        p.reset_cache()
+
+        monkeypatch.setattr(p, "_get_inference_retriever", lambda: None)
+        monkeypatch.setattr(p, "get_style_instruction", lambda ct: "")
+        monkeypatch.setattr(p, "_rag_examples", lambda q, ct: "")
+
+        original = "Write a commit message."
+        result = p.inject_style(original, "commit", "test query")
+        assert result == original
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — confidence_gate
+# ---------------------------------------------------------------------------
+
+class TestConfidenceGate:
+    """Inferences with confidence <= 0.4 must NOT be included in the injected section."""
+
+    def test_low_confidence_inference_excluded(self, monkeypatch):
+        import backend.personalization as p
+
+        p.reset_cache()
+
+        mock_retriever = MagicMock()
+        mock_retriever.get_top_inferences.return_value = _LOW_CONF_INFERENCE
+
+        monkeypatch.setattr(p, "_get_inference_retriever", lambda: mock_retriever)
+        monkeypatch.setattr(p, "get_style_instruction", lambda ct: "")
+        monkeypatch.setattr(p, "_rag_examples", lambda q, ct: "")
+
+        original = "Write a commit message."
+        result = p.inject_style(original, "commit", "test query")
+
+        # The low-confidence inference must not appear.
+        assert "Developer prefers lowercase messages." not in result
+        # The "Inferred developer patterns" header must also be absent when no inferences pass the gate.
+        assert "Inferred developer patterns" not in result
+        # But the original prompt must still be there.
+        assert original in result
+
+    def test_mixed_confidence_only_high_pass(self, monkeypatch):
+        """When both high- and low-confidence inferences are returned, only high passes."""
+        import backend.personalization as p
+
+        p.reset_cache()
+
+        mixed = [
+            {"id": 1, "subject": "tone", "inference": "Uses short sentences.", "confidence": 0.75},
+            {"id": 2, "subject": "style", "inference": "Prefers lowercase.", "confidence": 0.30},
+        ]
+
+        mock_retriever = MagicMock()
+        mock_retriever.get_top_inferences.return_value = mixed
+
+        monkeypatch.setattr(p, "_get_inference_retriever", lambda: mock_retriever)
+        monkeypatch.setattr(p, "get_style_instruction", lambda ct: "")
+        monkeypatch.setattr(p, "_rag_examples", lambda q, ct: "")
+
+        result = p.inject_style("prompt", "commit", "")
+
+        assert "Uses short sentences." in result
+        assert "Prefers lowercase." not in result
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — get_dialectic_query_endpoint
+# ---------------------------------------------------------------------------
+
+class TestGetDialecticQueryEndpoint:
+    """InferenceRetriever._fetch() correctly parses a mocked HTTP response from
+    the Go daemon's /dialectic/query endpoint."""
+
+    def _make_mock_response(self, data: dict):
+        """Create a mock urllib response that returns the given data as JSON."""
+        body = json.dumps(data).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.status = 200
+        mock_resp.read.return_value = body
+        return mock_resp
+
+    def test_parses_two_inferences_correctly(self, monkeypatch):
+        from backend.inference_retriever import InferenceRetriever
+
+        retriever = InferenceRetriever()
+
+        response_data = {
+            "inferences": [
+                {"id": 10, "subject": "commit tone", "inference": "Uses imperative mood.", "confidence": 0.85},
+                {"id": 11, "subject": "ticket refs", "inference": "Always includes ticket ID.", "confidence": 0.72},
+            ]
+        }
+
+        mock_resp = self._make_mock_response(response_data)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = retriever.get_top_inferences("commit", "imperative mood", top_k=5)
+
+        assert len(result) == 2
+        assert result[0]["inference"] == "Uses imperative mood."
+        assert result[0]["confidence"] == 0.85
+        assert result[1]["inference"] == "Always includes ticket ID."
+        assert result[1]["confidence"] == 0.72
+
+    def test_returns_empty_list_on_network_error(self, monkeypatch):
+        """Network errors must return [] without raising."""
+        from backend.inference_retriever import InferenceRetriever
+
+        retriever = InferenceRetriever()
+
+        with patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+            result = retriever.get_top_inferences("commit", "test", top_k=5)
+
+        assert result == []
+
+    def test_returns_empty_list_on_malformed_json(self, monkeypatch):
+        """Malformed JSON from daemon must return [] without raising."""
+        from backend.inference_retriever import InferenceRetriever
+
+        retriever = InferenceRetriever()
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.status = 200
+        mock_resp.read.return_value = b"not json at all"
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = retriever.get_top_inferences("commit", "test", top_k=5)
+
+        assert result == []
+
+    def test_sorted_by_confidence_desc(self, monkeypatch):
+        """Results are returned sorted by confidence descending."""
+        from backend.inference_retriever import InferenceRetriever
+
+        retriever = InferenceRetriever()
+
+        response_data = {
+            "inferences": [
+                {"id": 1, "subject": "a", "inference": "low conf", "confidence": 0.50},
+                {"id": 2, "subject": "b", "inference": "high conf", "confidence": 0.90},
+                {"id": 3, "subject": "c", "inference": "mid conf", "confidence": 0.70},
+            ]
+        }
+        mock_resp = self._make_mock_response(response_data)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = retriever.get_top_inferences("commit", "q", top_k=5)
+
+        assert len(result) == 3
+        assert result[0]["confidence"] == 0.90
+        assert result[1]["confidence"] == 0.70
+        assert result[2]["confidence"] == 0.50
+
+    def test_no_os_getenv_in_module(self):
+        """Verify inference_retriever.py uses backend.config, not os.getenv directly."""
+        import ast
+        import inspect
+        from backend import inference_retriever
+
+        source = inspect.getsource(inference_retriever)
+        tree = ast.parse(source)
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "getenv"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "os"
+            )
+        ]
+        assert not calls, (
+            f"inference_retriever.py must not call os.getenv() — use backend.config "
+            f"(found {len(calls)} call(s))"
+        )


### PR DESCRIPTION
## Summary

- Adds `devtrack_server/backend/inference_retriever.py` with `InferenceRetriever.get_top_inferences()` — calls `GET /dialectic/query` on the Go daemon's internal HTTP API; returns `[]` on any failure, never raises; no `os.getenv`
- Adds `GET /dialectic/query` endpoint to `devtrack_client/internal/daemon/http_api.go` — auth-gated (`X-DevTrack-API-Key`), calls `SearchInferences` (FTS5) when `q` is set or `ListInferencesByConfidence` when `q` is empty
- Adds `ListInferencesByConfidence()` to `devtrack_client/internal/db/inferences.go` — orders by `confidence DESC`, optionally filters by `context_type`
- Injects Signal 3 into `inject_style()` in `devtrack_server/backend/personalization.py` after Signal 2 (RAG); confidence gate `INFERENCE_MIN_CONFIDENCE = 0.4` excludes low-confidence noise; fully graceful (exception → pass)
- Adds `devtrack_server/backend/tests/test_inference_injection.py` — 11 tests: injection present, graceful degradation, confidence gate, HTTP endpoint mock

## Test plan

- [x] `go build ./...` clean (devtrack_client/)
- [x] `go vet ./...` clean (devtrack_client/)
- [x] `uv run pytest backend/tests/ -q` — 764 passed, 1 pre-existing failure (test_ollama_host_returns_string), no regressions
- [x] All 8 acceptance criteria met
- [x] No `os.getenv` in inference_retriever.py

## Closes

TASK-087 (Phase 6 — dialectic self-improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)