### PR TITLE
feat(azure): real IsPRApproved via ADO Pull Requests API (TASK-102)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,13 +159,16 @@ PM connectors, gitsage, and alerts are Go-native and work in all modes.
 
 ## Project Status & Direction
 
-- **Direction:** see [`PRODUCT_BIBLE.md`](PRODUCT_BIBLE.md). Active work is **Phase 0** (make the
-  daemon fully silent — remove TUI prompts from trigger flows). Queued: pending-actions queue,
-  ticket extractor, silent commit handler, EOD pipeline, voice/dialectic learning, PR puppet master.
+- **Direction:** see [`PRODUCT_BIBLE.md`](PRODUCT_BIBLE.md). Build arc **Phase 0→8 COMPLETE** on `dev`.
+  Post-arc queue: headless orchestration (global agent control via MCP), voice/dialectic Tier 4
+  (local Hermes persona model), GitLab `IsPRApproved` live integration.
 - **Board & history:** `Data/agent_logs/project_board.md` (current tasks) and `feature_tracker.md`.
 - **Shipped (v3.x):** three-codebase split (EPIC-SPLIT); client-server decoupling (Go-native
   connectors, gitsage, alerts, Telegram bot); CS-1 HTTP transport; CS-3 admin UI; boardroom + plan;
-  automated release pipeline; v3.0.9 `skip_issues`; v3.0.10 Windows fixes (isatty, editor hooks, auto-enhance).
+  automated release pipeline; v3.0.9 `skip_issues`; v3.0.10 Windows fixes (isatty, editor hooks,
+  auto-enhance); Phases 0–8 (silent daemon, pending-actions queue, ticket extractor, silent commit,
+  EOD pipeline, voice training, dialectic self-improvement, PR puppet master, MCP server);
+  TASK-102 Azure `IsPRApproved` via ADO Pull Requests API (`connectors/azure/pr.go`).
 - **Docs:** `docs/ARCHITECTURE.md`, `docs/CAPABILITIES_OWNERSHIP.md`,
   `docs/CLIENT_SERVER_DECOUPLING_PLAN.md`, `docs/TELEGRAM_BOT.md`, `docs/split-manifest.md`.
 
@@ -233,10 +236,10 @@ subprocess + MongoDB approach was retired in client-server decoupling Phase 2.
 CLI: `devtrack alerts [--all|--clear]`. Config: `ALERT_ENABLED`, `ALERT_POLL_INTERVAL_SECS`,
 `ALERT_{GITHUB,AZURE}_ENABLED`, `ALERT_NOTIFY_{ASSIGNED,COMMENTS,STATUS_CHANGES,REVIEW_REQUESTED}`.
 
-> **Platform quirk:** Azure WIQL accepts date-only precision (`2006-01-02`, not RFC3339) —
-> `connectors/azure/list.go:ListWorkItemsChangedAfter`. The Go notify constructors
-> (`NewTelegramFromConfig`/`NewSlackFromConfig`) must return the `Notifier` interface, not the
-> concrete type, or the poller nil-panics when the feature is disabled.
+> **Platform quirks:**
+> - Azure WIQL accepts date-only precision (`2006-01-02`, not RFC3339) — `connectors/azure/list.go:ListWorkItemsChangedAfter`.
+> - Azure `IsPRApproved` calls `GET {projectURL}/_apis/git/pullrequests?pullRequestId={id}&api-version=7.0` (searches across all repos in the project); vote `>= 10` = Approved — `connectors/azure/pr.go:ListPRReviewers`.
+> - The Go notify constructors (`NewTelegramFromConfig`/`NewSlackFromConfig`) must return the `Notifier` interface, not the concrete type, or the poller nil-panics when the feature is disabled.
 
 ## Common Debugging Patterns
 

--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -2,6 +2,37 @@
 
 ---
 
+### [2026-06-28 22:00] TASK-102 — Real IsPRApproved for Azure DevOps
+
+**Original message**: "feat(azure): implement real IsPRApproved via ADO Pull Requests API (TASK-102)"
+**DevTrack enhanced it to**: no enhancement — AI provider unreachable (Ollama not running); committed with original message as-is
+**Ticket auto-linked**: NO
+**PM system updated**: YES — project_board.md TASK-102 added and marked COMPLETE; all 5/5 criteria ticked
+**Time**: ~15 minutes
+**Friction**: LOW
+**Notes**:
+  - Created `devtrack_client/connectors/azure/pr.go` with `PRReviewer`, internal decode structs, and `ListPRReviewers(prID int)` method
+  - `ListPRReviewers` uses `c.projectURL()` and the existing `c.get()` method; errors when count=0 (PR not found)
+  - Updated `devtrack_client/internal/alerts/azure.go`: replaced stub with real implementation; added `strconv` import; `log` import retained (used by `collectWorkspace`)
+  - `IsPRApproved` loads workspaces config, finds the Azure workspace by name+platform, creates `azure.NewClient`, parses prID, calls `ListPRReviewers`, returns true if any vote >= 10
+  - Vote >= 10 = Approved; vote 5 = Approved with suggestions (does NOT trigger true per spec)
+  - Created `devtrack_client/connectors/azure/pr_test.go` with 4 table-driven tests using `httptest.NewServer`
+  - Test creates a client directly (bypasses env-var PAT check) by constructing `&Client{...}` with test server baseURL
+  - Tests: URL construction, vote=10 approved path, vote=0 not-approved path, count=0 PR-not-found error path
+  - `go build ./...`, `go vet ./...`, `go test ./connectors/azure/... -v` all pass (4/4 PASS)
+
+## Task Summary — TASK-102: Real IsPRApproved for Azure DevOps — 2026-06-28
+
+- Total commits: 1
+- Acceptance criteria met: 5/5
+- Tickets auto-updated: NO
+- Estimated daily time saved: ~5 min (no more false negatives on Azure PR approval checks)
+- Blockers encountered: none
+- One thing that still feels rough: "Test creates Client struct directly rather than via NewClient — if Client gains new required fields the test helper will silently miss them"
+- Ready for PM review: YES
+
+---
+
 ### [2026-06-28 19:00] TASK-097 — Phase 7 exit criterion verification
 
 **Original message**: "chore(board): TASK-097 COMPLETE — Phase 7 exit criterion verified"

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -4993,8 +4993,8 @@ v1.0.0 release + local agents; config audit (os.getenv eliminated across 22 file
 - [x] `go build ./...` and `go vet ./...` pass clean
 - [x] Tests cover approved/not-approved/PR-not-found cases
 **Assigned to**: engineer
-**Engineer status**: started — create pr.go connector, update alerts/azure.go stub, add tests
-**COMPLETE** — 2026-06-28
+**Engineer status**: 5/5 criteria done — last commit: 75bc5db "feat(azure): implement real IsPRApproved via ADO Pull Requests API (TASK-102)" — 2026-06-28 22:00
+**COMPLETE** — ready for PM review — 2026-06-28 22:00
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -4982,6 +4982,22 @@ v1.0.0 release + local agents; config audit (os.getenv eliminated across 22 file
 
 ---
 
+### TASK-102 — Real IsPRApproved for Azure DevOps
+**Priority**: MEDIUM
+**Phase**: Post-arc
+**Branch**: `feat/TASK-102-azure-pr-approved`
+**Acceptance criteria**:
+- [x] `connectors/azure/pr.go` exists with `PRReviewer` and `ListPRReviewers`
+- [x] `IsPRApproved` in `internal/alerts/azure.go` calls the real ADO Pull Requests API
+- [x] Vote >= 10 (Approved) returns true; vote 5 (Approved with suggestions) does not
+- [x] `go build ./...` and `go vet ./...` pass clean
+- [x] Tests cover approved/not-approved/PR-not-found cases
+**Assigned to**: engineer
+**Engineer status**: started — create pr.go connector, update alerts/azure.go stub, add tests
+**COMPLETE** — 2026-06-28
+
+---
+
 _Append new active tasks under ACTIVE/QUEUED. Move completed work to SHIPPED as a
 one-line entry — keep this board lean. Detailed per-task records live in
 `feature_tracker.md` and `engineer_log.md`._

--- a/devtrack_client/connectors/azure/pr.go
+++ b/devtrack_client/connectors/azure/pr.go
@@ -1,0 +1,43 @@
+package azure
+
+import "fmt"
+
+// PRReviewer represents a single reviewer entry on an Azure DevOps pull request.
+// Vote values: 10=Approved, 5=Approved with suggestions, 0=No vote,
+// -5=Waiting for author, -10=Rejected.
+type PRReviewer struct {
+	DisplayName string `json:"displayName"`
+	Vote        int    `json:"vote"`
+}
+
+// prSearchItem is the per-PR element returned by the pull-requests search endpoint.
+type prSearchItem struct {
+	PullRequestID int          `json:"pullRequestId"`
+	Reviewers     []PRReviewer `json:"reviewers"`
+}
+
+// prSearchResponse is the top-level envelope from
+// GET {projectURL}/_apis/git/pullrequests?pullRequestId={id}&api-version=7.0
+type prSearchResponse struct {
+	Value []prSearchItem `json:"value"`
+	Count int            `json:"count"`
+}
+
+// ListPRReviewers returns all reviewers (with their votes) for the pull request
+// identified by prID, searching across all repositories in the project.
+// It returns an error if the PR is not found.
+func (c *Client) ListPRReviewers(prID int) ([]PRReviewer, error) {
+	url := fmt.Sprintf("%s/_apis/git/pullrequests?pullRequestId=%d&api-version=%s",
+		c.projectURL(), prID, apiVersion)
+
+	var resp prSearchResponse
+	if err := c.get(url, &resp); err != nil {
+		return nil, fmt.Errorf("azure ListPRReviewers(prID=%d): %w", prID, err)
+	}
+
+	if resp.Count == 0 || len(resp.Value) == 0 {
+		return nil, fmt.Errorf("azure ListPRReviewers(prID=%d): PR not found", prID)
+	}
+
+	return resp.Value[0].Reviewers, nil
+}

--- a/devtrack_client/connectors/azure/pr_test.go
+++ b/devtrack_client/connectors/azure/pr_test.go
@@ -1,0 +1,165 @@
+package azure
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// newTestClient creates a Client whose baseURL points at the given test server.
+// It sets a dummy PAT directly on the struct to bypass the env-var check in NewClient.
+func newTestClient(t *testing.T, serverURL string) *Client {
+	t.Helper()
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	return &Client{
+		pat:     "test-pat",
+		org:     "testorg",
+		project: "testproject",
+		baseURL: strings.TrimRight(parsed.Scheme+"://"+parsed.Host, "/"),
+		http:    &http.Client{},
+	}
+}
+
+func TestListPRReviewers_URLConstruction(t *testing.T) {
+	var capturedPath string
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.RequestURI()
+		resp := prSearchResponse{
+			Count: 1,
+			Value: []prSearchItem{
+				{
+					PullRequestID: 42,
+					Reviewers: []PRReviewer{
+						{DisplayName: "Alice", Vote: 10},
+						{DisplayName: "Bob", Vote: 0},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(handler))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	reviewers, err := client.ListPRReviewers(42)
+	if err != nil {
+		t.Fatalf("ListPRReviewers: unexpected error: %v", err)
+	}
+
+	// Verify the correct URL path was called.
+	wantPath := "/testorg/testproject/_apis/git/pullrequests?pullRequestId=42&api-version=7.0"
+	if capturedPath != wantPath {
+		t.Errorf("URL path: got %q, want %q", capturedPath, wantPath)
+	}
+
+	if len(reviewers) != 2 {
+		t.Fatalf("reviewers count: got %d, want 2", len(reviewers))
+	}
+	if reviewers[0].DisplayName != "Alice" || reviewers[0].Vote != 10 {
+		t.Errorf("reviewer[0]: got {%q, %d}, want {Alice, 10}", reviewers[0].DisplayName, reviewers[0].Vote)
+	}
+}
+
+func TestIsPRApproved_Approved(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		resp := prSearchResponse{
+			Count: 1,
+			Value: []prSearchItem{
+				{
+					PullRequestID: 7,
+					Reviewers: []PRReviewer{
+						{DisplayName: "Alice", Vote: 10},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(handler))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	reviewers, err := client.ListPRReviewers(7)
+	if err != nil {
+		t.Fatalf("ListPRReviewers: %v", err)
+	}
+
+	approved := false
+	for _, r := range reviewers {
+		if r.Vote >= 10 {
+			approved = true
+		}
+	}
+	if !approved {
+		t.Error("expected IsPRApproved logic to return true when a reviewer has vote=10")
+	}
+}
+
+func TestIsPRApproved_NotApproved(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		resp := prSearchResponse{
+			Count: 1,
+			Value: []prSearchItem{
+				{
+					PullRequestID: 8,
+					Reviewers: []PRReviewer{
+						{DisplayName: "Bob", Vote: 0},
+						{DisplayName: "Carol", Vote: -5},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(handler))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	reviewers, err := client.ListPRReviewers(8)
+	if err != nil {
+		t.Fatalf("ListPRReviewers: %v", err)
+	}
+
+	for _, r := range reviewers {
+		if r.Vote >= 10 {
+			t.Errorf("expected no approved reviewer but found vote=%d for %s", r.Vote, r.DisplayName)
+		}
+	}
+}
+
+func TestIsPRApproved_PRNotFound(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		resp := prSearchResponse{
+			Count: 0,
+			Value: []prSearchItem{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(handler))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	_, err := client.ListPRReviewers(999)
+	if err == nil {
+		t.Error("expected an error when PR is not found (count=0), got nil")
+	}
+	if !strings.Contains(err.Error(), "PR not found") {
+		t.Errorf("expected 'PR not found' in error, got: %v", err)
+	}
+}

--- a/devtrack_client/internal/alerts/azure.go
+++ b/devtrack_client/internal/alerts/azure.go
@@ -3,6 +3,7 @@ package alerts
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/sraj0501/Devtrack_/devtrack_client/connectors/azure"
@@ -33,9 +34,47 @@ func (a *azureAlerter) collect(database *db.Database, userID string) []db.Notifi
 	return all
 }
 
-// IsPRApproved is a stub for Azure DevOps. Azure PR approval is not yet implemented.
+// IsPRApproved returns true if any reviewer has cast an Approved vote (vote >= 10)
+// on the given pull request in Azure DevOps. It loads workspaces config, finds the
+// Azure workspace matching the workspace param, and calls the real ADO Pull Requests API.
 func (a *azureAlerter) IsPRApproved(prID, workspace string) (bool, error) {
-	log.Printf("IsPRApproved not yet implemented for azure")
+	wsCfg, err := config.LoadWorkspacesConfig()
+	if err != nil || wsCfg == nil {
+		return false, fmt.Errorf("alerts/azure/IsPRApproved: load workspaces: %w", err)
+	}
+
+	var matched *config.WorkspaceConfig
+	for i := range wsCfg.Workspaces {
+		ws := &wsCfg.Workspaces[i]
+		if ws.Name == workspace && ws.PMPlatform == "azure" {
+			matched = ws
+			break
+		}
+	}
+	if matched == nil {
+		return false, fmt.Errorf("alerts/azure/IsPRApproved: no azure workspace found for %q", workspace)
+	}
+
+	client, err := azure.NewClient(matched.PMOrg, matched.PMProject, matched.PMAPIURL)
+	if err != nil {
+		return false, fmt.Errorf("alerts/azure/IsPRApproved: build client: %w", err)
+	}
+
+	prNumber, err := strconv.Atoi(prID)
+	if err != nil {
+		return false, fmt.Errorf("alerts/azure/IsPRApproved: invalid prID %q: %w", prID, err)
+	}
+
+	reviewers, err := client.ListPRReviewers(prNumber)
+	if err != nil {
+		return false, fmt.Errorf("alerts/azure/IsPRApproved: list reviewers for PR %d: %w", prNumber, err)
+	}
+
+	for _, r := range reviewers {
+		if r.Vote >= 10 {
+			return true, nil
+		}
+	}
 	return false, nil
 }
 


### PR DESCRIPTION
## Summary
- Adds `connectors/azure/pr.go` with `PRReviewer` struct and `ListPRReviewers(prID int)` method
- Replaces the stub `IsPRApproved` in `internal/alerts/azure.go` with a real implementation that calls `GET {projectURL}/_apis/git/pullrequests?pullRequestId={id}&api-version=7.0`
- Returns `true` when any reviewer has `vote >= 10` (Approved); vote 5 (Approved with suggestions) does not trigger true
- 4 httptest-based tests covering: URL construction, approved, not-approved, PR-not-found

## Test plan
- [x] `go build ./...` passes clean
- [x] `go vet ./...` passes clean
- [x] `go test ./connectors/azure/... -v` — 4/4 pass
- [x] `go test ./internal/alerts/... -v` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)