### PR TITLE
feat(reviewer): TASK-096 escalation and notification channels

### DIFF
--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -29,6 +29,7 @@
 - Blockers encountered: none
 - One thing that still feels rough: "prURLFromCommentURL derives PR URL from comment URL by stripping fragment — fragile for non-GitHub platforms, but acceptable for Phase 7"
 - Ready for PM review: YES
+- PR: https://github.com/sraj0501/Devtrack_/pull/207
 
 ---
 

--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -2,6 +2,36 @@
 
 ---
 
+### [2026-06-28 18:20] TASK-096 — Escalation and notification channels
+
+**Original message**: "feat(reviewer): TASK-096 escalation and notification channels"
+**DevTrack enhanced it to**: no enhancement — AI provider unreachable (Ollama not running); committed with original message as-is
+**Ticket auto-linked**: NO
+**PM system updated**: YES — project_board.md TASK-096 updated, all 9/9 criteria ticked
+**Time**: ~60 minutes
+**Friction**: LOW — clean implementation once import path typos were identified (srav0501 vs sraj0501 in daemon.go and cli_review.go)
+**Notes**:
+  - review_notify.go: new file in telegram package with SendPRApproved + SendPREscalation; nil-Bot guard on both
+  - daemon.go: replaced two log.Printf stubs with InsertPendingAction + telegram calls; added prURLFromCommentURL helper; also wired "needs_human" escalation path (was just a log before)
+  - webhook_server.py: pr_approved_notify and pr_escalation handlers added BEFORE workspace_router guard (notification-only, no PM API needed)
+  - tui_queue.go: queueActionTypeBadge function added; "PR DONE" (Success) and "PR STUCK" (Danger) badges
+  - cli_review.go: handleReviewStatus added with dual-table query (pending_actions + pr_review_comments); routing in cli.go updated
+  - db/pr_review.go: ListPRReviewCommentsRecent(hours) added for review status CLI
+  - test_pr_notifications.py: 8 tests, all passing; tests confirm notification-only path does not require workspace_router
+  - Python regression: 1 pre-existing failure (test_ollama_host_returns_string) unchanged; 797 pass
+
+## Task Summary — TASK-096: Escalation and notification channels — 2026-06-28
+
+- Total commits: 1 (implementation) + 1 (board update)
+- Acceptance criteria met: 9/9
+- Tickets auto-updated: NO (branch not in a watched workspace)
+- Estimated daily time saved: ~5 min (no manual Telegram messages for PR outcomes)
+- Blockers encountered: none
+- One thing that still feels rough: "prURLFromCommentURL derives PR URL from comment URL by stripping fragment — fragile for non-GitHub platforms, but acceptable for Phase 7"
+- Ready for PM review: YES
+
+---
+
 ### [2026-06-28 16:07] TASK-095 — Phase 7 fix-commit-push loop
 
 **Original message**: "feat(reviewer): Phase 7 fix-commit-push loop (TASK-095)"

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -3941,7 +3941,7 @@ must pass.
 **Depends on**: TASK-095 (MERGED — de48d214)
 **Branch**: `feat/TASK-096-escalation-and-notification`
 **Started**: 2026-06-28
-**Engineer status**: started — implementing (A) daemon goroutine pending_actions inserts, (B) Python _execute_pm_action handlers, (C) telegram review_notify.go, (D) TUI action-type badges, (E) review status CLI, (F) Python tests
+**Engineer status**: 9/9 criteria done — last commit: 4d8d028 "feat(reviewer): TASK-096 escalation and notification channels" — 2026-06-28 18:20
 
 **Spec**:
 
@@ -4085,15 +4085,19 @@ cover `b.api.Send()` mock pattern; add a smoke test if they do not.
 Build: `go build ./...` and `go vet ./...` from `devtrack_client/`. `uv run pytest backend/tests/ -q` — no regressions.
 
 **Acceptance criteria**:
-- [ ] `pr_approved_notify` and `pr_escalation` are staged as `pending_actions` rows when loop terminates (not direct sends)
-- [ ] `_execute_pm_action` handles both new action types without raising; no PM API call (notification-only)
-- [ ] `bot.SendPRApproved()` and `bot.SendPREscalation()` methods exist and send correct message format
-- [ ] TUI Queue tab shows `"PR DONE"` (Success) and `"PR STUCK"` (Danger) badges for the new action types
-- [ ] `devtrack review status` command prints per-PR status grouped by PR ID
-- [ ] `go build ./...` and `go vet ./...` pass clean from `devtrack_client/`
-- [ ] Python tests: both new action types handled cleanly; no regressions
-- [ ] No `os.getenv` in any new Python file; no hardcoded literals
-- [ ] Channel parity: Telegram receives notification for both outcomes (SendPRApproved / SendPREscalation wired in daemon goroutine)
+- [x] `pr_approved_notify` and `pr_escalation` are staged as `pending_actions` rows when loop terminates (not direct sends)
+- [x] `_execute_pm_action` handles both new action types without raising; no PM API call (notification-only)
+- [x] `bot.SendPRApproved()` and `bot.SendPREscalation()` methods exist and send correct message format
+- [x] TUI Queue tab shows `"PR DONE"` (Success) and `"PR STUCK"` (Danger) badges for the new action types
+- [x] `devtrack review status` command prints per-PR status grouped by PR ID
+- [x] `go build ./...` and `go vet ./...` pass clean from `devtrack_client/`
+- [x] Python tests: both new action types handled cleanly; no regressions
+- [x] No `os.getenv` in any new Python file; no hardcoded literals
+- [x] Channel parity: Telegram receives notification for both outcomes (SendPRApproved / SendPREscalation wired in daemon goroutine)
+
+**Engineer status**: 9/9 criteria done — last commit: 4d8d028 "feat(reviewer): TASK-096 escalation and notification channels" — 2026-06-28 18:20
+
+**COMPLETE** — ready for PM review — 2026-06-28 18:20
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -4097,6 +4097,7 @@ Build: `go build ./...` and `go vet ./...` from `devtrack_client/`. `uv run pyte
 
 **Engineer status**: 9/9 criteria done — last commit: 4d8d028 "feat(reviewer): TASK-096 escalation and notification channels" — 2026-06-28 18:20
 
+**PR**: https://github.com/sraj0501/Devtrack_/pull/207 (base: dev)
 **COMPLETE** — ready for PM review — 2026-06-28 18:20
 
 ---

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -3934,10 +3934,14 @@ must pass.
 ---
 
 ### TASK-096 — Escalation and completion notification: Telegram, TUI, and CLI channels
+**Assigned to**: engineer
+**Status**: IN PROGRESS
 **Priority**: MEDIUM
 **Phase**: Phase 7
-**Depends on**: TASK-095
+**Depends on**: TASK-095 (MERGED — de48d214)
 **Branch**: `feat/TASK-096-escalation-and-notification`
+**Started**: 2026-06-28
+**Engineer status**: started — implementing (A) daemon goroutine pending_actions inserts, (B) Python _execute_pm_action handlers, (C) telegram review_notify.go, (D) TUI action-type badges, (E) review status CLI, (F) Python tests
 
 **Spec**:
 

--- a/devtrack_client/cli.go
+++ b/devtrack_client/cli.go
@@ -26,7 +26,8 @@ func NewCLI() (*CLI, error) {
 			cmd == "azure-list" || cmd == "azure-sync" || cmd == "azure-view" ||
 			cmd == "gitlab-list" || cmd == "gitlab-sync" || cmd == "gitlab-view" ||
 			cmd == "github-list" || cmd == "github-sync" || cmd == "github-view" ||
-			cmd == "ticket-sync" || cmd == "narrative" || cmd == "eod" || cmd == "skills" {
+			cmd == "ticket-sync" || cmd == "narrative" || cmd == "eod" || cmd == "skills" ||
+			cmd == "review" {
 			return &CLI{}, nil
 		}
 	}
@@ -217,6 +218,9 @@ func (cli *CLI) Execute() error {
 	case "alerts":
 		return cli.handleAlerts()
 	case "review":
+		if len(os.Args) > 2 && os.Args[2] == "status" {
+			return cli.handleReviewStatus()
+		}
 		return cli.handleReview()
 	case "vacation":
 		return cli.handleVacation()

--- a/devtrack_client/cli_review.go
+++ b/devtrack_client/cli_review.go
@@ -1,18 +1,21 @@
 package main
 
-// cli_review.go — implements `devtrack review` command.
+// cli_review.go — implements `devtrack review` and `devtrack review status` commands.
 //
-// Queries the local pr_review_comments SQLite table for new and classified
-// review comments, groups them by (Platform, PRID), and prints a summary.
+// `devtrack review`        — shows new/classified review comments grouped by PR.
+// `devtrack review status` — shows per-PR outcome summary from the last 24 hours,
+//                            combining pr_review_comments and pending_actions data.
 //
-// Usage:
-//   devtrack review
+// Both commands read from SQLite directly (no daemon required).
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/sraj0501/Devtrack_/devtrack_client/internal/db"
+	"github.com/sraj0501/Devtrack_/devtrack_client/internal/reviewer"
 )
 
 // handleReview prints the current PR review queue grouped by PR.
@@ -118,4 +121,153 @@ func (cli *CLI) handleReview() error {
 	}
 
 	return nil
+}
+
+// handleReviewStatus prints the per-PR activity summary from the last 24 hours.
+// It combines pr_review_comments (for in-progress / stuck state) and
+// pending_actions (for approved / escalated final states staged by the fix loop).
+//
+// Output format:
+//
+//	PR Review Activity (last 24h)
+//	-----------------------------
+//	PR #42   github   my-workspace   APPROVED     2 fixes applied
+//	PR #19   github   my-workspace   STUCK        comment needs human: "arch question"
+//	PR #7    azure    my-workspace   IN PROGRESS  (fix attempt 1/5)
+func (cli *CLI) handleReviewStatus() error {
+	database, err := db.NewDatabase()
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer database.Close()
+
+	// Collect pr_review_comments from the last 24 hours.
+	comments, err := database.ListPRReviewCommentsRecent(24)
+	if err != nil {
+		return fmt.Errorf("list recent review comments: %w", err)
+	}
+
+	// Collect pending_actions from the last 24 hours to capture final outcomes
+	// (pr_approved_notify / pr_escalation actions staged by the fix loop).
+	pendingActions, err := database.ListPendingActionsRecent(24)
+	if err != nil {
+		// Non-fatal: proceed without pending action data.
+		pendingActions = nil
+	}
+
+	// per-PR outcome accumulator.
+	type prKey struct{ platform, prID string }
+	type prOutcome struct {
+		status    string // "APPROVED" | "STUCK" | "IN PROGRESS" | ""
+		detail    string
+		workspace string
+	}
+
+	outcomes := make(map[prKey]*prOutcome)
+	keyOrder := []prKey{}
+	seen := make(map[prKey]bool)
+	addKey := func(k prKey, ws string) {
+		if !seen[k] {
+			seen[k] = true
+			keyOrder = append(keyOrder, k)
+			outcomes[k] = &prOutcome{workspace: ws}
+		}
+	}
+
+	// Pass 1: resolve final outcomes from pending_actions
+	// (pr_approved_notify and pr_escalation rows).
+	for _, a := range pendingActions {
+		if a.ActionType != "pr_approved_notify" && a.ActionType != "pr_escalation" {
+			continue
+		}
+		// Target format: "github:PR #42"
+		target := a.Target
+		platform := a.Platform
+		prIDStr := target
+		if idx := strings.Index(target, ":PR #"); idx >= 0 {
+			platform = target[:idx]
+			prIDStr = target[idx+5:]
+		}
+		k := prKey{platform: platform, prID: prIDStr}
+		addKey(k, a.Workspace)
+		o := outcomes[k]
+
+		var payload map[string]any
+		_ = json.Unmarshal([]byte(a.Payload), &payload)
+
+		if a.ActionType == "pr_approved_notify" && o.status != "APPROVED" {
+			detail := ""
+			if payload != nil {
+				if n, ok := payload["fixes_applied"]; ok {
+					detail = fmt.Sprintf("%v fixes applied", n)
+				}
+			}
+			o.status = "APPROVED"
+			o.detail = detail
+		} else if a.ActionType == "pr_escalation" && o.status == "" {
+			blocker := ""
+			if payload != nil {
+				if r, ok := payload["blocker_reason"].(string); ok {
+					blocker = r
+				}
+			}
+			o.status = "STUCK"
+			o.detail = "comment needs human: " + reviewTruncate(blocker, 40)
+		}
+	}
+
+	// Pass 2: derive IN PROGRESS / STUCK from pr_review_comments for PRs not
+	// yet resolved via pending_actions.
+	for _, c := range comments {
+		k := prKey{platform: c.Platform, prID: c.PRID}
+		addKey(k, c.Workspace)
+		o := outcomes[k]
+		if o.status != "" {
+			continue // already resolved
+		}
+		switch {
+		case c.ClassifiedAs == "needs_human" || c.Status == "escalated":
+			o.status = "STUCK"
+			o.detail = "comment needs human: " + reviewTruncate(c.CommentBody, 40)
+		case c.ClassifiedAs == "auto_fixable":
+			o.status = "IN PROGRESS"
+			o.detail = fmt.Sprintf("(fix attempt %d/%d)", c.AttemptCount, reviewer.MaxAttemptsPerComment)
+		}
+	}
+
+	if len(keyOrder) == 0 {
+		fmt.Println("No PR review activity in the last 24 hours.")
+		return nil
+	}
+
+	// Sort: platform ascending, then PR ID ascending.
+	sort.Slice(keyOrder, func(i, j int) bool {
+		ki, kj := keyOrder[i], keyOrder[j]
+		if ki.platform != kj.platform {
+			return ki.platform < kj.platform
+		}
+		return ki.prID < kj.prID
+	})
+
+	fmt.Println("PR Review Activity (last 24h)")
+	fmt.Println("-----------------------------")
+	for _, k := range keyOrder {
+		o := outcomes[k]
+		status := o.status
+		if status == "" {
+			status = "PENDING"
+		}
+		fmt.Printf("PR #%-6s  %-8s  %-18s  %-12s  %s\n",
+			k.prID, k.platform, reviewTruncate(o.workspace, 18), status, o.detail)
+	}
+	return nil
+}
+
+// reviewTruncate shortens s to at most maxLen runes, appending "…" when trimmed.
+func reviewTruncate(s string, maxLen int) string {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
 }

--- a/devtrack_client/internal/daemon/daemon.go
+++ b/devtrack_client/internal/daemon/daemon.go
@@ -2,12 +2,14 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -610,21 +612,116 @@ func (d *Daemon) startAlertPoller() {
 						)
 						loop := reviewer.NewPRFixLoop(database, ag, nil)
 						report := loop.Run(d.ctx, event.Platform, event.PRID, event.Workspace, "")
+
+						// Count fixes applied so far for this PR.
+						allComments, _ := database.ListPRReviewCommentsByPR(event.Platform, event.PRID)
+						fixesApplied := 0
+						for _, c := range allComments {
+							if c.Status == "fix_applied" {
+								fixesApplied++
+							}
+						}
+						prTitle := event.PRTitle
+						prURL := prURLFromCommentURL(event.CommentURL)
+
 						if report.Stuck {
-							log.Printf("review: stuck on PR %s — %s", event.PRID, report.BlockerReason)
+							// Stage pr_escalation pending action (Non-Negotiable #2: queue first).
+							payload, _ := json.Marshal(map[string]any{
+								"pr_title":       prTitle,
+								"pr_id":          event.PRID,
+								"blocker_reason": report.BlockerReason,
+								"comment_url":    report.CommentURL,
+								"fixes_applied":  fixesApplied,
+								"pr_url":         prURL,
+							})
+							_, _ = database.InsertPendingAction(db.PendingAction{
+								ActionType: "pr_escalation",
+								Target:     event.Platform + ":PR #" + event.PRID,
+								Platform:   event.Platform,
+								Workspace:  event.Workspace,
+								Confidence: 1.0,
+								Payload:    string(payload),
+								Status:     "pending",
+								ExpiresAt:  time.Now().Add(db.ConfidenceTimeout(1.0, false)),
+							})
+							// Channel parity: send Telegram immediately alongside queue insert.
+							if d.telegramBot != nil {
+								_ = d.telegramBot.SendPREscalation(prTitle, report.BlockerReason, report.CommentURL, prURL)
+							}
+							log.Printf("review: staged pr_escalation for PR %s — %s", event.PRID, report.BlockerReason)
 						} else {
-							log.Printf("review: PR %s approved", event.PRID)
+							// Stage pr_approved_notify pending action.
+							payload, _ := json.Marshal(map[string]any{
+								"pr_title":      prTitle,
+								"pr_id":         event.PRID,
+								"fixes_applied": fixesApplied,
+								"pr_url":        prURL,
+							})
+							_, _ = database.InsertPendingAction(db.PendingAction{
+								ActionType: "pr_approved_notify",
+								Target:     event.Platform + ":PR #" + event.PRID,
+								Platform:   event.Platform,
+								Workspace:  event.Workspace,
+								Confidence: 1.0,
+								Payload:    string(payload),
+								Status:     "pending",
+								ExpiresAt:  time.Now().Add(db.ConfidenceTimeout(1.0, false)),
+							})
+							// Channel parity: send Telegram immediately alongside queue insert.
+							if d.telegramBot != nil {
+								_ = d.telegramBot.SendPRApproved(prTitle, prURL)
+							}
+							log.Printf("review: staged pr_approved_notify for PR %s", event.PRID)
 						}
 					}(ev)
 				}
 			} else {
-				log.Printf("review: needs_human — escalation not yet wired (TASK-096)")
+				// needs_human: escalate immediately — no fix loop will run.
+				prTitle := ev.PRTitle
+				blockerReason := "comment needs human review"
+				commentURL := ev.CommentURL
+				prURL := prURLFromCommentURL(commentURL)
+
+				payload, _ := json.Marshal(map[string]any{
+					"pr_title":       prTitle,
+					"pr_id":          ev.PRID,
+					"blocker_reason": blockerReason,
+					"comment_url":    commentURL,
+					"fixes_applied":  0,
+					"pr_url":         prURL,
+				})
+				_, _ = database.InsertPendingAction(db.PendingAction{
+					ActionType: "pr_escalation",
+					Target:     ev.Platform + ":PR #" + ev.PRID,
+					Platform:   ev.Platform,
+					Workspace:  ev.Workspace,
+					Confidence: 1.0,
+					Payload:    string(payload),
+					Status:     "pending",
+					ExpiresAt:  time.Now().Add(db.ConfidenceTimeout(1.0, false)),
+				})
+				if d.telegramBot != nil {
+					_ = d.telegramBot.SendPREscalation(prTitle, blockerReason, commentURL, prURL)
+				}
+				// Update comment status to "escalated" so the review CLI shows it.
+				_ = database.UpdatePRReviewCommentStatus(ev.Platform, ev.CommentID, "escalated", classification, fixHint)
+				log.Printf("review: staged pr_escalation (needs_human) for PR %s comment %s", ev.PRID, ev.CommentID)
 			}
 		}
 	})
 
 	poller.Start(d.ctx)
 	d.alertPoller = poller
+}
+
+// prURLFromCommentURL derives the PR web URL from a review comment URL by stripping
+// the fragment identifier (the "#discussion_r..." suffix on GitHub comment URLs).
+// Returns the input unchanged when no fragment is present.
+func prURLFromCommentURL(commentURL string) string {
+	if i := strings.Index(commentURL, "#"); i >= 0 {
+		return commentURL[:i]
+	}
+	return commentURL
 }
 
 // startWorkspacesFileWatcher watches workspaces.yaml for changes and triggers

--- a/devtrack_client/internal/db/pr_review.go
+++ b/devtrack_client/internal/db/pr_review.go
@@ -145,6 +145,28 @@ func (d *Database) ListPRReviewCommentsByStatus(status string) ([]PRReviewCommen
 	return scanPRReviewComments(rows)
 }
 
+// ListPRReviewCommentsRecent returns all pr_review_comments created or updated
+// within the last N hours, ordered by created_at ASC.
+// Used by "devtrack review status" to build the per-PR activity summary.
+func (d *Database) ListPRReviewCommentsRecent(hours int) ([]PRReviewComment, error) {
+	query := `
+		SELECT platform, comment_id, pr_id, workspace, status, comment_body,
+		       COALESCE(classified_as, ''), fix_hint, created_at, updated_at,
+		       COALESCE(attempt_count, 0)
+		FROM pr_review_comments
+		WHERE created_at >= datetime('now', ? || ' hours')
+		ORDER BY created_at ASC
+	`
+	// SQLite modifier requires a negative number for "N hours ago".
+	modifier := fmt.Sprintf("-%d", hours)
+	rows, err := d.db.Query(query, modifier)
+	if err != nil {
+		return nil, fmt.Errorf("ListPRReviewCommentsRecent: %w", err)
+	}
+	defer rows.Close()
+	return scanPRReviewComments(rows)
+}
+
 // IncrementPRReviewCommentAttempts increments attempt_count for (platform, commentID)
 // and stamps updated_at = datetime('now'). Returns the new attempt_count value.
 func (d *Database) IncrementPRReviewCommentAttempts(platform, commentID string) (int, error) {

--- a/devtrack_client/internal/telegram/review_notify.go
+++ b/devtrack_client/internal/telegram/review_notify.go
@@ -1,0 +1,54 @@
+package telegram
+
+import (
+	"fmt"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+// SendPRApproved sends a "[DevTrack] PR Approved" notification to all configured
+// notify chat IDs. This is a plain-text status message — no inline keyboard is
+// needed because the developer has no action to take.
+//
+// Safe to call on a nil receiver (Telegram disabled or bot token missing).
+func (b *Bot) SendPRApproved(prTitle, prURL string) error {
+	if b == nil || b.api == nil {
+		return nil
+	}
+	text := fmt.Sprintf(
+		"[DevTrack] PR Approved\n%s\n%s\n\nAll review comments resolved automatically.",
+		prTitle, prURL,
+	)
+	var lastErr error
+	for _, chatID := range b.notifyIDs {
+		msg := tgbotapi.NewMessage(chatID, text)
+		if _, err := b.api.Send(msg); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+// SendPREscalation sends a "[DevTrack] PR Needs You" escalation notification to
+// all configured notify chat IDs. Called when the fix loop gives up on a comment
+// that cannot be automatically resolved.
+//
+// No inline keyboard is attached — the developer must inspect the PR directly.
+// Safe to call on a nil receiver (Telegram disabled or bot token missing).
+func (b *Bot) SendPREscalation(prTitle, blockerReason, commentURL, prURL string) error {
+	if b == nil || b.api == nil {
+		return nil
+	}
+	text := fmt.Sprintf(
+		"[DevTrack] PR Needs You\n%s\n%s\n\nBlocker: %s\nComment: %s\n\nDevTrack attempted fixes but could not resolve this comment.",
+		prTitle, prURL, blockerReason, commentURL,
+	)
+	var lastErr error
+	for _, chatID := range b.notifyIDs {
+		msg := tgbotapi.NewMessage(chatID, text)
+		if _, err := b.api.Send(msg); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}

--- a/devtrack_client/internal/tui/tui_queue.go
+++ b/devtrack_client/internal/tui/tui_queue.go
@@ -280,6 +280,24 @@ func queueStatusBadge(status string) string {
 	}
 }
 
+// queueActionTypeBadge returns a colored badge for action types that benefit
+// from visual distinction (PR lifecycle events). For all other types it returns
+// the action type as truncated plain text matching the 18-char TYPE column.
+func queueActionTypeBadge(actionType string) string {
+	switch actionType {
+	case "pr_approved_notify":
+		return StyleBadge(ColorSuccess).Render("  PR DONE  ")
+	case "pr_escalation":
+		return StyleBadge(ColorDanger).Render(" PR STUCK  ")
+	default:
+		at := actionType
+		if len(at) > 18 {
+			at = at[:15] + "..."
+		}
+		return at
+	}
+}
+
 // confidenceBar renders a 5-character block bar colored by threshold.
 func confidenceBar(c float64) string {
 	if c < 0 {
@@ -391,17 +409,14 @@ func (m queueModel) View() string {
 		bar := confidenceBar(item.Confidence)
 		expiry := expiresCountdown(item.ExpiresAt, m.pulseState)
 
-		actionType := item.ActionType
-		if len(actionType) > 18 {
-			actionType = actionType[:15] + "..."
-		}
+		actionTypeFmt := queueActionTypeBadge(item.ActionType)
 		target := item.Target
 		if len(target) > 20 {
 			target = target[:17] + "..."
 		}
 
 		row := fmt.Sprintf("  %s  %s  %-10s  %-18s  %-20s",
-			badge, bar, expiry, actionType, target)
+			badge, bar, expiry, actionTypeFmt, target)
 
 		if i == m.cursor {
 			row = lipgloss.NewStyle().

--- a/devtrack_client/main.go
+++ b/devtrack_client/main.go
@@ -211,6 +211,7 @@ func printBasicUsage() {
 	fmt.Println("COMMITS:    commits pending | commits review")
 	fmt.Println("ALERTS:     alerts | alerts --all | alerts --clear")
 	fmt.Println("REVIEW:     review                                  show PR review comment queue")
+	fmt.Println("            review status                           per-PR outcome summary (last 24h)")
 	fmt.Println("REPORTS:    preview-report | send-report | save-report")
 	fmt.Println("CLOUD:      cloud login --url URL --key KEY    connect to external server")
 	fmt.Println("            cloud status | cloud logout")

--- a/devtrack_server/backend/tests/test_pr_notifications.py
+++ b/devtrack_server/backend/tests/test_pr_notifications.py
@@ -1,0 +1,121 @@
+"""
+TASK-096 tests: _execute_pm_action handling for pr_approved_notify and pr_escalation.
+
+Verifies that:
+  - pr_approved_notify returns {"status": "posted"} without calling any PM API
+  - pr_escalation returns {"status": "posted"} without calling any PM API
+  - Neither action type raises an exception under any payload shape
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _bare_processor():
+    """Build a TriggerProcessor with no real components wired in."""
+    from backend.webhook_server import TriggerProcessor
+    proc = TriggerProcessor.__new__(TriggerProcessor)
+    proc.nlp_parser = None
+    proc.description_enhancer = None
+    proc.azure_client = None
+    proc.gitlab_client = None
+    proc.github_client = None
+    proc.workspace_router = None
+    proc.task_matcher = None
+    return proc
+
+
+def _action(action_type: str, payload: dict | None = None) -> dict:
+    """Build a minimal pending_actions dict for _execute_pm_action."""
+    return {
+        "id": 999,
+        "action_type": action_type,
+        "target": "github:PR #42",
+        "platform": "github",
+        "workspace": "test-ws",
+        "payload": json.dumps(payload or {}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# pr_approved_notify
+# ---------------------------------------------------------------------------
+
+class TestPRApprovedNotify:
+    def test_returns_posted(self):
+        """pr_approved_notify should return {"status": "posted"}."""
+        proc = _bare_processor()
+        result = proc._execute_pm_action(
+            _action("pr_approved_notify", {"pr_title": "feat: add login", "pr_id": "42", "fixes_applied": 2})
+        )
+        assert result == {"status": "posted"}
+
+    def test_no_workspace_router_required(self):
+        """pr_approved_notify must NOT call workspace_router (it is None here)."""
+        proc = _bare_processor()
+        proc.workspace_router = None
+        # If this raises AttributeError / TypeError, the router was called.
+        result = proc._execute_pm_action(_action("pr_approved_notify"))
+        assert result["status"] == "posted"
+
+    def test_empty_payload_does_not_raise(self):
+        """An empty payload dict should be handled gracefully."""
+        proc = _bare_processor()
+        result = proc._execute_pm_action(_action("pr_approved_notify", {}))
+        assert result["status"] == "posted"
+
+    def test_missing_payload_field_does_not_raise(self):
+        """payload with no pr_title should not raise."""
+        proc = _bare_processor()
+        result = proc._execute_pm_action(_action("pr_approved_notify", {"fixes_applied": 0}))
+        assert result["status"] == "posted"
+
+
+# ---------------------------------------------------------------------------
+# pr_escalation
+# ---------------------------------------------------------------------------
+
+class TestPREscalation:
+    def test_returns_posted(self):
+        """pr_escalation should return {"status": "posted"}."""
+        proc = _bare_processor()
+        result = proc._execute_pm_action(
+            _action("pr_escalation", {
+                "pr_title": "feat: add login",
+                "pr_id": "19",
+                "blocker_reason": "architecture question",
+                "comment_url": "https://github.com/org/repo/pull/19#discussion_r1",
+                "fixes_applied": 1,
+            })
+        )
+        assert result == {"status": "posted"}
+
+    def test_no_workspace_router_required(self):
+        """pr_escalation must NOT call workspace_router (notification-only)."""
+        proc = _bare_processor()
+        proc.workspace_router = None
+        result = proc._execute_pm_action(_action("pr_escalation"))
+        assert result["status"] == "posted"
+
+    def test_empty_payload_does_not_raise(self):
+        proc = _bare_processor()
+        result = proc._execute_pm_action(_action("pr_escalation", {}))
+        assert result["status"] == "posted"
+
+    def test_missing_blocker_does_not_raise(self):
+        """Missing blocker_reason should be handled with a graceful empty string."""
+        proc = _bare_processor()
+        result = proc._execute_pm_action(_action("pr_escalation", {"pr_id": "19"}))
+        assert result["status"] == "posted"

--- a/devtrack_server/backend/webhook_server.py
+++ b/devtrack_server/backend/webhook_server.py
@@ -361,6 +361,38 @@ class TriggerProcessor:
         action_type = action.get("action_type", "")
         target      = action.get("target", "")
 
+        # ---------------------------------------------------------------------------
+        # Notification-only actions (no PM API call required, no workspace_router).
+        # These are handled before the workspace_router guard so they work even
+        # when the router is unavailable. Telegram delivery is done by the Go bot.
+        # ---------------------------------------------------------------------------
+
+        if action_type == "pr_approved_notify":
+            # Notification-only action — Telegram delivery is handled by the Go bot
+            # (SendPRApproved wired in the daemon goroutine). The Python server just
+            # acknowledges receipt so the queue executor can mark the row posted.
+            pr_id = payload.get("pr_id", target)
+            fixes_applied = payload.get("fixes_applied", 0)
+            logger.info(
+                "queue: pr_approved_notify action %s (pr=%s fixes_applied=%s) — "
+                "notification handled by Go Telegram bot",
+                action.get("id"), pr_id, fixes_applied,
+            )
+            return {"status": "posted"}
+
+        if action_type == "pr_escalation":
+            # Notification-only action — Telegram delivery is handled by the Go bot
+            # (SendPREscalation wired in the daemon goroutine). The Python server just
+            # acknowledges receipt so the queue executor can mark the row posted.
+            pr_id = payload.get("pr_id", target)
+            blocker_reason = payload.get("blocker_reason", "")
+            logger.info(
+                "queue: pr_escalation action %s (pr=%s blocker=%r) — "
+                "notification handled by Go Telegram bot",
+                action.get("id"), pr_id, blocker_reason,
+            )
+            return {"status": "posted"}
+
         if not self.workspace_router:
             return {"status": "failed", "error": "workspace_router not available"}
 


### PR DESCRIPTION
## Summary

- Wire PRFixLoop.Run terminal states (approved / stuck) to pending_actions queue and Telegram notification channels
- Add bot.SendPRApproved and bot.SendPREscalation methods to Go Telegram bot (internal/telegram/review_notify.go)
- Handle pr_approved_notify and pr_escalation action types in Python _execute_pm_action (notification-only, no PM API call)
- Add "PR DONE" (Success) and "PR STUCK" (Danger) badges to TUI Queue tab action type rendering
- Add devtrack review status CLI command showing per-PR outcome summary from last 24h
- Wire immediate escalation for needs_human classified comments (previously just logged)

## Test plan

- [x] go build ./... and go vet ./... pass clean from devtrack_client/
- [x] go test ./... all packages pass
- [x] uv run pytest backend/tests/test_pr_notifications.py -q — 8 tests pass
- [x] uv run pytest backend/tests/ -q — 797 pass, 1 pre-existing failure unchanged
- [x] All 9/9 acceptance criteria on TASK-096 board entry ticked

Closes TASK-096 on project board.