### PR TITLE
TASK-105: devtrack upgrade — also pull + uv sync Python server

### DIFF
--- a/Data/agent_logs/engineer_log.md
+++ b/Data/agent_logs/engineer_log.md
@@ -1,4 +1,32 @@
-﻿# DevTrack Engineer Log
+# DevTrack Engineer Log
+
+---
+
+### [2026-06-30 12:50] TASK-105 -- upgradeServer() -- pull + uv sync Python server on upgrade
+
+**Original message**: "feat(upgrade): add upgradeServer() -- pull + uv sync Python server on upgrade (TASK-105)"
+**Enhanced to**: no enhancement -- used original (GIT_NO_DEVTRACK=1, daemon stopped)
+**Ticket auto-linked**: NO
+**PM system updated**: YES -- project_board.md TASK-105 marked COMPLETE; all 4/4 criteria ticked; PR #211 linked
+**Time**: ~20 minutes
+**Friction**: HIGH -- concurrent agent branch-switching caused the working branch to change between PowerShell tool calls multiple times; required stashing, force-switching, and doing stage+commit+push in a single PowerShell call
+**Notes**:
+  - Added upgradeServer(devtrackHome string) error at the bottom of devtrack_client/upgrade.go
+  - Wired call into RunUpgrade() after RunPendingMigrations() and before daemon restart
+  - Uses GetDevTrackDir() (config_shim.go forwards to cfg.GetDevTrackDir() which reads DEVTRACK_HOME env var)
+  - All required imports (exec, os, filepath, fmt) were already present in upgrade.go
+  - go build ./... and go vet ./... passed clean from devtrack_client/
+  - The multi-agent shared working directory caused branch changes between tool calls
+
+## Task Summary -- TASK-105: devtrack upgrade also updates Python server -- 2026-06-30
+
+- Total commits: 2 (b8f5bef -- implementation; fc02555 -- board PR link update)
+- Acceptance criteria met: 4/4
+- Tests passed: SKIPPED -- no test commands configured in pm-config.md that apply here; build and vet passed clean
+- Blockers encountered: none (functional); friction: concurrent branch-switching between PowerShell calls
+- One thing that still feels rough: shared git working directory between concurrent agents makes branch operations unreliable across tool calls
+- Ready for PM review: YES
+- PR: https://github.com/sraj0501/Devtrack_/pull/211
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -5143,8 +5143,10 @@ add it if not (reads `DEVTRACK_HOME` env var, falls back to `os.UserHomeDir()+"/
 ### TASK-105 — `devtrack upgrade`: also pull + sync the Python server
 **Priority**: CRITICAL
 **Phase**: Post-arc (Managed Install epic)
+**Assigned to**: engineer
 **Depends on**: TASK-103 (server dir established)
 **Branch**: `feat/TASK-105-upgrade-server`
+**Status**: IN PROGRESS
 
 **Spec**:
 
@@ -5182,10 +5184,15 @@ if err := upgradeServer(config.GetDevtrackHome()); err != nil {
 ```
 
 **Acceptance criteria**:
-- [ ] `devtrack upgrade` runs `git pull --ff-only` + `uv sync` on `$DEVTRACK_HOME/server/` when present
-- [ ] When server dir absent: prints skip message, upgrade continues cleanly
-- [ ] Server upgrade failure is a warning — binary upgrade still succeeds
-- [ ] `go build ./...` and `go vet ./...` pass clean
+- [x] `devtrack upgrade` runs `git pull --ff-only` + `uv sync` on `$DEVTRACK_HOME/server/` when present
+- [x] When server dir absent: prints skip message, upgrade continues cleanly
+- [x] Server upgrade failure is a warning — binary upgrade still succeeds
+- [x] `go build ./...` and `go vet ./...` pass clean
+
+**Engineer status**: 4/4 criteria done — last commit: pending — 2026-06-30 12:50
+**PR**: pending
+
+**COMPLETE** — ready for PM review — 2026-06-30 12:50
 
 ---
 

--- a/Data/agent_logs/project_board.md
+++ b/Data/agent_logs/project_board.md
@@ -5189,8 +5189,8 @@ if err := upgradeServer(config.GetDevtrackHome()); err != nil {
 - [x] Server upgrade failure is a warning — binary upgrade still succeeds
 - [x] `go build ./...` and `go vet ./...` pass clean
 
-**Engineer status**: 4/4 criteria done — last commit: pending — 2026-06-30 12:50
-**PR**: pending
+**Engineer status**: 4/4 criteria done — last commit: b8f5bef — 2026-06-30 12:50
+**PR**: https://github.com/sraj0501/Devtrack_/pull/211
 
 **COMPLETE** — ready for PM review — 2026-06-30 12:50
 

--- a/devtrack_client/upgrade.go
+++ b/devtrack_client/upgrade.go
@@ -110,6 +110,13 @@ func RunUpgrade(checkOnly bool) error {
 	fmt.Println("\nApplying configuration migrations...")
 	RunPendingMigrations()
 
+	fmt.Println()
+	if err := upgradeServer(GetDevTrackDir()); err != nil {
+		fmt.Printf("Warning: Python server upgrade failed: %v\n", err)
+		fmt.Println("The binary was upgraded successfully. Run 'devtrack setup' to repair the server.")
+		// non-fatal — binary upgrade succeeded; continue to restart
+	}
+
 	if isDaemonRunning() {
 		fmt.Println("\nRestarting daemon with new binary...")
 		restart := exec.Command(execPath, "restart")
@@ -356,4 +363,31 @@ func copyFile(src, dst string) error {
 // normaliseTag strips a leading 'v' for comparison.
 func normaliseTag(tag string) string {
 	return strings.TrimPrefix(tag, "v")
+}
+
+// upgradeServer updates the sparse-cloned Python server under devtrackHome/server/.
+// It runs "git pull --ff-only" to fetch the latest commits, then "uv sync" inside
+// devtrack_server/ to bring Python dependencies in line with the new lockfile.
+// If the server directory does not exist (e.g. setup was never run), it prints a
+// skip notice and returns nil — absence is not an error.
+// Called by RunUpgrade() after the binary has been replaced and migrations applied.
+func upgradeServer(devtrackHome string) error {
+	serverDir := filepath.Join(devtrackHome, "server")
+	if _, err := os.Stat(serverDir); os.IsNotExist(err) {
+		fmt.Println("Python server not installed — skipping server upgrade (run 'devtrack setup' to install)")
+		return nil
+	}
+	fmt.Println("Updating Python server...")
+	pull := exec.Command("git", "-C", serverDir, "pull", "--ff-only")
+	pull.Stdout = os.Stdout
+	pull.Stderr = os.Stderr
+	if err := pull.Run(); err != nil {
+		return fmt.Errorf("git pull failed: %w", err)
+	}
+	fmt.Println("Syncing Python dependencies...")
+	sync := exec.Command("uv", "sync")
+	sync.Dir = filepath.Join(serverDir, "devtrack_server")
+	sync.Stdout = os.Stdout
+	sync.Stderr = os.Stderr
+	return sync.Run()
 }


### PR DESCRIPTION
## Summary

- Adds `upgradeServer(devtrackHome string) error` to `devtrack_client/upgrade.go`
- Wired into `RunUpgrade()` after `RunPendingMigrations()`: runs `git pull --ff-only` on `<devtrackHome>/server/` then `uv sync` in `server/devtrack_server/`
- When server dir absent: prints skip notice, upgrade continues cleanly
- Server upgrade failure: prints warning, does NOT fail the overall upgrade
- `go build ./...` and `go vet ./...` pass clean

Closes TASK-105 on project board.